### PR TITLE
✨ Close the login/register template feature gap in Keycloak theme

### DIFF
--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/LoginBean.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/LoginBean.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sequent.keycloak.authenticator.forgot_password;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.stream.Stream;
+import org.keycloak.forms.login.freemarker.model.AbstractUserProfileBean;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
+import org.keycloak.userprofile.UserProfileProvider;
+
+/**
+ * Exposes the realm's User Profile attribute declarations to {@code login.ftl}'s {@code
+ * matchAttributes} rendering, the same {@code profile.attributesByName[...]} shape {@code
+ * register.ftl} already consumes via {@code user-profile-commons.ftl} - so a matched attribute
+ * (e.g. {@code dateOfBirth}) gets the same field type, helper text, and required marker at login as
+ * it does at registration.
+ *
+ * <p>Mirrors Keycloak's own {@code RegisterBean}: built with {@link
+ * UserProfileContext#REGISTRATION} and no {@link UserModel}, since no user is resolved yet at the
+ * point this form is rendered - the submitted values are what {@link
+ * MultiAttributeCredentialResolver} uses to find one. Unlike {@code RegisterBean}, this passes
+ * {@code writeableOnly=false} to {@link #init}: this form never persists anything through {@link
+ * UserProfileProvider} (matching happens via a direct user-store search, not {@code
+ * UserProfile.update()}), so an attribute a voter can't self-edit (write-restricted) should still
+ * be usable to identify themselves for login, not silently hidden the way an actual registration
+ * form must hide it.
+ */
+public class LoginBean extends AbstractUserProfileBean {
+
+  public LoginBean(MultivaluedMap<String, String> formData, KeycloakSession session) {
+    super(formData);
+    init(session, false);
+  }
+
+  @Override
+  protected UserProfile createUserProfile(UserProfileProvider provider) {
+    return provider.create(UserProfileContext.REGISTRATION, null, (UserModel) null);
+  }
+
+  @Override
+  protected Stream<String> getAttributeDefaultValues(String name) {
+    return null;
+  }
+
+  @Override
+  public String getContext() {
+    return "MULTI_ATTRIBUTE_LOGIN";
+  }
+}

--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticator.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticator.java
@@ -8,10 +8,11 @@ import com.google.auto.service.AutoService;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.Config;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -20,6 +21,7 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.AuthenticatorFactory;
 import org.keycloak.events.Errors;
 import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.forms.login.freemarker.model.AbstractUserProfileBean;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -50,7 +52,9 @@ public class MultiAttributePasswordAuthenticator implements Authenticator, Authe
    * bespoke template, so this authenticator gets the same registration link, social-provider
    * buttons, remember-me and password-visibility toggle as the standard login form. {@code
    * login.ftl} renders its single "username" field as one field per {@code matchAttributes} entry
-   * when that template attribute is set - see {@link #challenge}.
+   * when that template attribute is set, looking each one up in the {@code profile} attribute (a
+   * {@link LoginBean}) via {@code profile.attributesByName} and rendering it with the same {@code
+   * user-profile-commons.ftl} macros {@code register.ftl} uses - see {@link #challenge}.
    */
   public static final String FORM_FTL = "login.ftl";
 
@@ -94,11 +98,14 @@ public class MultiAttributePasswordAuthenticator implements Authenticator, Authe
         Utils.getThrottleConfig(context.getAuthenticatorConfig());
     MultiAttributeCredentialResolver.MatchPolicy matchPolicy =
         Utils.getMatchPolicy(context.getAuthenticatorConfig());
+    Set<String> optionalAttributes = optionalAttributes(context, matchAttributes, formData);
+    List<String> attributesToMatch =
+        effectiveMatchAttributes(matchAttributes, submittedValues, optionalAttributes);
     MultiAttributeCredentialResolver.Resolution result =
         resolveAuthenticatedUser(
             context.getSession(),
             context.getRealm(),
-            matchAttributes,
+            attributesToMatch,
             submittedValues,
             password,
             throttleConfig,
@@ -190,12 +197,82 @@ public class MultiAttributePasswordAuthenticator implements Authenticator, Authe
   }
 
   /**
+   * When {@link Utils#HONOR_USER_PROFILE_REQUIRED} is enabled, returns the subset of {@code
+   * matchAttributes} the realm's User Profile does <em>not</em> mark required for this same {@link
+   * LoginBean} context - the same source of truth {@link #challenge} uses to decide the client-side
+   * required marking, so a field is never marked required in the form while being optional to
+   * match, or vice versa. An attribute with no User Profile entry at all stays mandatory (the
+   * conservative default - see the fallback field in {@code login.ftl}). When disabled (default),
+   * returns an empty set, so every configured attribute stays mandatory, unchanged from before this
+   * setting existed.
+   *
+   * <p>Consumed by {@link #effectiveMatchAttributes} - {@link MultiAttributeCredentialResolver}
+   * itself has no notion of "optional", it's purely a form-level concern handled before calling it.
+   */
+  protected Set<String> optionalAttributes(
+      AuthenticationFlowContext context,
+      List<String> matchAttributes,
+      MultivaluedMap<String, String> formData) {
+    if (!Utils.getBoolean(
+        context.getAuthenticatorConfig(),
+        Utils.HONOR_USER_PROFILE_REQUIRED,
+        Boolean.parseBoolean(Utils.HONOR_USER_PROFILE_REQUIRED_DEFAULT))) {
+      return Set.of();
+    }
+    LoginBean profile = new LoginBean(formData, context.getSession());
+    Map<String, AbstractUserProfileBean.Attribute> attributesByName = profile.getAttributesByName();
+    Set<String> optional = new HashSet<>();
+    for (String attribute : matchAttributes) {
+      AbstractUserProfileBean.Attribute declared = attributesByName.get(attribute);
+      if (declared != null && !declared.isRequired()) {
+        optional.add(attribute);
+      }
+    }
+    return optional;
+  }
+
+  /**
+   * Drops any {@code optionalAttributes} entry left blank in {@code submittedValues} from the list
+   * passed to {@link MultiAttributeCredentialResolver#resolveAuthenticatedUser} - the resolver then
+   * never sees that attribute for this request, the same as if it weren't configured at all, rather
+   * than the resolver needing its own "optional" concept. A mandatory attribute left blank is
+   * deliberately kept in the list even though it'll fail: that's what makes the resolver's existing
+   * blank-attribute check reject it (with its usual dummy-hash timing safety), exactly as it
+   * already does today.
+   *
+   * <p>Falls back to the original, unfiltered {@code matchAttributes} if every entry would be
+   * dropped (every configured attribute is optional and blank): passing an empty list to the
+   * resolver would misreport a normal, if unusual, submission as a static misconfiguration (see
+   * {@link MultiAttributeCredentialResolver#resolveAuthenticatedUser}'s empty-list check), and
+   * would let the request through as an unconstrained "match everyone" query. Passing the original
+   * list instead lets the resolver's own blank-attribute check reject it the same way as any other
+   * invalid submission.
+   */
+  protected List<String> effectiveMatchAttributes(
+      List<String> matchAttributes,
+      Map<String, String> submittedValues,
+      Set<String> optionalAttributes) {
+    List<String> kept =
+        matchAttributes.stream()
+            .filter(
+                attribute ->
+                    !optionalAttributes.contains(attribute)
+                        || hasValue(submittedValues.get(attribute)))
+            .toList();
+    return kept.isEmpty() ? matchAttributes : kept;
+  }
+
+  private static boolean hasValue(String value) {
+    return value != null && !value.isBlank();
+  }
+
+  /**
    * Reads each configured attribute's submitted value, normalizing date-typed attributes (per the
-   * realm's User Profile {@code html5-date} annotation, the same source {@link
-   * #buildAttributeFields} reads) into the canonical {@code YYYY-MM-DD} storage format - see {@link
-   * Utils#normalizeDate}. An HTML5 date input already submits exactly {@code YYYY-MM-DD}, so this
-   * is a no-op for the common case; it's still applied defensively so the browser path stays
-   * consistent with the IVR path, which needs real reordering.
+   * realm's User Profile {@code html5-date} annotation - see {@link Utils#resolveHtml5InputType})
+   * into the canonical {@code YYYY-MM-DD} storage format - see {@link Utils#normalizeDate}. An
+   * HTML5 date input already submits exactly {@code YYYY-MM-DD}, so this is a no-op for the common
+   * case; it's still applied defensively so the browser path stays consistent with the IVR path,
+   * which needs real reordering.
    */
   protected Map<String, String> collectSubmittedValues(
       KeycloakSession session,
@@ -229,33 +306,16 @@ public class MultiAttributePasswordAuthenticator implements Authenticator, Authe
             context.getAuthenticatorConfig(),
             Utils.MATCH_ATTRIBUTES,
             Utils.MATCH_ATTRIBUTES_DEFAULT);
-    form.setAttribute(
-        "matchAttributes", buildAttributeFields(context.getSession(), matchAttributes));
+    form.setAttribute("matchAttributes", matchAttributes);
+    form.setAttribute("profile", new LoginBean(formData, context.getSession()));
+    if (Utils.getBoolean(
+        context.getAuthenticatorConfig(),
+        Utils.HONOR_USER_PROFILE_REQUIRED,
+        Boolean.parseBoolean(Utils.HONOR_USER_PROFILE_REQUIRED_DEFAULT))) {
+      form.setAttribute("honorUserProfileRequired", true);
+    }
 
     return form.createForm(FORM_FTL);
-  }
-
-  /**
-   * Builds the {@code {name, type}} pairs the template renders one input per configured attribute
-   * from. {@code type} mirrors whatever HTML5 input type (e.g. {@code date}) the realm's User
-   * Profile configuration declares for that attribute, so a field like {@code dateOfBirth} renders
-   * the same native date picker here as it does at registration - see {@link
-   * Utils#resolveHtml5InputType}. Fetches the User Profile attribute list once up front rather than
-   * once per configured attribute.
-   */
-  protected List<Map<String, String>> buildAttributeFields(
-      KeycloakSession session, List<String> matchAttributes) {
-    List<UPAttribute> profileAttributes = Utils.getRealmUserProfileAttributes(session);
-    List<Map<String, String>> fields = new ArrayList<>();
-    for (String attribute : matchAttributes) {
-      fields.add(
-          Map.of(
-              "name",
-              attribute,
-              "type",
-              Utils.resolveHtml5InputType(profileAttributes, attribute)));
-    }
-    return fields;
   }
 
   @Override
@@ -392,7 +452,25 @@ public class MultiAttributePasswordAuthenticator implements Authenticator, Authe
                 + ".",
             ProviderConfigProperty.STRING_TYPE,
             Utils.MAX_ATTRIBUTE_LOOKUP_RESULTS_DEFAULT),
