### PR TITLE
fix: harden Maven setup in Sonar Java job

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -175,10 +175,28 @@ jobs:
         with:
           java-version: '17'
           distribution: 'corretto'
-      - name: Install Maven
+      - name: Ensure Maven
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y maven
+          if command -v mvn >/dev/null 2>&1; then
+            echo "Maven already available: $(mvn -v | head -n 1)"
+            exit 0
+          fi
+
+          sudo mkdir -p /usr/share/man/man1
+          for attempt in 1 2 3; do
+            echo "Installing Maven (attempt $attempt/3)"
+            if sudo apt-get update && sudo apt-get install -y maven; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to install Maven after 3 attempts."
+              exit 1
+            fi
+            sleep 15
+          done
+
+          mvn -v
       - name: SonarQube Scan for Java
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
## Summary
- replace apt-only Maven setup in `scan-java` with a resilient `Ensure Maven` step
- reuse preinstalled `mvn` when available
- for fresh images, create `/usr/share/man/man1` and retry apt install up to 3 times

## Why
This mirrors the hardening applied in Beyond after a runner-image failure during Maven post-install (`update-alternatives` could not create manpage symlink because `/usr/share/man/man1` was missing).

## Validation
- Sonar workflow run on this branch: https://github.com/sequentech/step/actions/runs/27929558108
- Note: in this dispatch run, `scan-java` was skipped because no Java file changes were present in the branch diff.

Co-Authored-By: Oz <oz-agent@warp.dev>