### PR TITLE
✨ Unify election event generation, validation and import on one shared Rust core

### DIFF
--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The election event import bundle: what it contains, and whether it is valid.
+//!
+//! This is the single definition of the format shared by everything that
+//! produces or consumes an import — windmill's importer on the server, and the
+//! configuration tools in `beyond/packages` in the browser.
+//!
+//! It lives here rather than in `beyond` because the dependency between the
+//! repositories runs one way: `beyond` is a git submodule of step and
+//! path-depends on this crate, so step cannot depend on `beyond`. Anything
+//! windmill must use has to be here. `sequent-core` also already compiles to
+//! WASM and is already vendored into the front ends as a package, so both
+//! consumers reach this module through paths that already carry production
+//! code.
+//!
+//! Everything in this module must stay **pure** — no database, no IO, no
+//! clock — or it cannot run in a browser, and the browser is where a delivery
+//! engineer wants the answer.
+//!
+//! See `beyond/docs/docusaurus/docs/engineering/election-config-architecture.md`
+//! and <https://github.com/sequentech/meta/issues/12769>.
+
+pub mod report;
+
+pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};

--- a/packages/sequent-core/src/election_config/report.rs
+++ b/packages/sequent-core/src/election_config/report.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Report definitions, as they appear in an import bundle.
+//!
+//! Moved here from `windmill::postgres::reports` and
+//! `windmill::services::reports::template_renderer` so that the tools which
+//! *write* an import describe reports the same way the importer reads them.
+//! windmill re-exports these, so its own call sites are unchanged.
+//!
+//! The database mapping (`ReportWrapper`, `TryFrom<Row>`) deliberately stays in
+//! windmill: it needs `tokio_postgres`, which has no place in a module that has
+//! to compile to WASM.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumString, IntoStaticStr};
+
+/// How a generated report document is protected.
+///
+/// Serialized `snake_case`. There are exactly two: a report is either readable
+/// or encrypted with a password configured alongside it.
+#[allow(non_camel_case_types)]
+#[derive(
+    Display,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumString,
+    IntoStaticStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum EReportEncryption {
+    Unencrypted,
+    ConfiguredPassword,
+}
+
+/// Schedule for a report that regenerates itself and mails the result.
+///
+/// Every field defaults, because a report without a cron config is the normal
+/// case and an absent key must not fail deserialization.
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone, Default)]
+pub struct ReportCronConfig {
+    #[serde(default)]
+    pub is_active: bool,
+    #[serde(default)]
+    pub last_document_produced: Option<String>,
+    #[serde(default)]
+    pub cron_expression: String,
+    #[serde(default)]
+    pub email_recipients: Vec<String>,
+    #[serde(default)]
+    pub executer_username: String,
+}
+
+/// One report definition.
+///
+/// `permission_label` is a list here, unlike `Election::permission_label`, which
+/// is a single string. Both are matched against the administrator's
+/// `permission_labels` attribute, and an entity carrying a label nobody holds is
+/// invisible in the Admin Portal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Report {
+    pub id: String,
+    pub election_event_id: String,
+    pub tenant_id: String,
+    pub election_id: Option<String>,
+    pub report_type: String,
+    pub template_alias: Option<String>,
+    pub encryption_policy: EReportEncryption,
+    pub cron_config: Option<ReportCronConfig>,
+    pub created_at: DateTime<Utc>,
+    pub permission_label: Option<Vec<String>>,
+}
+
+/// The kinds of report the platform can generate.
+///
+/// `Report::report_type` is a `String` rather than this enum because the column
+/// is free text in the database; this is the set a writer should choose from.
+#[allow(non_camel_case_types)]
+#[derive(
+    Display, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, EnumString,
+)]
+pub enum ReportType {
+    INITIALIZATION_REPORT,
+    ELECTORAL_RESULTS,
+    BALLOT_IMAGES,
+    BALLOT_RECEIPT,
+    ACTIVITY_LOGS,
+    MANUAL_VERIFICATION,
+    PARTICIPATION_REPORT,
+    CREDENTIALS,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn encryption_policy_serializes_snake_case() {
+        // The importer reads this straight out of a CSV column, so the wire form
+        // is part of the file format rather than an implementation detail.
+        assert_eq!(
+            serde_json::to_string(&EReportEncryption::ConfiguredPassword)
+                .unwrap(),
+            "\"configured_password\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EReportEncryption::Unencrypted).unwrap(),
+            "\"unencrypted\""
+        );
+    }
+
+    #[test]
+    fn encryption_policy_parses_from_the_csv_spelling() {
+        assert_eq!(
+            EReportEncryption::from_str("configured_password").unwrap(),
+            EReportEncryption::ConfiguredPassword
+        );
+        assert!(EReportEncryption::from_str("generated_password").is_err());
+    }
+
+    #[test]
+    fn cron_config_tolerates_an_empty_object() {
+        // An absent key must not fail deserialization: most reports have no cron.
+        let parsed: ReportCronConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(parsed, ReportCronConfig::default());
+        assert!(!parsed.is_active);
+    }
+
+    #[test]
+    fn cron_config_round_trips_the_shape_the_workbook_writes() {
+        let source = r#"{"is_active":true,"last_document_produced":null,
+            "cron_expression":"46 0 * * *","email_recipients":["ops@example.org"],
+            "executer_username":"admin"}"#;
+        let parsed: ReportCronConfig = serde_json::from_str(source).unwrap();
+        assert!(parsed.is_active);
+        assert_eq!(parsed.cron_expression, "46 0 * * *");
+        assert_eq!(parsed.email_recipients, vec!["ops@example.org"]);
+    }
+
+    #[test]
+    fn every_report_type_round_trips() {
+        for name in [
+            "INITIALIZATION_REPORT",
+            "ELECTORAL_RESULTS",
+            "BALLOT_IMAGES",
+            "BALLOT_RECEIPT",
+            "ACTIVITY_LOGS",
+            "MANUAL_VERIFICATION",
+            "PARTICIPATION_REPORT",
+            "CREDENTIALS",
+        ] {
+            let parsed = ReportType::from_str(name)
+                .unwrap_or_else(|_| panic!("{name} should be a ReportType"));
+            assert_eq!(parsed.to_string(), name);
+        }
+    }
+
+    #[test]
+    fn permission_label_is_a_list() {
+        // Election::permission_label is a single string; getting these the wrong
+        // way round fails deserialization at import time.
+        let source = r#"{"id":"a","election_event_id":"b","tenant_id":"c",
+            "election_id":null,"report_type":"ACTIVITY_LOGS","template_alias":null,
+            "encryption_policy":"unencrypted","cron_config":null,
+            "created_at":"2026-01-01T00:00:00Z","permission_label":["x","y"]}"#;
+        let parsed: Report = serde_json::from_str(source).unwrap();
+        assert_eq!(parsed.permission_label, Some(vec!["x".into(), "y".into()]));
+    }
+}

