### PR TITLE
🐞 Using a Deferred user for OTP - Message via Email/SMS has the fields in the wrong order

### DIFF
--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/Utils.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/Utils.java
@@ -296,10 +296,10 @@ public class Utils {
 
       emailSender.send(
           realm.getSmtpConfig(),
+          address,
           emailTemplate.getSubject(),
           emailTemplate.getTextBody(),
-          emailTemplate.getHtmlBody(),
-          address);
+          emailTemplate.getHtmlBody());
     } catch (EmailException e) {
       throw e;
     } catch (Exception e) {


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/1553