### PR TITLE
✨ Voting Portal: Fix English translations (#2939)

### DIFF
--- a/packages/ui-core/src/translations/en.ts
+++ b/packages/ui-core/src/translations/en.ts
@@ -94,9 +94,9 @@ const englishTranslation = {
                 maxSelectionsPerType:
                     "Number of selected choices {{numSelected}} for list {{type}} is more than the maximum {{max}}",
                 underVote:
-                    "Undervote: Number of selected choices {{numSelected}} is less than the maximum {{max}}",
+                    "You have not used all {{max}} of your selections in this contest. You may continue, or go back to make another selection.",
                 overVoteDisabled:
-                    "Maximum reached: You have selected the maximum {{numSelected}} choices. To change your selection, please deselect another option first.",
+                    "Maximum reached: You have selected the maximum of {{numSelected}} allowed. To change your selection, please deselect an option first.",
                 blankVote: "Blank Vote: 0 choices selected",
                 preferenceOrderWithGaps:
                     "Invalid vote! The order of preference has one or more gaps.",

--- a/packages/voting-portal/src/translations/en.ts
+++ b/packages/voting-portal/src/translations/en.ts
@@ -34,7 +34,7 @@ const englishTranslation = {
             ballotHelpDialog: {
                 title: "About this screen",
                 content:
-                    "This screen shows the contest you are eligible to vote in. You can make your selection by activating the checkbox next to the candidate or answer. To reset your selections, click the “<b>Clear choices</b>” button. To move to the next step, click the “<b>Next</b>” button below.",
+                    "This screen shows the contests you are eligible to vote in. You can make your selection by activating the checkbox to the right of the Candidate/Answer. To reset your selections, click the “<b>Clear selection</b>” button; to move to the next step, click the “<b>Next</b>” button below.",
                 ok: "OK",
             },
             nonVotedDialog: {
@@ -275,7 +275,7 @@ const englishTranslation = {
             chooserHelpDialog: {
                 title: "About the Ballot list",
                 content:
-                    "This screen lists the ballots you can access. Some may be open, scheduled, or closed. You can only vote on ballots that are open",
+                    "Welcome to the Voting Booth. This screen shows the ballots you can vote on. Ballots displayed in this list can be open to voting, scheduled, or closed. You will be able to access the ballot only if the voting period is open.",
                 ok: "OK",
             },
             noResults: "No ballots for now.",
@@ -378,7 +378,7 @@ const englishTranslation = {
             titleHelpDialog: {
                 title: "About the Ballot Finder Screen",
                 content:
-                    "The Ballot Finder screen lets you enter your Ballot ID to locate your vote and confirm it was recorded correctly.",
+                    "This screen allows you to find your vote by using the Ballot ID to retrieve it. This procedure enables you to check that your ballot was correctly cast and that the recorded ballot matches the encrypted ballot you sent.",
                 ok: "OK",
             },
             tabs: {


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12743

Fixes six English voter-facing strings found during Ontario UAT (v10.0.0-rc.35). These are platform default translations, so the errors appear on every municipality.

| Ref | Package | Key | Fix |
| --- | --- | --- | --- |
| Q1 | voting-portal | `ballotHelpDialog.content` | `elegible`->eligible, `section`->selection, `by activate`->by activating, `eligible to vote`->eligible to vote in | | Q2 | voting-portal | `titleHelpDialog.content` | third person -> second person; `coincides with`->matches |
| Q6 | voting-portal | `electionSelectionScreen.description` | missing preposition `on` |
| Q7 | voting-portal | `chooserHelpDialog.content` | comma splice; sentence never completes |
| Q4 | ui-core | `validation.implicit.overVoteDisabled` | plural disagreement when max is 1 |
| Q5 | ui-core | `validation.implicit.underVote` | system message -> plain language |

Ballot screen help (Q1), ballot list heading and help (Q6, Q7), Ballot Locator help (Q2), Mayor contest second selection attempt (Q4), review screen with a contest left blank (Q5). Confirm Q1 and Q7 on a second municipality - they are shared strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified voting guidance for undervotes and overvotes, including how to continue, return, deselect options, and follow selection limits.
  * Improved help-dialog instructions for ballot selection and eligibility.
  * Added information explaining that Ballot Finder verifies the recorded ballot against the submitted encrypted ballot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->