### PR TITLE
fix: use aws-selfhosted-ubuntu24 for reusable build push (release/9.2)

### DIFF
--- a/.github/workflows/reusable_build_push.yml
+++ b/.github/workflows/reusable_build_push.yml
@@ -18,11 +18,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on:
-      - env=infra-euw1
-      - runs-on=${{ github.run_id }}
-      - runner=2cpu-linux-x64
-      - image=ubuntu24-full-x64
+    runs-on: aws-selfhosted-ubuntu24
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- update `reusable_build_push.yml` on `release/9.2` to use `aws-selfhosted-ubuntu24`
- remove runs-on labels list (`env=infra-euw1`, `runs-on=${{ github.run_id }}`, `runner`, `image`) for this reusable workflow job

Co-Authored-By: Oz <oz-agent@warp.dev>