### PR TITLE
🐞 The contest description doesn't show up in the voting portal when it is not declared in English

### DIFF
--- a/packages/voting-portal/src/components/Question/Question.tsx
+++ b/packages/voting-portal/src/components/Question/Question.tsx
@@ -181,7 +181,7 @@ export const Question: React.FC<IQuestionProps> = ({
             >
                 {translate(question, "name", i18n.language) || ""}
             </StyledTitle>
-            {question.description ? (
+            {question.description || question.description_i18n?.[i18n.language] ? (
                 <Typography variant="body2" sx={{color: theme.palette.customGrey.main}}>
                     {stringToHtml(translate(question, "description", i18n.language) || "")}
                 </Typography>


### PR DESCRIPTION
Parent issue link: https://github.com/sequentech/meta/issues/2819