### PR TITLE
chore: update workflow runners to ubuntu-latest for release/9.3

### DIFF
--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build_wasm:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   e2e:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set loadtestingImage variable with default fallback

--- a/.github/workflows/java_test.yml
+++ b/.github/workflows/java_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/license_reuse.yml
+++ b/.github/workflows/license_reuse.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   reuse:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/lint_prettify.yml
+++ b/.github/workflows/lint_prettify.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   lint-prettify:
     name: Check frontend linting
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
 
   lint-prettify-hasura:
     name: Check Hasura prettify
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
 
   rust-fmt:
     name: Check Rust format 
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
   
   java-spotless:
     name: Check Java format
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/locs_report.yml
+++ b/.github/workflows/locs_report.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   locs:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   create-release-branch:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     outputs:
       NEW_RELEASE_BRANCH: ${{ steps.CreateReleaseBranch.outputs.NEW_RELEASE_BRANCH }}
       DEPLOYER_BRANCH: ${{ steps.CreateReleaseBranch.outputs.DEPLOYER_BRANCH }}
@@ -118,7 +118,7 @@ jobs:
         fi
 
   release:
-    runs-on: gcp-selfhosted-ubuntu24 #gcp
+    runs-on: ubuntu-latest
     needs: create-release-branch
     outputs:
       VERSION: ${{ steps.Release.outputs.VERSION }}
@@ -274,7 +274,7 @@ jobs:
   trigger-beyond-release:
     needs: [release]
     if: ${{ always() && needs.release.result == 'success' }}
-    runs-on: gcp-selfhosted-ubuntu24 #gcp
+    runs-on: ubuntu-latest
     steps:
     - name: Trigger Beyond Release Workflow
       uses: the-actions-org/workflow-dispatch@v4 # https://github.com/the-actions-org/workflow-dispatch
@@ -289,7 +289,7 @@ jobs:
   trigger-deployer:
     needs: [release, create-release-branch, trigger-beyond-release]
     if: ${{ always() && needs.release.result == 'success' && needs.create-release-branch.result == 'success' }}
-    runs-on: gcp-selfhosted-ubuntu24 #gcp
+    runs-on: ubuntu-latest
     steps:
     - name: Trigger Deployer Workflow
       uses: the-actions-org/workflow-dispatch@v4 # https://github.com/the-actions-org/workflow-dispatch
@@ -304,7 +304,7 @@ jobs:
     if: failure()
     # Here define the depenency jobs
     needs: [release]
-    runs-on: gcp-selfhosted-ubuntu24 #gcp
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -320,7 +320,7 @@ jobs:
 
   slack-report:
     needs: [release, trigger-deployer, cleanup]
-    runs-on: gcp-selfhosted-ubuntu24 #gcp
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     if: always()
     steps:

--- a/.github/workflows/step_cli_build.yml
+++ b/.github/workflows/step_cli_build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-cli:
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       CARGO_TARGET_DIR: rust-local-target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   run-tests:
     name: Run Rust tests
-    runs-on: gcp-selfhosted-ubuntu24
+    runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
       matrix:


### PR DESCRIPTION
This PR updates workflow job runners in `release/9.3` to `ubuntu-latest`.

Only runner declarations were changed in existing workflow files.

Related: https://github.com/sequentech/meta/issues/12296

Co-Authored-By: Oz <oz-agent@warp.dev>