### PR TITLE
🐞 Admin Portal > Tally: Ballot_Images/Vote_Receipts don't download in QA env

### DIFF
--- a/packages/admin-portal/src/components/tally/GenerateReport.tsx
+++ b/packages/admin-portal/src/components/tally/GenerateReport.tsx
@@ -94,7 +94,6 @@ export const GenerateReport: React.FC<GenerateReportProps> = ({
                             electionEventId={electionEventId}
                             fileName={null}
                             onDownload={() => {
-                                // console.log("aa onDownload called")
                                 setDocumentId(null)
                             }}
                         />


### PR DESCRIPTION
Parent issue:
https://github.com/sequentech/meta/issues/5738