### PR TITLE
🐞 Admin Portal > Init Report: `Start Tally` is NOT not disabled even if trustees didn't import their keys

### DIFF
--- a/packages/admin-portal/src/resources/Tally/TallyCeremony.tsx
+++ b/packages/admin-portal/src/resources/Tally/TallyCeremony.tsx
@@ -361,7 +361,12 @@ export const TallyCeremony: React.FC = () => {
                 console.log(
                     `init report: setIsButtonDisabled = true, tallySession?.tally_type = ${tallySession?.tally_type}`
                 )
-                setIsButtonDisabled(false)
+                let newIsButtonDisabled =
+                    tally?.execution_status !== ITallyExecutionStatus.CONNECTED
+
+                if (newIsButtonDisabled !== isButtonDisabled) {
+                    setIsButtonDisabled(newIsButtonDisabled)
+                }
             }
         }
 


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/5173