### PR TITLE
🐞 Admin Portal: Service Accounts were counted as voters

### DIFF
--- a/packages/windmill/src/services/users.rs
+++ b/packages/windmill/src/services/users.rs
@@ -319,6 +319,7 @@ pub async fn list_keycloak_enabled_users_by_area_id_and_authorized_elections(
     delegated_voting_enabled: bool,
 ) -> Result<()> {
     let delegated_statement = if delegated_voting_enabled {
+        let no_service_account_delegators = service_account_exclusion("delegator");
         format!(
             r#"
             ,(
@@ -329,6 +330,7 @@ pub async fn list_keycloak_enabled_users_by_area_id_and_authorized_elections(
                 JOIN
                     user_attribute AS ua_delegate ON delegator.id = ua_delegate.user_id
                 WHERE
+                    {no_service_account_delegators} AND
                     ua_delegate.name = '{DELEGATE_TO_ATTR_NAME}' AND
                     ua_delegate.value = u.username
             ) AS delegate_count
@@ -345,6 +347,8 @@ pub async fn list_keycloak_enabled_users_by_area_id_and_authorized_elections(
     let area_id_escaped = escape_sql_literal(area_id);
     let election_alias_escaped = escape_sql_literal(election_alias);
 
+    let no_service_accounts = service_account_exclusion("u");
+
     let statement = format!(
         r#"
         SELECT
@@ -360,6 +364,7 @@ pub async fn list_keycloak_enabled_users_by_area_id_and_authorized_elections(
             user_attribute ua_elections ON u.id = ua_elections.user_id AND ua_elections.name = '{AUTHORIZED_ELECTION_IDS_NAME}'
         WHERE
             ra.name = '{realm_escaped}' AND
+            {no_service_accounts} AND
             u.enabled IS TRUE AND
             ua_area.value = '{area_id_escaped}' AND
             (ua_elections.value = '{election_alias_escaped}' OR ua_elections.value IS NULL)
@@ -611,6 +616,28 @@ fn get_query_bool_condition(field: &str, value: Option<bool>) -> String {
         Some(false) => format!(r#"AND u.{} = false"#, field),
         None => "".to_string(),
     }
+}
+
+/// Keycloak materialises a `user_entity` row for every client that has service accounts
+/// enabled (`service-account-ivr-service`, `service-account-realm-management`, ...). Those
+/// rows live in the same realm as the voters but are not voters, so they must never reach a
+/// voter count or listing. `service_account_client_link` holds the owning client's id and is
+/// null for real users, which makes it an exact test rather than a username-prefix guess.
+fn service_account_exclusion(alias: &str) -> String {
+    format!("{alias}.service_account_client_link IS NULL")
+}
+
+/// WHERE-clause head shared by the voter count and voter listing queries: scope to the realm,
+/// drop service accounts, then apply the caller's filters. `filters_clause` is the caller's
+/// already-composed column filters, which carries its own trailing boolean operator when set.
+fn voter_scope_clause(filters_clause: &str) -> String {
+    let no_service_accounts = service_account_exclusion("u");
+    format!(
+        r#"ra.name = $1 AND
+            {no_service_accounts} AND
+            {filters_clause}
+            (u.id = ANY($2) OR $2 IS NULL)"#
+    )
 }
 
 /// Gets sort clause ORDER BY, and the field parameter (column name or configurable attribute).
@@ -1312,6 +1339,7 @@ pub async fn count_keycloak_enabled_users(
     keycloak_transaction: &Transaction<'_>,
     realm: &str,
 ) -> Result<i64> {
+    let no_service_accounts = service_account_exclusion("u");
     let statement = keycloak_transaction
         .prepare(
             format!(
@@ -1323,7 +1351,8 @@ pub async fn count_keycloak_enabled_users(
                 INNER JOIN
                     realm AS ra ON ra.id = u.realm_id
                 WHERE
-                    ra.name = $1 AND 
+                    ra.name = $1 AND
+                    {no_service_accounts} AND
                     u.enabled IS TRUE
                 "#
             )
@@ -1429,6 +1458,7 @@ pub async fn lookup_users(
         true => "".to_string(),
         false => dynamic_attr_conditions.join(" OR "),
     };
+    let no_service_accounts = service_account_exclusion("u");
 
     debug!("parameters count: {}", next_param_number - 1);
     debug!("params {:?}", params);
@@ -1592,6 +1622,7 @@ pub async fn count_keycloak_enabled_users_by_attrs(
         attr_conditions.join(r#" AND "#)
     };
 
+    let no_service_accounts = service_account_exclusion("u");
     let statement = keycloak_transaction
         .prepare(
             format!(
@@ -1603,7 +1634,8 @@ pub async fn count_keycloak_enabled_users_by_attrs(
             INNER JOIN
                 realm AS ra ON ra.id = u.realm_id
             WHERE
-                ra.name = $1 
+                ra.name = $1
+                AND {no_service_accounts}
                 AND u.enabled IS TRUE
                 AND ({attr_conditions_sql})
             "#
@@ -1984,5 +2016,37 @@ mod tests {
     fn test_sql_boolean_operator_none_format() {
         let clause = format!("(col = $1){}", SqlBooleanOperator::None);
         assert_eq!(clause, "(col = $1)");
+    }
+
+    #[test]
+    fn test_service_account_exclusion_targets_the_given_alias() {
+        // The tally eligibility query joins user_entity twice, as `u` and as `delegator`.
+        assert_eq!(
+            service_account_exclusion("u"),
+            "u.service_account_client_link IS NULL"
+        );
+        assert_eq!(
+            service_account_exclusion("delegator"),
+            "delegator.service_account_client_link IS NULL"
+        );
+    }
+
+    #[test]
+    fn test_voter_scope_clause_excludes_service_accounts() {
+        let clause = voter_scope_clause("");
+        assert!(
+            clause.contains("u.service_account_client_link IS NULL"),
+            "voter queries must not report Keycloak service accounts as voters: {clause}"
+        );
+    }
+
+    #[test]
+    fn test_voter_scope_clause_keeps_realm_and_caller_filters() {
+        let filters_clause = format!(r#"("email" = $3){}"#, SqlBooleanOperator::And);
+        let clause = voter_scope_clause(&filters_clause);
+
+        assert!(clause.contains("ra.name = $1"));
+        assert!(clause.contains(r#"("email" = $3) AND"#));
+        assert!(clause.contains("(u.id = ANY($2) OR $2 IS NULL)"));
     }
 }


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voter-related user counts and listings now exclude service accounts.
  * Delegator, enabled-user, and attribute-based counts now reflect only eligible users.
  * Existing realm, caller, and user-specific filters continue to be applied correctly.
  * Improved consistency across voter-related views and statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->