### PR TITLE
🐞 Keycloak: Broken email/sms templates (#2950)

### DIFF
--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/BaseResetMessageOTPRequiredAction.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/BaseResetMessageOTPRequiredAction.java
@@ -230,20 +230,20 @@ public abstract class BaseResetMessageOTPRequiredAction implements RequiredActio
     String resend = context.getHttpRequest().getDecodedFormParameters().getFirst("resend");
     String code = authSession.getAuthNote(Utils.CODE);
     String ttl = authSession.getAuthNote(Utils.CODE_TTL);
-    String codeLengthStr = config != null ? config.getConfig().get(Utils.CODE_LENGTH) : "6";
+    String codeLengthStr = getConfigValue(config, Utils.CODE_LENGTH, Utils.CODE_LENGTH_DEFAULT);
     int codeLength = Integer.parseInt(codeLengthStr);
     String enteredCode = context.getHttpRequest().getDecodedFormParameters().getFirst("code");
     if (resend != null && resend.equals("true")) {
       // Handle resend logic: only allow if enough time has passed
       String resendTimerStr =
-          config != null ? config.getConfig().get(Utils.RESEND_ACTIVATION_TIMER) : "60";
+          getConfigValue(
+              config, Utils.RESEND_ACTIVATION_TIMER, Utils.RESEND_ACTIVATION_TIMER_DEFAULT);
       long resendTimer = Long.parseLong(resendTimerStr);
       long lastSent =
           ttl != null
               ? Long.parseLong(ttl)
-                  - (config != null
-                      ? Long.parseLong(config.getConfig().get(Utils.CODE_TTL)) * 1000L
-                      : 300000L)
+                  - Long.parseLong(getConfigValue(config, Utils.CODE_TTL, Utils.CODE_TTL_DEFAULT))
+                      * 1000L
               : 0;
       long now = System.currentTimeMillis();
       if (now - lastSent < resendTimer) {
@@ -407,6 +407,18 @@ public abstract class BaseResetMessageOTPRequiredAction implements RequiredActio
     return form.createForm(getEntryFtl());
   }
 
+  /**
+   * Reads a config value, falling back to the default when the realm's saved config has no entry
+   * for the key: the defaults declared in {@link MessageOTPAuthenticatorFactory} are applied by the
+   * admin console only, so a realm configured before a key existed simply doesn't have it, and the
+   * OTP template crashes with InvalidReferenceException on a missing attribute.
+   */
+  private String getConfigValue(AuthenticatorConfigModel config, String key, String defaultValue) {
+    Map<String, String> configMap = config == null ? null : config.getConfig();
+    String value = configMap == null ? null : configMap.get(key);
+    return value == null ? defaultValue : value;
+  }
+
   /** Creates the OTP entry form, setting all required attributes for the template. */
   protected Response createOTPForm(
       RequiredActionContext context,
@@ -415,13 +427,14 @@ public abstract class BaseResetMessageOTPRequiredAction implements RequiredActio
     LoginFormsProvider form = context.form();
     AuthenticationSessionModel authSession = context.getAuthenticationSession();
     String noteKey = getNoteKey(authSession);
-    String codeLength = config != null ? config.getConfig().get(Utils.CODE_LENGTH) : "6";
+    String codeLength = getConfigValue(config, Utils.CODE_LENGTH, Utils.CODE_LENGTH_DEFAULT);
     String resendTimer =
-        config != null ? config.getConfig().get(Utils.RESEND_ACTIVATION_TIMER) : "60";
+        getConfigValue(
+            config, Utils.RESEND_ACTIVATION_TIMER, Utils.RESEND_ACTIVATION_TIMER_DEFAULT);
     form.setAttribute("contact", authSession.getAuthNote(noteKey));
     form.setAttribute("codeLength", codeLength);
     form.setAttribute("resendTimer", resendTimer);
-    form.setAttribute("ttl", config.getConfig().get(Utils.CODE_TTL));
+    form.setAttribute("ttl", getConfigValue(config, Utils.CODE_TTL, Utils.CODE_TTL_DEFAULT));
     form.setAttribute("codeJustSent", true);
     form.setAttribute("i18nPrefix", getI18nPrefix());
     if (formConsumer != null) {

--- a/packages/keycloak-extensions/message-otp-authenticator/src/test/java/sequent/keycloak/authenticator/BaseResetMessageOTPRequiredActionTest.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/test/java/sequent/keycloak/authenticator/BaseResetMessageOTPRequiredActionTest.java
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+package sequent.keycloak.authenticator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+/**
+ * The OTP entry template interpolates the resendTimer, codeLength and ttl attributes directly, so a
+ * missing attribute renders the login page unusable with a 500. These tests cover realms whose
+ * saved authenticator config predates one of those keys.
+ */
+class BaseResetMessageOTPRequiredActionTest {
+
+  private final ResetEmailOTPRequiredAction action = new ResetEmailOTPRequiredAction();
+  private final Map<String, Object> attributes = new HashMap<>();
+
+  /** Runs the OTP form and returns the attributes it handed to the template. */
+  private Map<String, Object> renderWith(AuthenticatorConfigModel config) {
+    LoginFormsProvider form = mock(LoginFormsProvider.class);
+    when(form.setAttribute(anyString(), any()))
+        .thenAnswer(
+            invocation -> {
+              attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+              return form;
+            });
+
+    RequiredActionContext context = mock(RequiredActionContext.class);
+    AuthenticationSessionModel authSession = mock(AuthenticationSessionModel.class);
+    when(context.form()).thenReturn(form);
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+    when(authSession.getAuthNote("email")).thenReturn("voter@example.com");
+
+    action.createOTPForm(context, null, config);
+    return attributes;
+  }
+
+  private AuthenticatorConfigModel configWith(Map<String, String> values) {
+    AuthenticatorConfigModel config = new AuthenticatorConfigModel();
+    config.setConfig(values);
+    return config;
+  }
+
+  @Test
+  void otpFormFallsBackToDefaultsWhenTheConfigIsMissingKeys() {
+    renderWith(configWith(new HashMap<>()));
+
+    assertEquals(Utils.CODE_LENGTH_DEFAULT, attributes.get("codeLength"));
+    assertEquals(Utils.RESEND_ACTIVATION_TIMER_DEFAULT, attributes.get("resendTimer"));
+    assertEquals(Utils.CODE_TTL_DEFAULT, attributes.get("ttl"));
+  }
+
+  @Test
+  void otpFormFallsBackToDefaultsWhenThereIsNoConfig() {
+    renderWith(null);
+
+    assertEquals(Utils.CODE_LENGTH_DEFAULT, attributes.get("codeLength"));
+    assertEquals(Utils.RESEND_ACTIVATION_TIMER_DEFAULT, attributes.get("resendTimer"));
+    assertEquals(Utils.CODE_TTL_DEFAULT, attributes.get("ttl"));
+  }
+
+  @Test
+  void otpFormUsesTheConfiguredValues() {
+    Map<String, String> values = new HashMap<>();
+    values.put(Utils.CODE_LENGTH, "4");
+    values.put(Utils.RESEND_ACTIVATION_TIMER, "90");
+    values.put(Utils.CODE_TTL, "120");
+
+    renderWith(configWith(values));
+
+    assertEquals("4", attributes.get("codeLength"));
+    assertEquals("90", attributes.get("resendTimer"));
+    assertEquals("120", attributes.get("ttl"));
+  }
+}


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP configuration handling when settings or individual values are missing.
  * OTP forms now display reliable default values for code length, resend timing, and expiration.

* **Tests**
  * Added coverage for missing, absent, and fully configured OTP settings.
  * Verified that configured values override defaults correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->