--- a/packages/sequent-core/src/lib.rs
+++ b/packages/sequent-core/src/lib.rs
@@ -9,6 +9,13 @@ extern crate cfg_if;
 pub mod ballot;
 #[cfg(feature = "default_features")]
 pub mod ballot_style;
+
+// Gated like types::hasura, whose entities the bundle schema is built from. The
+// WASM build enables default_features (see build_wasm.yml), so this module is
+// present in the browser.
+#[cfg(feature = "default_features")]
+pub mod election_config;
+
 #[cfg(feature = "default_features")]
 pub mod error;
 #[cfg(feature = "default_features")]

--- a/packages/windmill/src/postgres/reports.rs
+++ b/packages/windmill/src/postgres/reports.rs
@@ -18,58 +18,14 @@ use uuid::Uuid;
 
 use crate::services::reports::template_renderer::EReportEncryption;
 
-#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
-pub struct ReportCronConfig {
-    #[serde(default)]
-    pub is_active: bool,
-    #[serde(default)]
-    pub last_document_produced: Option<String>,
-    #[serde(default)]
-    pub cron_expression: String,
-    #[serde(default)]
-    pub email_recipients: Vec<String>,
-    #[serde(default)]
-    pub executer_username: String,
-}
-
-impl Default for ReportCronConfig {
-    fn default() -> Self {
-        ReportCronConfig {
-            is_active: false,
-            last_document_produced: None,
-            cron_expression: Default::default(),
-            email_recipients: Default::default(),
-            executer_username: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Report {
-    pub id: String,
-    pub election_event_id: String,
-    pub tenant_id: String,
-    pub election_id: Option<String>,
-    pub report_type: String,
-    pub template_alias: Option<String>,
-    pub encryption_policy: EReportEncryption,
-    pub cron_config: Option<ReportCronConfig>,
-    pub created_at: DateTime<Utc>,
-    pub permission_label: Option<Vec<String>>,
-}
-
-#[allow(non_camel_case_types)]
-#[derive(Display, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, EnumString)]
-pub enum ReportType {
-    INITIALIZATION_REPORT,
-    ELECTORAL_RESULTS,
-    BALLOT_IMAGES,
-    BALLOT_RECEIPT,
-    ACTIVITY_LOGS,
-    MANUAL_VERIFICATION,
-    PARTICIPATION_REPORT,
-    CREDENTIALS,
-}
+// Report, ReportCronConfig and ReportType now live in
+// sequent_core::election_config, so that the tools which write an import bundle
+// describe reports exactly as the importer reads them. Re-exported here because
+// windmill refers to them by this path in a dozen places.
+//
+// The database mapping stays below: it needs tokio_postgres, which cannot be in
+// a module that compiles to WASM.
+pub use sequent_core::election_config::{Report, ReportCronConfig, ReportType};
 
 pub struct ReportWrapper(pub Report);
 

--- a/packages/windmill/src/services/reports/template_renderer.rs
+++ b/packages/windmill/src/services/reports/template_renderer.rs
@@ -82,16 +82,9 @@ pub enum ReportOriginatedFrom {
     ReportsTab,
 }
 
-#[allow(non_camel_case_types)]
-#[derive(
-    Display, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, EnumString, IntoStaticStr,
-)]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-pub enum EReportEncryption {
-    Unencrypted,
-    ConfiguredPassword,
-}
+// Moved to sequent_core::election_config so the import writers and the importer
+// agree on the wire form. Re-exported: windmill refers to it by this path.
+pub use sequent_core::election_config::EReportEncryption;
 
 pub const DEFAULT_ITEMS_PER_REPORT_LIMIT: usize = 1000;
 /// Trait that defines the behavior for rendering templates


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

Companion to https://github.com/sequentech/beyond/pull/802. Beyond's Rust CI looks
for a step branch of the same name, and this is it.

Unifies the three tools that build or check an election event import onto one
shared Rust definition. This PR is the step half; it lands in small increments.

## Why here and not in beyond

The dependency between the repositories runs one way. `beyond` is a **git
submodule of step** and its Rust workspace path-depends on step's crates
(`sequent-core = { path = "../../packages/sequent-core" }`). **step cannot depend
on beyond**, so anything windmill must use has to live here. A shared crate in
`beyond/packages` would serve the two configuration SPAs and leave the server on
its own implementation — which is the problem, not the fix.

`sequent-core` needs no new mechanism for the browser half either: it already
compiles to WASM (`build_wasm.yml`, `wasm-pack build --target web`) and that build
is already vendored into admin-portal, voting-portal, ui-core and ballot-verifier
as `file:./rust/sequent-core-0.1.0.tgz`.

## What is here so far

**`sequent-core::election_config`** — a new module for the import bundle format.
Gated on `default_features`, matching `types::hasura` whose entities the schema
will be built from; the WASM build enables that feature, so the module is present
in the browser.

**The report types move in.** `Report`, `ReportCronConfig`, `ReportType` and
`EReportEncryption` come from `windmill::postgres::reports` and
`windmill::services::reports::template_renderer`, so that the tools which *write*
an import describe reports the same way the importer reads them. windmill
re-exports all four, so its ~10 call sites are untouched — net −44 lines.

`ReportWrapper` and its `TryFrom<Row>` deliberately stay in windmill: they need
`tokio_postgres`, which has no place in a module that has to compile to WASM.

Six unit tests cover the wire forms that are part of the file format rather than
implementation details — the `snake_case` encryption policy the reports CSV
carries, a cron config surviving `{}`, and `permission_label` being a list here
where `Election`'s is a string.

## Verified

- `cargo check -p sequent-core` and `cargo check -p windmill` both clean.
- `cargo test -p sequent-core --lib --features default_features election_config` — 6 passed.
- `cargo fmt --check -p sequent-core` clean.

## The stack above this PR

Each is its own draft PR, based on the one before. Review bottom-up.

1. **this PR** — the module, and the report types moved in.
2. https://github.com/sequentech/step/pull/2961 — `election_config::schema`, the bundle schema moved out of windmill.
3. https://github.com/sequentech/step/pull/2962 — `election_config::validate`, the pure checks returning structured problems.
4. https://github.com/sequentech/step/pull/2968 — windmill validating before importing.
5. https://github.com/sequentech/step/pull/2970 — `election_config::emit`, the bundle's file formats written once.
6. https://github.com/sequentech/step/pull/2971 — `election_config::paths`, how a spreadsheet cell becomes JSON.
7. https://github.com/sequentech/step/pull/2972 — `election_config::sheet` and `::xlsx`, reading an authoring workbook.
8. https://github.com/sequentech/step/pull/2973 — `election_config::ids`, the deterministic uuid5 factory.
9. https://github.com/sequentech/step/pull/2974 — `election_config::render`, the base entity templates.
10. https://github.com/sequentech/step/pull/2975 — `election_config::build`, the bundle's JSON document.
11. https://github.com/sequentech/step/pull/2976 — the bundle's CSV members.
12. https://github.com/sequentech/step/pull/2977 — the auth presets and the Keycloak realm.
13. https://github.com/sequentech/step/pull/2978 — the files a bundle ships as, and the zip.
14. https://github.com/sequentech/step/pull/2979 — janitor folded into `step-cli`, and proven byte-identical to it.
15. https://github.com/sequentech/beyond/pull/803 — retires `beyond/packages/janitor` and points its docs at `step-cli` (in beyond, stacked on #802).
16. https://github.com/sequentech/step/pull/2980 — `election_config::wasm`, the browser's view of the same checks.
17. _next_ — the two SPAs in `beyond/packages`, and a WASM package that enables the config features for them.


## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

`<empty>` — no user-visible change in this PR; it is a refactor.

