### PR TITLE
🐞 When importing an election event, the election.initialization_report_generated column should be always false

### DIFF
--- a/packages/windmill/src/services/import/import_election_event.rs
+++ b/packages/windmill/src/services/import/import_election_event.rs
@@ -443,6 +443,7 @@ pub async fn process_election_event_file(
                 serde_json::to_value(status)
                     .with_context(|| "Error serializing election status")?,
             );
+            clone.initialization_report_generated = Some(false);
 
             Ok(clone)
         })


### PR DESCRIPTION
parent issue: https://github.com/sequentech/meta/issues/5404