### PR TITLE
🐞 Admin Portal > Miru Integration: Transmission Package Zip file is downloaded with wrong extension `.tar.gz`

### DIFF
--- a/packages/admin-portal/src/components/MiruPackageDownload.tsx
+++ b/packages/admin-portal/src/components/MiruPackageDownload.tsx
@@ -137,7 +137,7 @@ export const MiruPackageDownload: React.FC<MiruPackageDownloadProps> = ({
                             e.preventDefault()
                             e.stopPropagation()
                             handleClose()
-                            setFileNameWithExt(fileName + ".tar.gz")
+                            setFileNameWithExt(fileName + ".zip")
                             setDocumentToDownload(doc.document_ids.all_servers)
                             setOpenModal(true)
                         }}


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/5056