### PR TITLE
🐞 Large PDFs timeout - download multiple times

### DIFF
--- a/packages/admin-portal/src/components/tally/GenerateReport.tsx
+++ b/packages/admin-portal/src/components/tally/GenerateReport.tsx
@@ -42,7 +42,6 @@ export const GenerateReport: React.FC<GenerateReportProps> = ({
     const [addWidget, setWidgetTaskId, updateWidgetFail] = useWidgetStore()
 
     const onClick = async (e: React.MouseEvent<HTMLElement>) => {
-        console.log("aa onClick")
         e.preventDefault()
         e.stopPropagation()
         setDocumentId(null)


### PR DESCRIPTION
- [x] (Enric) Fix: After downloading ballot images or vote receipts once, page needs a refresh to re-download. It should not need the page refresh.


Parent issue:
https://github.com/sequentech/meta/issues/5380


https://github.com/user-attachments/assets/6ee931ae-41f4-4b0b-9ab0-09151dee9819

