### PR TITLE
🐞 Step CLI: Fix system template escaping and libssl not in `LD_LIBRARY_PATH` env var

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -68,6 +68,7 @@
   enterShell = ''
     set -a
     source .devcontainer/.env
+    export LD_LIBRARY_PATH=${pkgs.openssl.out}/lib:$LD_LIBRARY_PATH
     export PATH=/workspaces/step/packages/step-cli/rust-local-target/release:$PATH
     set +a
   '';

--- a/packages/step-cli/src/commands/render_template.rs
+++ b/packages/step-cli/src/commands/render_template.rs
@@ -113,7 +113,7 @@ impl RenderTemplate {
 
         // Determine the system template content based on the template type
         let system_template = match &self.template_type {
-            TemplateType::Custom => "{{rendered_user_template}}".to_string(),
+            TemplateType::Custom => "{{{rendered_user_template}}}".to_string(),
             TemplateType::ManualVerification => {
                 if let Some(system_template) = &self.system_template {
                     fs::read_to_string(system_template).map_err(|e| {


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/2875