### PR TITLE
🐞 Keycloak: Manual Verification fails because `resendTimer` is not set

### DIFF
--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/ResetMessageOTPRequiredAction.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/ResetMessageOTPRequiredAction.java
@@ -137,6 +137,7 @@ public class ResetMessageOTPRequiredAction implements RequiredActionProvider {
             "address",
             Utils.getOtpAddress(Utils.MessageCourier.BOTH, false, config.get(), authSession, user))
         .setAttribute("ttl", config.get().getConfig().get(Utils.CODE_TTL))
+        .setAttribute("codeJustSent", true)
         .setAttribute("resendTimer", resendTimer);
 
     if (formConsumer != null) {


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/1927