-        matchPolicy);
+        matchPolicy,
+        new ProviderConfigProperty(
+            Utils.HONOR_USER_PROFILE_REQUIRED,
+            "Honor User Profile required attributes",
+            "When enabled, each matchAttributes field's required-ness - both for matching and for"
+                + " the rendered form - comes from the realm's User Profile required setting for"
+                + " that attribute, instead of every configured attribute being unconditionally"
+                + " mandatory. An attribute User Profile marks required gets the HTML5 required"
+                + " attribute plus the asterisk + \"Required fields\" note register.ftl shows, and"
+                + " must be filled in to match. An attribute NOT marked required becomes optional:"
+                + " a voter may leave it blank and still match on the remaining attributes, as long"
+                + " as at least one configured attribute has a value - an all-blank submission"
+                + " still fails, same as today. WARNING: making an attribute optional widens who it"
+                + " can match (e.g. dateOfBirth alone instead of dateOfBirth+nationalId), so only"
+                + " enable this if that's the intended tradeoff for that attribute. Disabled by"
+                + " default: every configured attribute stays unconditionally mandatory, exactly as"
+                + " before this setting existed.",
+            ProviderConfigProperty.BOOLEAN_TYPE,
+            Utils.HONOR_USER_PROFILE_REQUIRED_DEFAULT));
   }
 
   @Override

