### PR TITLE
✨ Voting Portal: Fix English translations (#2939)

### DIFF
--- a/packages/voting-portal/src/translations/en.ts
+++ b/packages/voting-portal/src/translations/en.ts
@@ -20,7 +20,7 @@ const englishTranslation = {
             ballotHelpDialog: {
                 title: "Information: Ballot screen",
                 content:
-                    "This screen shows the contest you are elegible to vote. You can make your section by activate the checkbox on the Candidate/Answer right. To reset your selections, click “<b>Clear selection</b>” button, to move to next step, click “<b>Next</b>” button below.",
+                    "This screen shows the contests you are eligible to vote in. You can make your selection by activating the checkbox to the right of the Candidate/Answer. To reset your selections, click the “<b>Clear selection</b>” button; to move to the next step, click the “<b>Next</b>” button below.",
                 ok: "OK",
             },
             nonVotedDialog: {
@@ -250,11 +250,11 @@ const englishTranslation = {
         },
         electionSelectionScreen: {
             title: "Ballot list",
-            description: "Select the Ballot you want to vote",
+            description: "Select the ballot you want to vote on",
             chooserHelpDialog: {
                 title: "Information: Ballot List",
                 content:
-                    "Welcome to the Voting Booth, this screen shows the list of Ballots you can cast a ballot. Ballots displayed in this list can be open to voting, scheduled, or closed. You will be able to access the ballot only if the voting period is open.",
+                    "Welcome to the Voting Booth. This screen shows the ballots you can vote on. Ballots displayed in this list can be open to voting, scheduled, or closed. You will be able to access the ballot only if the voting period is open.",
                 ok: "OK",
             },
             noResults: "No ballots for now.",
@@ -344,7 +344,7 @@ const englishTranslation = {
             titleHelpDialog: {
                 title: "Information: Ballot Locator screen",
                 content:
-                    "This screen allows the voter to find their vote by using the Ballot ID to retrieve it. This procedure enables checking that their ballot was correctly cast and that the recorded ballot coincides with the encrypted ballot they sent.",
+                    "This screen allows you to find your vote by using the Ballot ID to retrieve it. This procedure enables you to check that your ballot was correctly cast and that the recorded ballot matches the encrypted ballot you sent.",
                 ok: "OK",
             },
         },


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12743

Fixes six English voter-facing strings found during Ontario UAT (v10.0.0-rc.35). These are platform default translations, so the errors appear on every municipality.

| Ref | Package | Key | Fix |
| --- | --- | --- | --- |
| Q1 | voting-portal | `ballotHelpDialog.content` | `elegible`->eligible, `section`->selection, `by activate`->by activating, `eligible to vote`->eligible to vote in | | Q2 | voting-portal | `titleHelpDialog.content` | third person -> second person; `coincides with`->matches |
| Q6 | voting-portal | `electionSelectionScreen.description` | missing preposition `on` |
| Q7 | voting-portal | `chooserHelpDialog.content` | comma splice; sentence never completes |
| Q4 | ui-core | `validation.implicit.overVoteDisabled` | plural disagreement when max is 1 |
| Q5 | ui-core | `validation.implicit.underVote` | system message -> plain language |

Ballot screen help (Q1), ballot list heading and help (Q6, Q7), Ballot Locator help (Q2), Mayor contest second selection attempt (Q4), review screen with a contest left blank (Q5). Confirm Q1 and Q7 on a second municipality - they are shared strings.