### PR TITLE
Create AWS infra-euw1 ARC setup and AWS ECR runner-image workflow (step AWS runs-on workflows)

### DIFF
--- a/.github/workflows/reusable_build_push.yml
+++ b/.github/workflows/reusable_build_push.yml
@@ -18,11 +18,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on:
-      - env=infra-euw1
-      - runs-on=${{ github.run_id }}
-      - runner=2cpu-linux-x64
-      - image=ubuntu24-full-x64
+    runs-on: aws-selfhosted-ubuntu24
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12309

- Normalize AWS workflow runner selection to the canonical aws-selfhosted-ubuntu24 label.
- Update reusable_build_push.yml only.

Co-Authored-By: Oz <oz-agent@warp.dev>