--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/Utils.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/Utils.java
@@ -77,6 +77,33 @@ public class Utils {
 
   public static final String MATCH_POLICY_DEFAULT =
       MultiAttributeCredentialResolver.MatchPolicy.REJECT_AMBIGUOUS.name();
+
+  /**
+   * Opt-in: makes each configured {@code matchAttributes} entry's required-ness - both for the
+   * rendered form and for matching itself - come from the realm's User Profile {@code required}
+   * setting for that attribute, instead of every configured attribute being unconditionally
+   * mandatory.
+   *
+   * <p>Client-side: an attribute User Profile marks required gets the HTML5 {@code required}
+   * attribute (blocking submission before it reaches the server) and the register.ftl-style "*
+   * Required fields" note.
+   *
+   * <p>Server-side: an attribute User Profile does <em>not</em> mark required becomes optional for
+   * matching - handled entirely as a form-level concern in {@code
+   * MultiAttributePasswordAuthenticator} (see {@code optionalAttributes}/{@code
+   * effectiveMatchAttributes}), which simply omits a blank optional attribute from the list it
+   * hands to {@link MultiAttributeCredentialResolver#resolveAuthenticatedUser} - the resolver
+   * itself has no notion of "optional" and is unchanged. A voter may leave an optional attribute
+   * blank and still match on the remaining attributes, as long as at least one configured attribute
+   * has a value (an all-blank submission still fails generically, the same as today).
+   *
+   * <p>Disabled by default: every configured attribute stays unconditionally mandatory, exactly as
+   * before this setting existed.
+   */
+  public static final String HONOR_USER_PROFILE_REQUIRED = "honorUserProfileRequired";
+
+  public static final String HONOR_USER_PROFILE_REQUIRED_DEFAULT = "false";
+
   public final String ATTEMPTED_EMAIL = "ATTEMPTED_EMAIL";
   public final String DISABLE_PASSWORD_ATTRIBUTE = "disablePassword";
   public final String HIDE_USER_NOT_FOUND = "hideUserNotFound";
@@ -248,17 +275,23 @@ public class Utils {
    * field).
    */
   public String resolveHtml5InputType(List<UPAttribute> attributes, String attributeName) {
-    Object inputType =
+    String inputType = resolveAnnotation(attributes, attributeName, "inputType");
+    if (inputType == null || !inputType.startsWith("html5-")) {
+      return "text";
+    }
+    return inputType.substring("html5-".length());
+  }
+
+  private String resolveAnnotation(
+      List<UPAttribute> attributes, String attributeName, String annotationKey) {
+    Object value =
         attributes.stream()
             .filter(attribute -> attributeName.equals(attribute.getName()))
             .findFirst()
             .map(UPAttribute::getAnnotations)
-            .map(annotations -> annotations.get("inputType"))
+            .map(annotations -> annotations.get(annotationKey))
             .orElse(null);
-    if (!(inputType instanceof String) || !((String) inputType).startsWith("html5-")) {
-      return "text";
-    }
-    return ((String) inputType).substring("html5-".length());
+    return value instanceof String ? (String) value : null;
   }
 
   /**

--- a/packages/keycloak-extensions/message-otp-authenticator/src/test/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticatorTest.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/test/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticatorTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -26,6 +28,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +37,7 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.events.EventBuilder;
+import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
@@ -46,6 +50,10 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.services.managers.BruteForceProtector;
+import org.keycloak.userprofile.AttributeMetadata;
+import org.keycloak.userprofile.Attributes;
+import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
 import org.keycloak.userprofile.UserProfileProvider;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -189,6 +197,70 @@ class MultiAttributePasswordAuthenticatorTest {
 
     assertTrue(result.authenticatedUser().isPresent());
     assertEquals(alice, result.authenticatedUser().get());
+  }
+
+  // ── effectiveMatchAttributes: form-level narrowing before the resolver ever sees the list ──
+
+  @Test
+  void effectiveMatchAttributes_dropsBlankOptionalAttribute() {
+    List<String> result =
+        authenticator.effectiveMatchAttributes(
+            List.of("dateOfBirth", "nationalId"),
+            valuesOf("dateOfBirth", "19900101", "nationalId", ""),
+            Set.of("nationalId"));
+
+    assertEquals(List.of("dateOfBirth"), result);
+  }
+
+  @Test
+  void effectiveMatchAttributes_keepsMandatoryAttributeEvenWhenBlank() {
+    // nationalId is blank but NOT in optionalAttributes - kept as-is, so the resolver's own
+    // blank-attribute check rejects it exactly as it does today.
+    List<String> result =
+        authenticator.effectiveMatchAttributes(
+            List.of("dateOfBirth", "nationalId"),
+            valuesOf("dateOfBirth", "19900101", "nationalId", ""),
+            Set.of());
+
+    assertEquals(List.of("dateOfBirth", "nationalId"), result);
+  }
+
+  @Test
+  void effectiveMatchAttributes_keepsOptionalAttributeWhenFilledIn() {
+    List<String> result =
+        authenticator.effectiveMatchAttributes(
+            List.of("dateOfBirth", "nationalId"),
+            valuesOf("dateOfBirth", "19900101", "nationalId", "X123"),
+            Set.of("nationalId"));
+
+    assertEquals(List.of("dateOfBirth", "nationalId"), result);
+  }
+
+  @Test
+  void effectiveMatchAttributes_fallsBackToOriginalListWhenEveryAttributeWouldBeDropped() {
+    // Both optional and blank - dropping both would hand the resolver an empty list, which it
+    // treats as a static misconfiguration (see MultiAttributeCredentialResolver's empty-list
+    // check) rather than a normal all-blank submission, and would run an unconstrained query if
+    // it didn't. Falling back to the original list instead lets the resolver's own
+    // blank-attribute check reject it the same way as any other invalid submission.
+    List<String> result =
+        authenticator.effectiveMatchAttributes(
+            List.of("dateOfBirth", "nationalId"),
+            valuesOf("dateOfBirth", "", "nationalId", ""),
+            Set.of("dateOfBirth", "nationalId"));
+
+    assertEquals(List.of("dateOfBirth", "nationalId"), result);
+  }
+
+  @Test
+  void effectiveMatchAttributes_dropsOptionalUsernameWhenBlank() {
+    List<String> result =
+        authenticator.effectiveMatchAttributes(
+            List.of("username", "dateOfBirth"),
+            valuesOf("username", "", "dateOfBirth", "19900101"),
+            Set.of("username"));
+
+    assertEquals(List.of("dateOfBirth"), result);
   }
 
   // ── DOB-not-unique-alone case: multiple candidates, password disambiguates ──
@@ -1074,36 +1146,6 @@ class MultiAttributePasswordAuthenticatorTest {
   }
 
   @Test
-  void buildAttributeFields_html5DateAnnotation_resolvesToDateInputType() {
-    mockUserProfileAttributes(new UPAttribute("dateOfBirth", Map.of("inputType", "html5-date")));
-
-    List<Map<String, String>> fields =
-        authenticator.buildAttributeFields(session, List.of("dateOfBirth"));
-
-    assertEquals(List.of(Map.of("name", "dateOfBirth", "type", "date")), fields);
-  }
-
-  @Test
-  void buildAttributeFields_nonHtml5InputType_fallsBackToText() {
-    mockUserProfileAttributes(new UPAttribute("country", Map.of("inputType", "select")));
-
-    List<Map<String, String>> fields =
-        authenticator.buildAttributeFields(session, List.of("country"));
-
-    assertEquals(List.of(Map.of("name", "country", "type", "text")), fields);
-  }
-
-  @Test
-  void buildAttributeFields_noUserProfileEntry_fallsBackToText() {
-    mockUserProfileAttributes();
-
-    List<Map<String, String>> fields =
-        authenticator.buildAttributeFields(session, List.of("nationalId"));
-
-    assertEquals(List.of(Map.of("name", "nationalId", "type", "text")), fields);
-  }
-
-  @Test
   void getRealmUserProfileAttributes_noUserProfileProvider_returnsEmptyList() {
     when(session.getProvider(UserProfileProvider.class)).thenReturn(null);
 
@@ -1144,6 +1186,168 @@ class MultiAttributePasswordAuthenticatorTest {
   @Test
   void resolveHtml5InputType_unknownAttribute_fallsBackToText() {
     assertEquals("text", Utils.resolveHtml5InputType(List.of(), "nationalId"));
+  }
+
+  private void mockEmptyUserProfile() {
+    UserProfileProvider userProfileProvider = mock(UserProfileProvider.class);
+    UserProfile userProfile = mock(UserProfile.class);
+    Attributes attributes = mock(Attributes.class);
+    lenient().when(attributes.getReadable()).thenReturn(Map.of());
+    lenient().when(userProfile.getAttributes()).thenReturn(attributes);
+    lenient()
+        .when(userProfileProvider.create(eq(UserProfileContext.REGISTRATION), isNull(), isNull()))
+        .thenReturn(userProfile);
+    lenient().when(session.getProvider(UserProfileProvider.class)).thenReturn(userProfileProvider);
+  }
+
+  private AuthenticationFlowContext mockChallengeContext(Map<String, String> config) {
+    AuthenticationFlowContext context = mock(AuthenticationFlowContext.class);
+    AuthenticatorConfigModel authConfig = mock(AuthenticatorConfigModel.class);
+    when(authConfig.getConfig()).thenReturn(config);
+    when(context.getAuthenticatorConfig()).thenReturn(authConfig);
+    lenient().when(context.getSession()).thenReturn(session);
+    LoginFormsProvider form = mock(LoginFormsProvider.class);
+    lenient().when(context.form()).thenReturn(form);
+    lenient()
+        .when(form.createForm(MultiAttributePasswordAuthenticator.FORM_FTL))
+        .thenReturn(mock(Response.class));
+    mockEmptyUserProfile();
+    return context;
+  }
+
+  @Test
+  void challenge_setsMatchAttributesAndProfileFormAttributes() {
+    AuthenticationFlowContext context =
+        mockChallengeContext(Map.of(Utils.MATCH_ATTRIBUTES, "dateOfBirth"));
+
+    authenticator.challenge(context, new MultivaluedHashMap<>(), null);
+
+    verify(context.form()).setAttribute("matchAttributes", List.of("dateOfBirth"));
+    verify(context.form()).setAttribute(eq("profile"), any(LoginBean.class));
+  }
+
+  @Test
+  void challenge_honorUserProfileRequiredEnabled_setsFormAttribute() {
+    AuthenticationFlowContext context =
+        mockChallengeContext(
+            Map.of(
+                Utils.MATCH_ATTRIBUTES, "dateOfBirth",
+                Utils.HONOR_USER_PROFILE_REQUIRED, "true"));
+
+    authenticator.challenge(context, new MultivaluedHashMap<>(), null);
+
+    verify(context.form()).setAttribute("honorUserProfileRequired", true);
+  }
+
+  @Test
+  void challenge_honorUserProfileRequiredNotConfigured_neverSetsFormAttribute() {
+    AuthenticationFlowContext context =
+        mockChallengeContext(Map.of(Utils.MATCH_ATTRIBUTES, "dateOfBirth"));
+
+    authenticator.challenge(context, new MultivaluedHashMap<>(), null);
+
+    verify(context.form(), never()).setAttribute(eq("honorUserProfileRequired"), any());
+  }
+
+  @Test
+  void factory_configPropertiesIncludeHonorUserProfileRequiredDisabledByDefault() {
+    MultiAttributePasswordAuthenticator factory = new MultiAttributePasswordAuthenticator();
+    ProviderConfigProperty honorRequiredProp =
+        factory.getConfigProperties().stream()
+            .filter(prop -> Utils.HONOR_USER_PROFILE_REQUIRED.equals(prop.getName()))
+            .findFirst()
+            .orElse(null);
+
+    assertTrue(honorRequiredProp != null);
+    assertEquals(ProviderConfigProperty.BOOLEAN_TYPE, honorRequiredProp.getType());
+    assertEquals("false", honorRequiredProp.getDefaultValue());
+  }
+
+  // ── optionalAttributes: which matchAttributes the realm's User Profile does NOT require ──
+
+  @Test
+  void optionalAttributes_declaredRequiredAttribute_staysMandatory() {
+    AuthenticationFlowContext context =
+        mockChallengeContext(
+            Map.of(
+                Utils.MATCH_ATTRIBUTES, "dateOfBirth",
+                Utils.HONOR_USER_PROFILE_REQUIRED, "true"));
+    mockUserProfileForOptionalAttributes(Map.of("dateOfBirth", true));
+
+    Set<String> optional =
+        authenticator.optionalAttributes(
+            context, List.of("dateOfBirth"), new MultivaluedHashMap<>());
+
+    assertTrue(optional.isEmpty());
+  }
+
+  @Test
+  void optionalAttributes_declaredNonRequiredAttribute_becomesOptional() {
+    AuthenticationFlowContext context =
+        mockChallengeContext(
+            Map.of(
+                Utils.MATCH_ATTRIBUTES, "nationalId",
+                Utils.HONOR_USER_PROFILE_REQUIRED, "true"));
+    mockUserProfileForOptionalAttributes(Map.of("nationalId", false));
+
+    Set<String> optional =
+        authenticator.optionalAttributes(
+            context, List.of("nationalId"), new MultivaluedHashMap<>());
+
+    assertEquals(Set.of("nationalId"), optional);
+  }
+
+  @Test
+  void optionalAttributes_undeclaredAttribute_staysMandatory() {
+    // "voterId" has no User Profile entry at all (e.g. a typo, or a non-User-Profile field) -
+    // the conservative default is to leave it mandatory rather than silently widen the match.
+    AuthenticationFlowContext context =
+        mockChallengeContext(
+            Map.of(
+                Utils.MATCH_ATTRIBUTES, "voterId",
+                Utils.HONOR_USER_PROFILE_REQUIRED, "true"));
+    mockUserProfileForOptionalAttributes(Map.of());
+
+    Set<String> optional =
+        authenticator.optionalAttributes(context, List.of("voterId"), new MultivaluedHashMap<>());
+
+    assertTrue(optional.isEmpty());
+  }
+
+  @Test
+  void optionalAttributes_notEnabled_returnsEmptySetRegardlessOfUserProfile() {
+    AuthenticationFlowContext context =
+        mockChallengeContext(Map.of(Utils.MATCH_ATTRIBUTES, "nationalId"));
+    mockUserProfileForOptionalAttributes(Map.of("nationalId", false));
+
+    Set<String> optional =
+        authenticator.optionalAttributes(
+            context, List.of("nationalId"), new MultivaluedHashMap<>());
+
+    assertTrue(optional.isEmpty());
+  }
+
+  private void mockUserProfileForOptionalAttributes(Map<String, Boolean> requiredByName) {
+    UserProfileProvider userProfileProvider = mock(UserProfileProvider.class);
+    UserProfile userProfile = mock(UserProfile.class);
+    Attributes attributes = mock(Attributes.class);
+
+    Map<String, List<String>> readable = new HashMap<>();
+    for (Map.Entry<String, Boolean> entry : requiredByName.entrySet()) {
+      String name = entry.getKey();
+      readable.put(name, List.of());
+      AttributeMetadata metadata = mock(AttributeMetadata.class);
+      lenient().when(metadata.getName()).thenReturn(name);
+      lenient().when(attributes.getMetadata(name)).thenReturn(metadata);
+      lenient().when(attributes.isRequired(name)).thenReturn(entry.getValue());
+    }
+    lenient().when(attributes.getReadable()).thenReturn(readable);
+    lenient().when(attributes.getUnmanagedAttributes()).thenReturn(Map.of());
+    lenient().when(userProfile.getAttributes()).thenReturn(attributes);
+    lenient()
+        .when(userProfileProvider.create(eq(UserProfileContext.REGISTRATION), isNull(), isNull()))
+        .thenReturn(userProfile);
+    lenient().when(session.getProvider(UserProfileProvider.class)).thenReturn(userProfileProvider);
   }
 
   // ── Date normalization (collectSubmittedValues) ─────────────────────────
@@ -1219,6 +1423,60 @@ class MultiAttributePasswordAuthenticatorTest {
             org.keycloak.authentication.AuthenticationFlowError.INVALID_CREDENTIALS,
             challengeResponse);
     inOrder.verify(context).clearUser();
+  }
+
+  @Test
+  void action_passesNarrowedMatchAttributesFromOptionalAttributesToResolver() {
+    AuthenticationFlowContext context = mockActionContext();
+    AuthenticatorConfigModel authConfig = context.getAuthenticatorConfig();
+    when(authConfig.getConfig())
+        .thenReturn(Map.of(Utils.MATCH_ATTRIBUTES, "dateOfBirth##nationalId"));
+    java.util.concurrent.atomic.AtomicReference<List<String>> captured =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    MultiAttributePasswordAuthenticator actionAuthenticator =
+        new MultiAttributePasswordAuthenticator() {
+          @Override
+          protected Map<String, String> collectSubmittedValues(
+              KeycloakSession session,
+              List<String> matchAttributes,
+              MultivaluedMap<String, String> formData) {
+            // nationalId left blank - only dateOfBirth has a submitted value.
+            return valuesOf("dateOfBirth", "19900101");
+          }
+
+          @Override
+          protected Set<String> optionalAttributes(
+              AuthenticationFlowContext context,
+              List<String> matchAttributes,
+              MultivaluedMap<String, String> formData) {
+            return Set.of("nationalId");
+          }
+
+          @Override
+          protected Resolution resolveAuthenticatedUser(
+              KeycloakSession session,
+              RealmModel realm,
+              List<String> matchAttributes,
+              Map<String, String> submittedValues,
+              String password,
+              MultiAttributeCredentialResolver.ThrottleConfig throttleConfig,
+              MultiAttributeCredentialResolver.MatchPolicy matchPolicy) {
+            captured.set(matchAttributes);
+            return Resolution.failure();
+          }
+
+          @Override
+          protected Response challenge(
+              AuthenticationFlowContext context,
+              MultivaluedMap<String, String> formData,
+              String error) {
+            return mock(Response.class);
+          }
+        };
+
+    actionAuthenticator.action(context);
+
+    assertEquals(List.of("dateOfBirth"), captured.get());
   }
 
   private AuthenticationFlowContext mockActionContext() {

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/field-helper-text.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/field-helper-text.ftl
@@ -1,0 +1,22 @@
+<#--
+ SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<#--  Renders a User Profile attribute's inputHelperTextBefore/After annotation the same way
+      wherever that attribute is collected: register.ftl (via user-profile-commons.ftl) and
+      login.ftl's matchAttributes loop (MultiAttributePasswordAuthenticator). Lives in
+      sequent.admin-portal/login so sequent.voting-portal inherits it without its own copy.  -->
+
+<#macro helperTextBefore id text>
+    <#if text?has_content>
+        <div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${id}" aria-live="polite">${kcSanitize(advancedMsg(text))?no_esc}</div>
+    </#if>
+</#macro>
+
+<#macro helperTextAfter id text>
+    <#if text?has_content>
+        <div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${id}" aria-live="polite">${kcSanitize(advancedMsg(text))?no_esc}</div>
+    </#if>
+</#macro>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/login.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/login.ftl
@@ -5,7 +5,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled?? displaySocialProviders=social.providers?has_content; section>
+<#import "user-profile-commons.ftl" as userProfileCommons>
+<#import "tel-input-widget.ftl" as telInputWidget>
+<#import "select-filter-widget.ftl" as selectFilterWidget>
+<#import "social-providers.ftl" as socialProviders>
+<#assign matchAttributesHaveRequired = honorUserProfileRequired?? && matchAttributes?? && matchAttributes?filter(name -> profile.attributesByName[name]?? && profile.attributesByName[name].required)?has_content>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled?? displayRequiredFields=matchAttributesHaveRequired displaySocialProviders=social.providers?has_content; section>
     <#if section = "header">
         ${msg("loginAccountTitle")}
     <#elseif section = "form">
@@ -13,26 +18,25 @@ SPDX-License-Identifier: AGPL-3.0-only
           <div id="kc-form-wrapper">
             <#if realm.password>
                 <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
-                    <#-- Number of fields rendered ahead of the password field -->
-                    <#assign fieldCount = (matchAttributes?? && matchAttributes?has_content)?then(matchAttributes?size, 1)>
                     <#if !usernameHidden??>
                         <#if matchAttributes?? && matchAttributes?has_content>
-                            <#if matchAttributes?filter(f -> f.type == "tel")?has_content>
-                                <#include "intl-tel-input.ftl">
-                            </#if>
-                            <#list matchAttributes as field>
-                                <div class="${properties.kcFormGroupClass!}">
-                                    <label for="${field.name}" class="${properties.kcLabelClass!}">${msg(field.name)}</label>
+                            <@telInputWidget.assets/>
+                            <@selectFilterWidget.assets/>
 
-                                    <#if field.type == "tel">
-                                        <@renderIntlTelInput id=field.name name=field.name autofocus=(field?index == 0)/>
-                                    <#else>
-                                        <input tabindex="${field?index + 1}" id="${field.name}" class="${properties.kcInputClass!}" name="${field.name}" type="${field.type!'text'}"
-                                               <#if field?index == 0>autofocus</#if> autocomplete="off"
+                            <#list matchAttributes as name>
+                                <#if profile.attributesByName[name]??>
+                                    <#assign matchAttribute = profile.attributesByName[name]>
+                                    <#assign matchAttributeRequired = honorUserProfileRequired?? && matchAttribute.required>
+                                    <@userProfileCommons.inputFieldWithLabel attribute=matchAttribute name=name values=matchAttribute.values required=matchAttributeRequired requiredMarker=matchAttributeRequired/>
+                                <#else>
+                                    <#-- Not declared in the realm's User Profile - still usable for matching, rendered as a plain text field -->
+                                    <div class="${properties.kcFormGroupClass!}">
+                                        <label for="${name}" class="${properties.kcLabelClass!}">${msg(name)}</label>
+                                        <input id="${name}" class="${properties.kcInputClass!}" name="${name}" type="text" autocomplete="off"
                                                aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                                         />
-                                    </#if>
-                                </div>
+                                    </div>
+                                </#if>
                             </#list>
 
                             <#if messagesPerField.existsError('username','password')>
@@ -44,7 +48,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                             <div class="${properties.kcFormGroupClass!}">
                                 <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
 
-                                <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" type="text" autofocus autocomplete="off"
+                                <input id="username" class="${properties.kcInputClass!}" name="username" type="text" autofocus autocomplete="off"
                                        aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                                 />
 
@@ -62,12 +66,12 @@ SPDX-License-Identifier: AGPL-3.0-only
                         <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
 
                         <div class="${properties.kcInputGroup!}">
-                            <input tabindex="${fieldCount + 2}" id="password" class="${properties.kcInputClass!}" name="password" type="password"
+                            <input id="password" class="${properties.kcInputClass!}" name="password" type="password"
                                     autocomplete="off"
                                    aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                             />
                             <button class="${properties.kcFormPasswordVisibilityButtonClass!}" type="button" aria-label="${msg("showPassword")}"
-                                    aria-controls="password" data-password-toggle tabindex="${fieldCount + 3}"
+                                    aria-controls="password" data-password-toggle
                                     data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}" data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}"
                                     data-label-show="${msg('showPassword')}" data-label-hide="${msg('hidePassword')}">
                                 <i class="${properties.kcFormPasswordVisibilityIconShow!}" aria-hidden="true"></i>
@@ -88,9 +92,9 @@ SPDX-License-Identifier: AGPL-3.0-only
                                 <div class="checkbox">
                                     <label>
                                         <#if login.rememberMe??>
-                                            <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                                            <input id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
                                         <#else>
-                                            <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                                            <input id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
                                         </#if>
                                     </label>
                                 </div>
@@ -98,7 +102,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                             </div>
                             <div class="${properties.kcFormOptionsWrapperClass!}">
                                 <#if realm.resetPasswordAllowed>
-                                    <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                                    <span><a href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
                                 </#if>
                             </div>
 
@@ -129,7 +133,6 @@ SPDX-License-Identifier: AGPL-3.0-only
                       <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                           <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
                           <input
-                            tabindex="4" 
                             class="g-recaptcha ${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                             name="login"
                             id="kc-login"
@@ -146,34 +149,12 @@ SPDX-License-Identifier: AGPL-3.0-only
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
             <div id="kc-registration-container">
                 <div id="kc-registration">
-                    <span>${msg("noAccount")} <a tabindex="6"
-                                                 href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+                    <span>${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a></span>
                 </div>
             </div>
         </#if>
     <#elseif section = "socialProviders" >
-        <#if realm.password && social.providers??>
-            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
-                <hr/>
-                <h4>${msg("identity-provider-login-label")}</h4>
-
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
-                    <#list social.providers as p>
-                        <li>
-                            <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
-                                    type="button" href="${p.loginUrl}">
-                                <#if p.iconClasses?has_content>
-                                    <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
-                                    <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${p.displayName!}</span>
-                                <#else>
-                                    <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName!}</span>
-                                </#if>
-                            </a>
-                        </li>
-                    </#list>
-                </ul>
-            </div>
-        </#if>
+        <@socialProviders.render/>
     </#if>
 
 </@layout.registrationLayout>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/register.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/register.ftl
@@ -9,7 +9,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 <#import "template.ftl" as layout>
 <#import "user-profile-commons.ftl" as userProfileCommons>
 <#import "register-commons.ftl" as registerCommons>
-<#include "intl-tel-input.ftl">
+<#import "field-helper-text.ftl" as fieldHelperText>
+<#import "tel-input-widget.ftl" as telInputWidget>
+<#import "select-filter-widget.ftl" as selectFilterWidget>
+<#import "social-providers.ftl" as socialProviders>
 <#assign loginMode = formMode?? && formMode == 'LOGIN'>
 <#assign passwordRequired = passwordRequired!false>
 <#assign structuredCredentialLogin = loginMode && passwordRequired && (realm.attributes['credential-input-policy']!'standard') == 'structured'>
@@ -27,18 +30,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
             <@userProfileCommons.userProfileFormFields; callback, attribute>
                 <#if callback = "afterField">
-                    <#if attribute.name == 'mobile'>
-                        <div class="${properties.kcFormGroupClass!}">
-                            <div class="${properties.kcLabelWrapperClass!}">
-                                <label for="mobile" class="${properties.kcLabelClass!}">${msg("mobileOtp.auth.enterMobileLabel")}</label>
-                            </div>
-                            <div class="${properties.kcInputWrapperClass!}">
-                                <@renderIntlTelInput id="mobile" name="mobile" value=attribute.value />
-                            </div>
-                        </div>
-                    <#else>
-                        <#-- render password fields just under the username or email (if used as username) -->
-                        <#if passwordRequired && (attribute.name == 'username' || (attribute.name == 'email' && realm.registrationEmailAsUsername)) && (attribute.annotations.showPasswordAfterThis!'true') != 'false' || (attribute.annotations.showPasswordAfterThis!'false') == 'true'>
+                    <#-- render password fields just under the username or email (if used as username) -->
+                    <#if passwordRequired && (attribute.name == 'username' || (attribute.name == 'email' && realm.registrationEmailAsUsername)) && (attribute.annotations.showPasswordAfterThis!'true') != 'false' || (attribute.annotations.showPasswordAfterThis!'false') == 'true'>
                             <div class="${properties.kcFormGroupClass!}">
                                 <div class="${properties.kcLabelWrapperClass!}">
                                     <label id="structured-credential-label" for="password" class="${properties.kcLabelClass!}"><#if structuredCredentialLogin>${msg("structuredCredentialLabel")}<#else>${msg("password")}</#if></label> *
@@ -46,7 +39,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                                 <div class="${properties.kcInputWrapperClass!}">
                                     <#--  You can add a custom passwordHelperTextBefore to either username or email depending on realm.registrationEmailAsUsername settings to add a helpertext -->
                                     <#if attribute.annotations.passwordHelperTextBefore??>
-                                        <div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.passwordHelperTextBefore))?no_esc}</div>
+                                        <@fieldHelperText.helperTextBefore id=attribute.name text=attribute.annotations.passwordHelperTextBefore/>
                                     </#if>
 
                                     <div class="${properties.kcInputGroup!}"<#if structuredCredentialLogin>
@@ -97,7 +90,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
                                     <#--  You can add a custom passwordHelperTextAfter to either username or email depending on realm.registrationEmailAsUsername settings to add a helpertext -->
                                     <#if attribute.annotations.passwordHelperTextAfter??>
-                                        <div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${attribute.name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.passwordHelperTextAfter))?no_esc}</div>
+                                        <@fieldHelperText.helperTextAfter id=attribute.name text=attribute.annotations.passwordHelperTextAfter/>
                                     </#if>
                                 </div>
                             </div>
@@ -131,7 +124,6 @@ SPDX-License-Identifier: AGPL-3.0-only
                                 </div>
                             </#if>
                         </#if>
-                    </#if>
                 </#if>
             </@userProfileCommons.userProfileFormFields>
 
@@ -170,101 +162,14 @@ SPDX-License-Identifier: AGPL-3.0-only
             <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
         </#if>
 
-        <#--  Adding intel-tel-input  -->
-        <#--  https://github.com/jackocnr/intl-tel-input/tree/master  -->
-
-        <link rel="stylesheet" href="${url.resourcesPath}/intl-tel-input-23.3.2/css/intlTelInput.css">
-        <link rel="stylesheet" href="${url.resourcesPath}/intl-tel-input-23.3.2/css/customized.css">
-        <script type="text/javascript" src="${url.resourcesPath}/intl-tel-input-23.3.2/js/intlTelInput.min.js"></script>
-
-        <#--  Timezone country code data  -->
-        <script type="text/javascript" src="${url.resourcesPath}/js/timezone-countrycode-data.js"></script>
-
-        <#-- jQuery -->
-        <script type="text/javascript" src="${url.resourcesPath}/js/jquery-3.7.1.slim.min.js"></script>
-
-        <script>
-            // Get all inputs that use type tel
-            const listTelInputs = document.querySelectorAll("input[type='tel']");
-            listTelInputs.forEach(function (input) {
-                // Change id and name to use the correctly formatted phone number in the form
-                let id = input.id;
-                input.id = id + "-input";
-                input.name = id + "-input";
-
-                // Use intel-tel-input
-                window.intlTelInput(input, {
-                    utilsScript: "${url.resourcesPath}/intl-tel-input-23.3.2/js/utils.js",
-                    initialCountry: "auto",
-                    separateDialCode: true,
-					customPlaceholder: function(selectedCountryPlaceholder, selectedCountryData) {
-						return selectedCountryPlaceholder.replace(/\d/g, '0');
-					},
-                    hiddenInput: () => ({ phone: id, country: "country_code" }),
-                    geoIpLookup: function(success, failure) {
-                        const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-                        let timezoneCountrycodeData = JSON.parse(data);
-                        let countryCode = timezoneCountrycodeData[userTimeZone].toString();
-
-                        if (countryCode) {
-                            return success(countryCode);
-                        }
-                        return failure();
-                    },
-                });
-            });
-        </script>
-
-        <#-- Filter for select inputs -->
-        <script>
-            function filterSelectAttribute(e, elementId) {
-                e = e || window.event;
-                var selectElement = e.target;
-                var value = selectElement.value;
-
-                let first = null;
-                $('#' + elementId + ' option').hide();
-                $('#' + elementId).find('option').filter(function() {
-                    var optionValue = $(this)[0].value;
-                    let found = optionValue.indexOf(value) != -1;
-                    if (found && first === null) {
-                        first = optionValue;
-                    }
-                    return found;
-                }).show();
-                
-                // Set default value
-                $('#' + elementId).val(first);
-            }
-        </script>
+        <@telInputWidget.assets/>
+        <@selectFilterWidget.assets/>
 
         <#--  Password strength  -->
         <#--  https://github.com/dropbox/zxcvbn  -->
         <script type="text/javascript" src="${url.resourcesPath}/js/zxcvbn.js"></script>
         <script type="text/javascript" src="${url.resourcesPath}/js/keycloak-password-strength.js"></script>
     <#elseif section = "socialProviders" >
-        <#assign visibleProviders = social.providers?filter(p -> p.alias != 'digital-certificates' || (realm.attributes['voter-certificate-policy']!'disabled') == 'enabled')>
-        <#if realm.password && visibleProviders?has_content>
-            <hr/>
-            <h4 style="text-align: center;">${msg("identity-provider-login-label")}</h4>
-            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
-                <#list visibleProviders as p>
-                    <ul class="${properties.kcFormSocialAccountListClass!} <#if visibleProviders?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
-                        <li>
-                            <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if visibleProviders?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
-                                    type="button" href="${p.loginUrl}">
-                                <#if p.iconClasses?has_content>
-                                    <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
-                                    <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text"><#if p.alias == 'digital-certificates'>${msg("digitalCertificateButton")}<#else>${msg(p.displayName)!}</#if></span>
-                                <#else>
-                                    <span class="${properties.kcFormSocialAccountNameClass!}"><#if p.alias == 'digital-certificates'>${msg("digitalCertificateButton")}<#else>${msg(p.displayName)!}</#if></span>
-                                </#if>
-                            </a>
-                        </li>
-                    </ul>
-                </#list>
-            </div>
-        </#if>
+        <@socialProviders.render/>
     </#if>
 </@layout.registrationLayout>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/select-filter-widget.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/select-filter-widget.ftl
@@ -1,0 +1,39 @@
+<#--
+ SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<#--  jQuery + the filterSelectAttribute() function user-profile-commons.ftl's selectTag macro
+      wires up via an attribute's filterSelectAttribute annotation (onchange="filterSelectAttribute(...)").
+      Shared by register.ftl and login.ftl - any select-typed attribute rendered through
+      user-profile-commons.ftl's macros (including a matchAttributes entry) needs this loaded,
+      not just ones reached via register.ftl's own top-level userProfileFormFields call.  -->
+
+<#macro assets>
+    <#-- jQuery -->
+    <script type="text/javascript" src="${url.resourcesPath}/js/jquery-3.7.1.slim.min.js"></script>
+
+    <#-- Filter for select inputs -->
+    <script>
+        function filterSelectAttribute(e, elementId) {
+            e = e || window.event;
+            var selectElement = e.target;
+            var value = selectElement.value;
+
+            let first = null;
+            $('#' + elementId + ' option').hide();
+            $('#' + elementId).find('option').filter(function() {
+                var optionValue = $(this)[0].value;
+                let found = optionValue.indexOf(value) != -1;
+                if (found && first === null) {
+                    first = optionValue;
+                }
+                return found;
+            }).show();
+
+            // Set default value
+            $('#' + elementId).val(first);
+        }
+    </script>
+</#macro>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/social-providers.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/social-providers.ftl
@@ -1,0 +1,34 @@
+<#--
+ SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<#--  Renders the "socialProviders" section, filtering out the digital-certificates IdP unless the
+      realm has opted in via voter-certificate-policy=enabled. Shared by register.ftl and both
+      portals' login.ftl.  -->
+
+<#macro render>
+    <#assign visibleProviders = social.providers?filter(p -> p.alias != 'digital-certificates' || (realm.attributes['voter-certificate-policy']!'disabled') == 'enabled')>
+    <#if realm.password && visibleProviders?has_content>
+        <hr/>
+        <h4 style="text-align: center;">${msg("identity-provider-login-label")}</h4>
+        <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
+            <#list visibleProviders as p>
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if visibleProviders?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
+                    <li>
+                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if visibleProviders?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
+                                type="button" href="${p.loginUrl}">
+                            <#if p.iconClasses?has_content>
+                                <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
+                                <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text"><#if p.alias == 'digital-certificates'>${msg("digitalCertificateButton")}<#else>${msg(p.displayName)!}</#if></span>
+                            <#else>
+                                <span class="${properties.kcFormSocialAccountNameClass!}"><#if p.alias == 'digital-certificates'>${msg("digitalCertificateButton")}<#else>${msg(p.displayName)!}</#if></span>
+                            </#if>
+                        </a>
+                    </li>
+                </ul>
+            </#list>
+        </div>
+    </#if>
+</#macro>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/tel-input-widget.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/tel-input-widget.ftl
@@ -1,0 +1,53 @@
+<#--
+ SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<#--  Upgrades every plain `input[type='tel']` on the page (however it was rendered - a User
+      Profile attribute with an `html5-tel` inputType, via user-profile-commons.ftl, is the
+      common case) into an intl-tel-input widget. Shared by register.ftl and login.ftl so both
+      get the same phone-number UI for any tel-typed attribute, not just a hardcoded field name.
+      https://github.com/jackocnr/intl-tel-input/tree/master  -->
+
+<#macro assets>
+    <link rel="stylesheet" href="${url.resourcesPath}/intl-tel-input-23.3.2/css/intlTelInput.css">
+    <link rel="stylesheet" href="${url.resourcesPath}/intl-tel-input-23.3.2/css/customized.css">
+    <script type="text/javascript" src="${url.resourcesPath}/intl-tel-input-23.3.2/js/intlTelInput.min.js"></script>
+
+    <#--  Timezone country code data  -->
+    <script type="text/javascript" src="${url.resourcesPath}/js/timezone-countrycode-data.js"></script>
+
+    <script>
+        // Get all inputs that use type tel
+        const listTelInputs = document.querySelectorAll("input[type='tel']");
+        listTelInputs.forEach(function (input) {
+            // Change id and name to use the correctly formatted phone number in the form
+            let id = input.id;
+            input.id = id + "-input";
+            input.name = id + "-input";
+
+            // Use intel-tel-input
+            window.intlTelInput(input, {
+                utilsScript: "${url.resourcesPath}/intl-tel-input-23.3.2/js/utils.js",
+                initialCountry: "auto",
+                separateDialCode: true,
+                customPlaceholder: function(selectedCountryPlaceholder, selectedCountryData) {
+                    return selectedCountryPlaceholder.replace(/\d/g, '0');
+                },
+                hiddenInput: () => ({ phone: id, country: "country_code" }),
+                geoIpLookup: function(success, failure) {
+                    const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+                    let timezoneCountrycodeData = JSON.parse(data);
+                    let countryCode = timezoneCountrycodeData[userTimeZone].toString();
+
+                    if (countryCode) {
+                        return success(countryCode);
+                    }
+                    return failure();
+                },
+            });
+        });
+    </script>
+</#macro>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/user-profile-commons.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/user-profile-commons.ftl
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <#--  Source: https://github.com/keycloak/keycloak/blob/24.0.0/themes/src/main/resources/theme/base/login/user-profile-commons.ftl  -->
 
+<#import "field-helper-text.ftl" as fieldHelperText>
+
 <#--  True when the attribute was prefilled from a login hint annotated as READ_ONLY,
       in which case the voter must not be able to change the submitted value.  -->
 <#function isLoginHintReadOnly attributeName>
@@ -132,7 +134,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 	</#list>
 </#macro>
 
-<#macro inputFieldWithLabel attribute name values>
+<#--  requiredMarker controls the "*" label only; required controls the actual HTML5 required
+      attribute (see inputTag). They default to the same, always-on value register.ftl has always
+      used (attribute.required, unconditionally) so its rendering is unaffected. login.ftl passes
+      both explicitly, gated by honorUserProfileRequired, so the asterisk and the real enforcement
+      never disagree there - see login.ftl's matchAttributes loop.  -->
+<#macro inputFieldWithLabel attribute name values required=false requiredMarker=attribute.required>
 	<div class="${properties.kcFormGroupClass!}">
 		<div class="${properties.kcLabelWrapperClass!}">
 			<label for="${name}" class="${properties.kcLabelClass!}">
@@ -142,26 +149,26 @@ SPDX-License-Identifier: AGPL-3.0-only
 					${advancedMsg(attribute.displayName!'')}
 				</#if>
 			</label>
-			<#if attribute.required>*</#if>
+			<#if requiredMarker>*</#if>
 		</div>
 		<div class="${properties.kcInputWrapperClass!}">
 			<#if attribute.annotations.inputHelperTextBefore??>
-				<div class="${properties.kcInputHelperTextBeforeClass!}" id="form-help-text-before-${name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextBefore))?no_esc}</div>
+				<@fieldHelperText.helperTextBefore id=name text=attribute.annotations.inputHelperTextBefore/>
 			</#if>
-			<@inputFieldByType attribute=attribute name=name values=values/>
+			<@inputFieldByType attribute=attribute name=name values=values required=required/>
 			<#if messagesPerField.existsError('${name}')>
 				<span id="input-error-${name}" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
 					${kcSanitize(messagesPerField.get('${name}'))?no_esc}
 				</span>
 			</#if>
 			<#if attribute.annotations.inputHelperTextAfter??>
-				<div class="${properties.kcInputHelperTextAfterClass!}" id="form-help-text-after-${name}" aria-live="polite">${kcSanitize(advancedMsg(attribute.annotations.inputHelperTextAfter))?no_esc}</div>
+				<@fieldHelperText.helperTextAfter id=name text=attribute.annotations.inputHelperTextAfter/>
 			</#if>
 		</div>
 	</div>
 </#macro>
 
-<#macro inputFieldByType attribute name values>
+<#macro inputFieldByType attribute name values required=false>
 	<#switch attribute.annotations.inputType!''>
 	<#case 'textarea'>
 		<@textareaTag attribute=attribute name=name values=values/>
@@ -177,17 +184,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 	<#default>
 		<#if attribute.multivalued && values?has_content>
 			<#list values as value>
-				<@inputTag attribute=attribute name=name value=value!''/>
+				<@inputTag attribute=attribute name=name value=value!'' required=required/>
 			</#list>
 		<#else>
-			<@inputTag attribute=attribute name=name value=attribute.value!''/>
+			<@inputTag attribute=attribute name=name value=attribute.value!'' required=required/>
 		</#if>
 	</#switch>
 </#macro>
 
-<#macro inputTag attribute name value>
+<#macro inputTag attribute name value required=false>
 	<input type="<@inputTagType attribute=attribute/>" id="${name}" name="${name}" value="${(value!'')}" class="${properties.kcInputClass!}"
 		aria-invalid="<#if messagesPerField.existsError('${name}')>true</#if>"
+		<#if required>required</#if>
 		<#if attribute.readOnly>disabled</#if>
 		<#-- readonly rather than disabled so the locked value is still submitted -->
 		<#if isLoginHintReadOnly(attribute.name)>readonly</#if>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.voting-portal/login/login.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.voting-portal/login/login.ftl
@@ -5,10 +5,15 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <#import "template.ftl" as layout>
+<#import "user-profile-commons.ftl" as userProfileCommons>
+<#import "tel-input-widget.ftl" as telInputWidget>
+<#import "select-filter-widget.ftl" as selectFilterWidget>
+<#import "social-providers.ftl" as socialProviders>
 <#assign structuredCredential = (realm.attributes['credential-input-policy']!'standard') == 'structured'>
 <#assign credentialFieldError = messagesPerField.existsError('username','password')>
 <#assign structuredCredentialHasError = structuredCredential && credentialFieldError>
-<@layout.registrationLayout displayMessage=!credentialFieldError displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled?? displaySocialProviders=social.providers?has_content; section>
+<#assign matchAttributesHaveRequired = honorUserProfileRequired?? && matchAttributes?? && matchAttributes?filter(name -> profile.attributesByName[name]?? && profile.attributesByName[name].required)?has_content>
+<@layout.registrationLayout displayMessage=!credentialFieldError displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled?? displayRequiredFields=matchAttributesHaveRequired displaySocialProviders=social.providers?has_content; section>
     <#if section = "header">
         ${msg("loginAccountTitle")}
     <#elseif section = "form">
@@ -23,26 +28,25 @@ SPDX-License-Identifier: AGPL-3.0-only
           <div id="kc-form-wrapper">
             <#if realm.password>
                 <form id="kc-form-login" <#if !structuredCredential>onsubmit="login.disabled = true; return true;"</#if> action="${url.loginAction}" method="post">
-                    <#-- Number of fields rendered ahead of the password field -->
-                    <#assign fieldCount = (matchAttributes?? && matchAttributes?has_content)?then(matchAttributes?size, 1)>
                     <#if !usernameHidden??>
                         <#if matchAttributes?? && matchAttributes?has_content>
-                            <#if matchAttributes?filter(f -> f.type == "tel")?has_content>
-                                <#include "intl-tel-input.ftl">
-                            </#if>
-                            <#list matchAttributes as field>
-                                <div class="${properties.kcFormGroupClass!}">
-                                    <label for="${field.name}" class="${properties.kcLabelClass!}">${msg(field.name)}</label>
+                            <@telInputWidget.assets/>
+                            <@selectFilterWidget.assets/>
 
-                                    <#if field.type == "tel">
-                                        <@renderIntlTelInput id=field.name name=field.name autofocus=(field?index == 0)/>
-                                    <#else>
-                                        <input tabindex="${field?index + 1}" id="${field.name}" class="${properties.kcInputClass!}" name="${field.name}" type="${field.type!'text'}"
-                                               <#if field?index == 0>autofocus</#if> autocomplete="off"
+                            <#list matchAttributes as name>
+                                <#if profile.attributesByName[name]??>
+                                    <#assign matchAttribute = profile.attributesByName[name]>
+                                    <#assign matchAttributeRequired = honorUserProfileRequired?? && matchAttribute.required>
+                                    <@userProfileCommons.inputFieldWithLabel attribute=matchAttribute name=name values=matchAttribute.values required=matchAttributeRequired requiredMarker=matchAttributeRequired/>
+                                <#else>
+                                    <#-- Not declared in the realm's User Profile - still usable for matching, rendered as a plain text field -->
+                                    <div class="${properties.kcFormGroupClass!}">
+                                        <label for="${name}" class="${properties.kcLabelClass!}">${msg(name)}</label>
+                                        <input id="${name}" class="${properties.kcInputClass!}" name="${name}" type="text" autocomplete="off"
                                                <#if credentialFieldError>aria-invalid="true"</#if>
                                         />
-                                    </#if>
-                                </div>
+                                    </div>
+                                </#if>
                             </#list>
 
                             <#if credentialFieldError && !structuredCredential>
@@ -55,7 +59,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                                 <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
 
                                 <#-- readonly rather than disabled so the locked value is still submitted -->
-                                <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" autofocus autocomplete="<#if structuredCredential>username<#else>off</#if>"
+                                <input id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" autofocus autocomplete="<#if structuredCredential>username<#else>off</#if>"
                                        <#if usernameReadOnly>readonly</#if>
                                        <#if credentialFieldError>aria-invalid="true"</#if>
                                 />
@@ -82,14 +86,14 @@ SPDX-License-Identifier: AGPL-3.0-only
                              data-label-id="structured-credential-label"
                              data-hint-id="structured-credential-hint"
                              data-error-id="structured-credential-error"</#if>>
-                            <input tabindex="${fieldCount + 2}" id="password" class="${properties.kcInputClass!}" name="password" type="password"
+                            <input id="password" class="${properties.kcInputClass!}" name="password" type="password"
                                    autocomplete="<#if structuredCredential>current-password<#else>off</#if>"
                                    <#if structuredCredential>inputmode="numeric"</#if>
                                    <#if structuredCredential>aria-describedby="structured-credential-hint structured-credential-error"</#if>
                                    <#if structuredCredentialHasError || credentialFieldError>aria-invalid="true"</#if>
                             />
                             <button class="${properties.kcFormPasswordVisibilityButtonClass!}" type="button" aria-label="<#if structuredCredential>${msg('showStructuredCredential')}<#else>${msg('showPassword')}</#if>"
-                                    aria-controls="password" <#if structuredCredential>data-structured-credential-toggle<#else>data-password-toggle</#if> tabindex="${fieldCount + 3}"
+                                    aria-controls="password" <#if structuredCredential>data-structured-credential-toggle<#else>data-password-toggle</#if>
                                     data-icon-show="${properties.kcFormPasswordVisibilityIconShow!}" data-icon-hide="${properties.kcFormPasswordVisibilityIconHide!}"
                                     data-label-show="<#if structuredCredential>${msg('showStructuredCredential')}<#else>${msg('showPassword')}</#if>"
                                     data-label-hide="<#if structuredCredential>${msg('hideStructuredCredential')}<#else>${msg('hidePassword')}</#if>">
@@ -116,9 +120,9 @@ SPDX-License-Identifier: AGPL-3.0-only
                                 <div class="checkbox">
                                     <label>
                                         <#if login.rememberMe??>
-                                            <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
+                                            <input id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
                                         <#else>
-                                            <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
+                                            <input id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
                                         </#if>
                                     </label>
                                 </div>
@@ -126,7 +130,7 @@ SPDX-License-Identifier: AGPL-3.0-only
                             </div>
                             <div class="${properties.kcFormOptionsWrapperClass!}">
                                 <#if realm.resetPasswordAllowed>
-                                    <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                                    <span><a href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
                                 </#if>
                             </div>
 
@@ -157,7 +161,6 @@ SPDX-License-Identifier: AGPL-3.0-only
                       <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                           <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
                           <input
-                            tabindex="4"
                             class="g-recaptcha ${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
                             name="login"
                             id="kc-login"
@@ -178,34 +181,12 @@ SPDX-License-Identifier: AGPL-3.0-only
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
             <div id="kc-registration-container">
                 <div id="kc-registration">
-                    <span>${msg("noAccount")} <a tabindex="6"
-                                                 href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+                    <span>${msg("noAccount")} <a href="${url.registrationUrl}">${msg("doRegister")}</a></span>
                 </div>
             </div>
         </#if>
     <#elseif section = "socialProviders" >
-        <#assign visibleProviders = social.providers?filter(p -> p.alias != 'digital-certificates' || (realm.attributes['voter-certificate-policy']!'disabled') == 'enabled')>
-        <#if realm.password && visibleProviders?has_content>
-            <hr/>
-            <h4 style="text-align: center;">${msg("identity-provider-login-label")}</h4>
-            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
-                <#list visibleProviders as p>
-                    <ul class="${properties.kcFormSocialAccountListClass!} <#if visibleProviders?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
-                        <li>
-                            <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if visibleProviders?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
-                                    type="button" href="${p.loginUrl}">
-                                <#if p.iconClasses?has_content>
-                                    <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
-                                    <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text"><#if p.alias == 'digital-certificates'>${msg("digitalCertificateButton")}<#else>${msg(p.displayName)!}</#if></span>
-                                <#else>
-                                    <span class="${properties.kcFormSocialAccountNameClass!}"><#if p.alias == 'digital-certificates'>${msg("digitalCertificateButton")}<#else>${msg(p.displayName)!}</#if></span>
-                                </#if>
-                            </a>
-                        </li>
-                    </ul>
-                </#list>
-            </div>
-        </#if>
+        <@socialProviders.render/>
     </#if>
 
 </@layout.registrationLayout>

--- a/packages/keycloak-extensions/sequent-theme/src/test/java/sequent/keycloak/theme/RegisterTemplateTest.java
+++ b/packages/keycloak-extensions/sequent-theme/src/test/java/sequent/keycloak/theme/RegisterTemplateTest.java
@@ -17,6 +17,9 @@ class RegisterTemplateTest {
   private static final Path REGISTER_TEMPLATE =
       Path.of("src/main/resources/theme/sequent.admin-portal/login/register.ftl");
 
+  private static final Path SOCIAL_PROVIDERS_TEMPLATE =
+      Path.of("src/main/resources/theme/sequent.admin-portal/login/social-providers.ftl");
+
   @Test
   void deferredLoginModeEnablesSocialProviders() throws IOException {
     String template = Files.readString(REGISTER_TEMPLATE);
@@ -25,10 +28,22 @@ class RegisterTemplateTest {
         template.contains(
             "displaySocialProviders=(formMode?? && formMode = 'LOGIN' && (social.providers)?has_content)"));
     assertTrue(template.contains("<#elseif section = \"socialProviders\" >"));
+    assertTrue(template.contains("<@socialProviders.render/>"));
+  }
+
+  @Test
+  void socialProvidersMacroRendersProviderList() throws IOException {
+    // Shared with sequent.voting-portal/login/login.ftl - see social-providers.ftl's own header
+    // comment. Content assertions live here rather than duplicated per caller.
+    String template = Files.readString(SOCIAL_PROVIDERS_TEMPLATE);
+
     assertTrue(template.contains("id=\"kc-social-providers\""));
     assertTrue(template.contains("msg(\"identity-provider-login-label\")"));
     assertTrue(template.contains("href=\"${p.loginUrl}\""));
     assertTrue(template.contains("${msg(p.displayName)!}"));
+    assertTrue(
+        template.contains(
+            "p.alias != 'digital-certificates' || (realm.attributes['voter-certificate-policy']!'disabled') == 'enabled'"));
   }
 
   @Test

--- a/packages/keycloak-extensions/sequent-theme/src/test/java/sequent/keycloak/theme/TemplateSyntaxTest.java
+++ b/packages/keycloak-extensions/sequent-theme/src/test/java/sequent/keycloak/theme/TemplateSyntaxTest.java
@@ -63,25 +63,193 @@ class TemplateSyntaxTest {
   }
 
   @Test
+  void socialProvidersFilterDigitalCertificatesUnlessRealmOptsIn()
+      throws IOException, TemplateException {
+    List<Map<String, Object>> providers =
+        List.of(
+            Map.of(
+                "alias", "google",
+                "loginUrl", "/broker/google",
+                "iconClasses", "",
+                "displayName", "Google"),
+            Map.of(
+                "alias", "digital-certificates",
+                "loginUrl", "/broker/digital-certificates",
+                "iconClasses", "",
+                "displayName", "Digital Certificate"));
+
+    Map<String, Object> disabledModel = baseModel("standard");
+    disabledModel.put("social", Map.of("providers", providers));
+    String disabledHtml = renderVotingPortalLogin(disabledModel);
+
+    assertTrue(disabledHtml.contains("id=\"social-google\""));
+    assertFalse(disabledHtml.contains("id=\"social-digital-certificates\""));
+
+    Map<String, Object> enabledModel = baseModel("standard");
+    enabledModel.put("social", Map.of("providers", providers));
+    enabledModel.put(
+        "realm",
+        Map.ofEntries(
+            Map.entry(
+                "attributes",
+                Map.of(
+                    "credential-input-policy", "standard",
+                    "credential-input-pattern", "dddd-dddd-dddd-dddd",
+                    "voter-certificate-policy", "enabled")),
+            Map.entry("password", true),
+            Map.entry("registrationAllowed", false),
+            Map.entry("loginWithEmailAllowed", false),
+            Map.entry("registrationEmailAsUsername", false),
+            Map.entry("rememberMe", false),
+            Map.entry("resetPasswordAllowed", false),
+            Map.entry("internationalizationEnabled", false),
+            Map.entry("displayName", "Realm"),
+            Map.entry("defaultLocale", "en")));
+    String enabledHtml = renderVotingPortalLogin(enabledModel);
+
+    assertTrue(enabledHtml.contains("id=\"social-google\""));
+    assertTrue(enabledHtml.contains("id=\"social-digital-certificates\""));
+  }
+
+  @Test
   void multiAttributeLoginSupportsStructuredCredentialToggle()
       throws IOException, TemplateException {
     Map<String, Object> structuredModel = baseModel("structured");
-    structuredModel.put("matchAttributes", List.of(Map.of("name", "dateOfBirth", "type", "date")));
+    structuredModel.put("matchAttributes", List.of("dateOfBirth"));
+    structuredModel.put(
+        "profile",
+        profileWithAttributes(
+            mockAttribute("dateOfBirth", "${dateOfBirth}", Map.of("inputType", "html5-date"))));
     String structuredHtml = renderVotingPortalLogin(structuredModel);
 
-    assertTrue(structuredHtml.contains("name=\"dateOfBirth\" type=\"date\""));
+    assertTrue(structuredHtml.contains("type=\"date\" id=\"dateOfBirth\" name=\"dateOfBirth\""));
     assertTrue(structuredHtml.contains("data-structured-credential"));
     assertTrue(structuredHtml.contains("src=\"/resources/js/structured-credential.js\""));
     assertFalse(structuredHtml.contains("src=\"/resources/js/passwordVisibility.js\""));
 
     Map<String, Object> standardModel = baseModel("standard");
-    standardModel.put("matchAttributes", List.of(Map.of("name", "dateOfBirth", "type", "date")));
+    standardModel.put("matchAttributes", List.of("dateOfBirth"));
+    standardModel.put(
+        "profile",
+        profileWithAttributes(
+            mockAttribute("dateOfBirth", "${dateOfBirth}", Map.of("inputType", "html5-date"))));
     String standardHtml = renderVotingPortalLogin(standardModel);
 
-    assertTrue(standardHtml.contains("name=\"dateOfBirth\" type=\"date\""));
+    assertTrue(standardHtml.contains("type=\"date\" id=\"dateOfBirth\" name=\"dateOfBirth\""));
     assertFalse(standardHtml.contains("data-structured-credential"));
     assertTrue(standardHtml.contains("src=\"/resources/js/passwordVisibility.js\""));
     assertFalse(standardHtml.contains("src=\"/resources/js/structured-credential.js\""));
+  }
+
+  @Test
+  void multiAttributeLoginRendersConfiguredHelperText() throws IOException, TemplateException {
+    Map<String, Object> model = baseModel("standard");
+    model.put("matchAttributes", List.of("dateOfBirth"));
+    model.put(
+        "profile",
+        profileWithAttributes(
+            mockAttribute(
+                "dateOfBirth",
+                "${dateOfBirth}",
+                Map.of(
+                    "inputType", "html5-date",
+                    "inputHelperTextBefore", "Enter as printed on your ID",
+                    "inputHelperTextAfter", "Format: DD/MM/YYYY"))));
+    String html = renderVotingPortalLogin(model);
+
+    assertTrue(
+        html.contains(
+            "id=\"form-help-text-before-dateOfBirth\" aria-live=\"polite\">Enter as printed on your"
+                + " ID</div>"));
+    assertTrue(
+        html.contains(
+            "id=\"form-help-text-after-dateOfBirth\" aria-live=\"polite\">Format: DD/MM/YYYY</div>"));
+  }
+
+  @Test
+  void multiAttributeLoginOmitsHelperTextWhenNotConfigured() throws IOException, TemplateException {
+    Map<String, Object> model = baseModel("standard");
+    model.put("matchAttributes", List.of("dateOfBirth"));
+    model.put(
+        "profile",
+        profileWithAttributes(
+            mockAttribute("dateOfBirth", "${dateOfBirth}", Map.of("inputType", "html5-date"))));
+    String html = renderVotingPortalLogin(model);
+
+    assertFalse(html.contains("form-help-text-before-dateOfBirth"));
+    assertFalse(html.contains("form-help-text-after-dateOfBirth"));
+  }
+
+  @Test
+  void multiAttributeLoginFallsBackToPlainTextFieldWhenNotInUserProfile()
+      throws IOException, TemplateException {
+    Map<String, Object> model = baseModel("standard");
+    model.put("matchAttributes", List.of("nationalId"));
+    model.put("profile", profileWithAttributes());
+    String html = renderVotingPortalLogin(model);
+
+    assertTrue(html.contains("id=\"nationalId\""));
+    assertTrue(html.contains("name=\"nationalId\""));
+    assertTrue(html.contains("type=\"text\""));
+  }
+
+  @Test
+  void multiAttributeLoginMarksRequiredAttributeWhenEnabled()
+      throws IOException, TemplateException {
+    Map<String, Object> model = baseModel("standard");
+    model.put("matchAttributes", List.of("dateOfBirth"));
+    model.put("honorUserProfileRequired", true);
+    model.put(
+        "profile",
+        profileWithAttributes(
+            mockAttribute(
+                "dateOfBirth", "${dateOfBirth}", Map.of("inputType", "html5-date"), true)));
+    String html = renderVotingPortalLogin(model);
+    String normalized = html.replaceAll("\\s+", " ");
+
+    assertTrue(normalized.contains("aria-invalid=\"\" required"));
+    assertTrue(html.contains("requiredFields"));
+    assertTrue(normalized.contains("</label> *"));
+  }
+
+  @Test
+  void multiAttributeLoginOmitsRequiredMarkingWhenNotEnabled()
+      throws IOException, TemplateException {
+    // dateOfBirth is required=true in the realm's User Profile, but honorUserProfileRequired is
+    // not set - neither the HTML5 required attribute nor the "*" marker should appear, since
+    // matching-mandatoriness here comes entirely from matchAttributes, not User Profile.
+    Map<String, Object> model = baseModel("standard");
+    model.put("matchAttributes", List.of("dateOfBirth"));
+    model.put(
+        "profile",
+        profileWithAttributes(
+            mockAttribute(
+                "dateOfBirth", "${dateOfBirth}", Map.of("inputType", "html5-date"), true)));
+    String html = renderVotingPortalLogin(model);
+    String normalized = html.replaceAll("\\s+", " ");
+
+    assertFalse(normalized.contains("aria-invalid=\"\" required"));
+    assertFalse(html.contains("requiredFields"));
+    assertFalse(normalized.contains("</label> *"));
+  }
+
+  @Test
+  void multiAttributeLoginDoesNotMarkNonRequiredAttributeEvenWhenEnabled()
+      throws IOException, TemplateException {
+    Map<String, Object> model = baseModel("standard");
+    model.put("matchAttributes", List.of("dateOfBirth"));
+    model.put("honorUserProfileRequired", true);
+    model.put(
+        "profile",
+        profileWithAttributes(
+            mockAttribute(
+                "dateOfBirth", "${dateOfBirth}", Map.of("inputType", "html5-date"), false)));
+    String html = renderVotingPortalLogin(model);
+    String normalized = html.replaceAll("\\s+", " ");
+
+    assertFalse(normalized.contains("aria-invalid=\"\" required"));
+    assertFalse(html.contains("requiredFields"));
+    assertFalse(normalized.contains("</label> *"));
   }
 
   @Test
@@ -89,7 +257,6 @@ class TemplateSyntaxTest {
       throws IOException, TemplateException {
     Path parent = THEME_ROOT.resolve("sequent.admin-portal/login");
     StringTemplateLoader baseThemeStubs = new StringTemplateLoader();
-    baseThemeStubs.putTemplate("intl-tel-input.ftl", "");
     baseThemeStubs.putTemplate("register-commons.ftl", "<#macro termsAcceptance></#macro>");
     Configuration configuration = configuration();
     configuration.setTemplateLoader(
@@ -150,6 +317,39 @@ class TemplateSyntaxTest {
     StringWriter rendered = new StringWriter();
     configuration.getTemplate("login.ftl").process(model, rendered);
     return rendered.toString();
+  }
+
+  /** Mimics {@code AbstractUserProfileBean}'s {@code attributesByName} shape - see LoginBean. */
+  private static Map<String, Object> profileWithAttributes(Map<String, Object>... attributes) {
+    Map<String, Object> attributesByName = new HashMap<>();
+    for (Map<String, Object> attribute : attributes) {
+      attributesByName.put((String) attribute.get("name"), attribute);
+    }
+    return Map.of("attributesByName", attributesByName);
+  }
+
+  /**
+   * Mimics one {@code AbstractUserProfileBean.Attribute} - the fields user-profile-commons.ftl
+   * reads.
+   */
+  private static Map<String, Object> mockAttribute(
+      String name, String displayName, Map<String, Object> annotations) {
+    return mockAttribute(name, displayName, annotations, false);
+  }
+
+  private static Map<String, Object> mockAttribute(
+      String name, String displayName, Map<String, Object> annotations, boolean required) {
+    Map<String, Object> attribute = new HashMap<>();
+    attribute.put("name", name);
+    attribute.put("displayName", displayName);
+    attribute.put("required", required);
+    attribute.put("readOnly", false);
+    attribute.put("multivalued", false);
+    attribute.put("value", "");
+    attribute.put("values", List.of());
+    attribute.put("annotations", annotations);
+    attribute.put("html5DataAnnotations", Map.of());
+    return attribute;
   }
 
   private static Configuration configuration() {


### PR DESCRIPTION
## Summary
- `MultiAttributePasswordAuthenticator`'s `login.ftl` fields now render through the same User Profile-driven macros `register.ftl` uses (a new `LoginBean`, mirroring Keycloak's own `RegisterBean`, exposes `profile.attributesByName`), instead of a bespoke `{name,type}` field list - closing the gap where `login.ftl` didn't show field-specific input types, helper text, select filtering, or the shared tel-input widget.
- Extracted the duplication this surfaced into shared macros under `sequent.admin-portal/login/`: `field-helper-text.ftl`, `tel-input-widget.ftl`, `select-filter-widget.ftl`, `social-providers.ftl` - now used by `register.ftl` and both `sequent.admin-portal`/`sequent.voting-portal` `login.ftl` copies.
- Removed a dead `mobile`-attribute special case in `register.ftl` (no realm ever configures a User Profile attribute literally named `mobile`).
- Added an opt-in `honorUserProfileRequired` config property on `MultiAttributePasswordAuthenticator`: when enabled, a `matchAttributes` field's required-ness (asterisk, HTML5 `required`, and whether it's optional for matching) follows the realm's User Profile `required` setting for that attribute, instead of every configured attribute being unconditionally mandatory. Disabled by default - no behavior change for existing realms.
- The optional-attribute filtering (`effectiveMatchAttributes`) lives entirely in the authenticator, so `MultiAttributeCredentialResolver` - shared with the IVR direct grant flow - is untouched.

## Test plan
- [x] `mvn -pl sequent-theme,message-otp-authenticator clean test` - 134 tests passing (including new coverage for `honorUserProfileRequired`'s required/optional matching and rendering, and the shared macros)
- [x] `mvn -pl sequent-theme,message-otp-authenticator spotless:check` - clean
- [ ] Manual: verify `login.ftl` renders correctly for both portals with a realm configuring `matchAttributes` (date/select/tel field types, helper text)
- [ ] Manual: enable `honorUserProfileRequired` on a test realm and confirm optional attributes can be left blank while still matching

Parent issue: https://github.com/sequentech/meta/issues/12713

🤖 Generated with [Claude Code](https://claude.com/claude-code)