### PR TITLE
Recovering Locked immudb Instance

### DIFF
--- a/packages/immudb-rs/proto/immudb/immudb.proto
+++ b/packages/immudb-rs/proto/immudb/immudb.proto
@@ -560,6 +560,8 @@ message DatabaseNullableSettings {
 	NullableUint32 writeBufferSize = 24;
 
 	AHTNullableSettings ahtSettings = 25;
+
+	NullableUint32 maxActiveTransactions = 100000;
 }
 
 message ReplicationNullableSettings {


### PR DESCRIPTION
After discussing with @ruescasd, I received a critical diff that allowed us to recover the locked immudb instance. The changes are as follows:

```diff
diff --git a/embedded/store/immustore.go b/embedded/store/immustore.go
index 4cc70461..ced35709 100644
--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -520,7 +520,9 @@ func OpenWith(path string, vLogs []appendable.Appendable, txLog, cLog appendable
 		}
 	}
 
-	cLogBuf := newPrecommitBuffer(opts.MaxActiveTransactions)
+	// drb
+	cLogBuf := newPrecommitBuffer(100000)
+	// cLogBuf := newPrecommitBuffer(opts.MaxActiveTransactions)
 
 	precommittedTxID := committedTxID
 	precommittedAlh := committedAlh
@@ -854,7 +856,8 @@ func (s *ImmuStore) InitIndexing(spec *IndexSpec) error {
 	}
 
 	if indexer.Ts() > s.LastCommittedTxID() {
-		return fmt.Errorf("%w: index size is too large", ErrCorruptedIndex)
+		// drb
+		// return fmt.Errorf("%w: index size is too large", ErrCorruptedIndex)
 
 		// TODO: if indexing is done on pre-committed txs, the index may be rollback to a previous snapshot where it was already synced
 		// NOTE: compaction should preserve snapshot which are not synced... so to ensure rollback can be achieved

```

With these changes, I was able to configure the system to make the adjustments permanent without needing to rebuild the immudb server. This involved tuning the parameters via the provided configuration mechanisms in immudb.

I am considering forking the immudb repository to build our custom immudb container image incorporating these changes. However, I would prefer to leverage the native configuration capabilities of immudb to fine-tune this parameter.

What are your thoughts on:

- **Forking the immudb repository:** This would allow us to control and include these specific changes in our builds.
- **Using the native configuration:** This would be a cleaner solution, ensuring we use immudb's built-in mechanisms for configuration management.

Please review and provide your feedback.