### PR TITLE
🐞 Windmill/Keycloak: OTP gets disabled when editing the election event data

### DIFF
--- a/packages/admin-portal/src/resources/ElectionEvent/EditElectionEventDataForm.tsx
+++ b/packages/admin-portal/src/resources/ElectionEvent/EditElectionEventDataForm.tsx
@@ -1200,14 +1200,12 @@ export const EditElectionEventDataForm: React.FC = () => {
                                             )}
                                             source="presentation.enrollment"
                                             choices={enrollmentChoices()}
-                                            validate={required()}
                                             onChange={(value) => handleEnrollmentChange(value)}
                                         />
                                         <SelectInput
                                             label={t(`electionEventScreen.field.otp.policyLabel`)}
                                             source="presentation.otp"
                                             choices={otpChoices()}
-                                            validate={required()}
                                             onChange={(value) => handleOtpChange(value)}
                                         />
                                     </Box>

--- a/packages/harvest/src/routes/set_voter_authentication.rs
+++ b/packages/harvest/src/routes/set_voter_authentication.rs
@@ -96,7 +96,8 @@ pub async fn set_voter_authentication(
         );
 
     // Update enrollment if it has changed
-    if prev_enrollment != body.enrollment {
+    if !body.enrollment.trim().is_empty() && prev_enrollment != body.enrollment
+    {
         let enable_enrollment =
             body.enrollment.eq(&Enrollment::ENABLED.to_string());
         info!("Updating enrollment to: {}", enable_enrollment);
@@ -116,7 +117,7 @@ pub async fn set_voter_authentication(
         })?;
     }
 
-    if prev_otp != body.otp {
+    if !body.otp.trim().is_empty() && prev_otp != body.otp {
         let new_otp_state = if body.otp == Otp::ENABLED.to_string() {
             "REQUIRED".to_string()
         } else {

--- a/packages/windmill/external-bin/janitor/templates/electionEvent.hbs
+++ b/packages/windmill/external-bin/janitor/templates/electionEvent.hbs
@@ -97,7 +97,8 @@
             "countdown_anticipation_secs": 360,
             "countdown_alert_anticipation_secs": 180
         },
-        "enrollment": "disabled"
+        "enrollment": "disabled",
+        "otp": "enabled"
     },
     "bulletin_board_reference": {
         "id": 44,


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/4875