### PR TITLE
🐞 Keycloak: Enrollment > No masked number is shown in OTP message (Mobile Phone)

### DIFF
--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/Utils.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/Utils.java
@@ -720,7 +720,9 @@ public class Utils {
       case SMS:
         return obscurePhoneNumber(mobileNumber);
       case BOTH:
-        return emailAddress != null && !emailAddress.isEmpty() ? obscureEmail(emailAddress) : obscurePhoneNumber(mobileNumber);
+        return emailAddress != null && !emailAddress.isEmpty()
+            ? obscureEmail(emailAddress)
+            : obscurePhoneNumber(mobileNumber);
     }
     return emailAddress;
   }


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/4878