### PR TITLE
🐞 Admin Portal > Reports: Electoral Results: Missing the `results hash` that should be the same as in statistical report

### DIFF
--- a/packages/windmill/src/services/consolidation/create_transmission_package_service.rs
+++ b/packages/windmill/src/services/consolidation/create_transmission_package_service.rs
@@ -57,7 +57,6 @@ pub async fn download_to_file(
     hasura_transaction: &Transaction<'_>,
     tenant_id: &str,
     election_event_id: &str,
-    election_id: Option<&str>,
     tally_session_id: &str,
 ) -> Result<NamedTempFile> {
     let tally_session_executions = get_tally_session_executions(
@@ -88,7 +87,7 @@ pub async fn download_to_file(
     .await
     .with_context(|| "Error fetching results event")?;
 
-    let document_type = ResultDocumentType::TarGz;
+    let document_type = ResultDocumentType::TarGzOriginal;
     let document_id = result_event
         .documents
         .ok_or_else(|| anyhow!("Missing documents in results_event"))?
@@ -313,7 +312,6 @@ pub async fn create_transmission_package_service(
         &hasura_transaction,
         tenant_id,
         &election_event.id,
-        None,
         tally_session_id,
     )
     .await?;

--- a/packages/windmill/src/services/reports/report_variables.rs
+++ b/packages/windmill/src/services/reports/report_variables.rs
@@ -8,7 +8,6 @@ use crate::postgres::results_election::{
 };
 use crate::postgres::tally_session::get_tally_sessions_by_election_event_id;
 use crate::postgres::tally_session_execution::get_tally_session_executions;
-use crate::services::consolidation::create_transmission_package_service::download_to_file;
 use crate::services::consolidation::eml_generator::ValidateAnnotations;
 use crate::services::election_dates::get_election_dates;
 use crate::services::election_event_status::get_election_event_status;


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/5182

Make transmission great again