### PR TITLE
♻️ Move the import bundle schema into sequent-core::election_config

### DIFF
--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -24,5 +24,7 @@
 //! and <https://github.com/sequentech/meta/issues/12769>.
 
 pub mod report;
+pub mod schema;
 
 pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};
+pub use schema::ImportElectionEventSchema;

--- a/packages/sequent-core/src/election_config/schema.rs
+++ b/packages/sequent-core/src/election_config/schema.rs
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The election event import bundle.
+//!
+//! This is the shape of `export_election_event-<uuid>.json`, and the single
+//! definition of it. It was previously declared in
+//! `windmill::services::import::import_election_event`, which meant every tool
+//! that *wrote* an import had to reproduce it — janitor in Handlebars templates,
+//! the Election Architect in a hand-built TypeScript object — and each
+//! reproduction drifted.
+//!
+//! windmill re-exports this, so its own call sites are unchanged.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::types::hasura::core::{
+    Application, Area, AreaContest, Candidate, Contest, Election,
+    ElectionEvent, KeysCeremony,
+};
+use crate::types::scheduled_event::ScheduledEvent;
+use crate::util::version::HISTORICAL_DEFAULT_VERSION;
+
+use super::report::Report;
+
+/// Everything an election event import carries.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ImportElectionEventSchema {
+    /// The tenant the bundle was exported from.
+    ///
+    /// A `String` rather than a `Uuid` on purpose. Import replaces this value
+    /// with the tenant of the importing request regardless of what it says
+    /// (`replace_ids`: "always replace to ensure consistency"), so it is a
+    /// placeholder rather than a destination, and every consumer only ever
+    /// stringifies it.
+    ///
+    /// Keeping it a `String` also keeps `uuid` out of this module. That crate is
+    /// only enabled by the `keycloak` feature here, and pulling it into
+    /// `default_features` would put `getrandom` in the WASM build for no benefit.
+    /// Its format is checked by validation instead, which reports a readable
+    /// problem where a `Uuid` field would have produced an opaque serde error.
+    pub tenant_id: String,
+
+    /// The Keycloak realm, carried opaquely.
+    ///
+    /// Deliberately a `Value` and not a `RealmRepresentation`: that type comes
+    /// from the `keycloak` crate, which pulls `reqwest`, and this module has to
+    /// compile to WASM. Nothing is lost — serde round-trips it exactly, and
+    /// windmill deserializes it into the typed form where it actually talks to
+    /// Keycloak.
+    ///
+    /// Validating a realm needs a live Keycloak, so it is not something the
+    /// shared validation could check even if the type were available.
+    pub keycloak_event_realm: Option<Value>,
+
+    pub election_event: ElectionEvent,
+    pub elections: Vec<Election>,
+    pub contests: Vec<Contest>,
+    pub candidates: Vec<Candidate>,
+    pub areas: Vec<Area>,
+    pub area_contests: Vec<AreaContest>,
+
+    /// The voting window.
+    ///
+    /// Normally `None`: the importer reads scheduled events from the
+    /// `export_scheduled_events-<uuid>.csv` member of the zip, not from here.
+    pub scheduled_events: Option<Vec<ScheduledEvent>>,
+
+    /// Report definitions.
+    ///
+    /// Normally empty for the same reason: `insert_reports` is only ever called
+    /// from `process_reports_file`, so reports travel in
+    /// `export_reports-<uuid>.csv` and a populated array here is silently
+    /// dropped. The field is required by the format, so it must still be present.
+    pub reports: Vec<Report>,
+
+    pub keys_ceremonies: Option<Vec<KeysCeremony>>,
+    pub applications: Option<Vec<Application>>,
+
+    /// The platform version that wrote the bundle.
+    ///
+    /// Defaults to the first version that recorded one, so bundles predating the
+    /// field still import.
+    #[serde(default = "default_version")]
+    pub version: String,
+}
+
+fn default_version() -> String {
+    HISTORICAL_DEFAULT_VERSION.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The smallest bundle that deserializes. Every field here is one the format
+    /// requires; anything omitted below has a serde default.
+    const MINIMAL: &str = r#"{
+        "tenant_id": "9384db41-1b21-4b93-a6aa-edfc007136d8",
+        "keycloak_event_realm": null,
+        "election_event": {
+            "id": "11111111-1111-5111-8111-111111111111",
+            "tenant_id": "9384db41-1b21-4b93-a6aa-edfc007136d8",
+            "is_archived": false,
+            "encryption_protocol": "RSA256"
+        },
+        "elections": [],
+        "contests": [],
+        "candidates": [],
+        "areas": [],
+        "area_contests": [],
+        "scheduled_events": null,
+        "reports": [],
+        "keys_ceremonies": [],
+        "applications": []
+    }"#;
+
+    #[test]
+    fn a_minimal_bundle_deserializes() {
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(MINIMAL).unwrap();
+        assert_eq!(parsed.election_event.encryption_protocol, "RSA256");
+        assert!(parsed.keycloak_event_realm.is_none());
+    }
+
+    #[test]
+    fn a_missing_version_falls_back_to_the_historical_default() {
+        // Bundles written before the field existed must still import.
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(MINIMAL).unwrap();
+        assert_eq!(parsed.version, HISTORICAL_DEFAULT_VERSION);
+    }
+
+    #[test]
+    fn the_realm_round_trips_untouched() {
+        // Carried opaquely, so whatever the exporter wrote comes back byte for
+        // byte — including keys this crate has never heard of.
+        let source = MINIMAL.replace(
+            "\"keycloak_event_realm\": null",
+            r#""keycloak_event_realm": {"realm":"r","displayName":"D","somethingNew":[1,2]}"#,
+        );
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(&source).unwrap();
+        let realm = parsed.keycloak_event_realm.as_ref().unwrap();
+        assert_eq!(realm["displayName"], "D");
+        assert_eq!(realm["somethingNew"], serde_json::json!([1, 2]));
+
+        let round_tripped = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(&round_tripped["keycloak_event_realm"], realm);
+    }
+
+    #[test]
+    fn a_missing_required_field_is_rejected() {
+        // encryption_protocol is not Option, so its absence fails the whole file
+        // at parse time. This is the error the shared validation exists to
+        // pre-empt with something readable.
+        //
+        // Built by removing the key from the parsed tree rather than by editing
+        // the text: a string replacement that stops matching would silently pass
+        // this test instead of failing it.
+        let mut tree: serde_json::Value =
+            serde_json::from_str(MINIMAL).unwrap();
+        let removed = tree["election_event"]
+            .as_object_mut()
+            .unwrap()
+            .remove("encryption_protocol");
+        assert!(removed.is_some(), "the fixture should have had the field");
+
+        let parsed: Result<ImportElectionEventSchema, _> =
+            serde_json::from_value(tree);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn tenant_id_is_carried_as_written() {
+        // Import replaces it, so it is a placeholder; it must survive unaltered
+        // so that replace_ids can map it.
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(MINIMAL).unwrap();
+        assert_eq!(parsed.tenant_id, "9384db41-1b21-4b93-a6aa-edfc007136d8");
+    }
+}

--- a/packages/windmill/src/services/export/export_election_event.rs
+++ b/packages/windmill/src/services/export/export_election_event.rs
@@ -147,8 +147,10 @@ pub async fn read_export_data(
         std::env::var(ENV_VAR_APP_VERSION).unwrap_or_else(|_| DEV_APP_VERSION.to_string());
 
     let import_election_event_schema = ImportElectionEventSchema {
-        tenant_id: parse_uuid_v4(&tenant_id)?,
-        keycloak_event_realm: Some(realm),
+        // parse_uuid_v4 still runs: the schema now carries a String, but an
+        // export must not emit a tenant id that is not a UUID.
+        tenant_id: parse_uuid_v4(&tenant_id)?.to_string(),
+        keycloak_event_realm: Some(serde_json::to_value(realm)?),
         election_event: election_event,
         elections: export_elections,
         contests: contests.clone(),

--- a/packages/windmill/src/services/import/import_election_event.rs
+++ b/packages/windmill/src/services/import/import_election_event.rs
@@ -110,28 +110,20 @@ use sequent_core::types::keycloak::{
 };
 use sequent_core::types::scheduled_event::*;
 use sequent_core::util::temp_path::{generate_temp_file, get_file_size};
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ImportElectionEventSchema {
-    pub tenant_id: Uuid,
-    pub keycloak_event_realm: Option<RealmRepresentation>,
-    pub election_event: ElectionEvent,
-    pub elections: Vec<Election>,
-    pub contests: Vec<Contest>,
-    pub candidates: Vec<Candidate>,
-    pub areas: Vec<Area>,
-    pub area_contests: Vec<AreaContest>,
-    pub scheduled_events: Option<Vec<ScheduledEvent>>,
-    pub reports: Vec<Report>,
-    pub keys_ceremonies: Option<Vec<KeysCeremony>>,
-    pub applications: Option<Vec<Application>>,
-    #[serde(default = "default_version")]
-    pub version: String,
-}
-
-/// Set the default version of an imported election event to be compatible with version 9, which is the first version to include this feature.
-fn default_version() -> String {
-    HISTORICAL_DEFAULT_VERSION.to_string()
-}
+// The bundle schema now lives in sequent_core::election_config, so that the tools
+// which write an import describe it the same way this importer reads it.
+// Re-exported because windmill refers to it by this path throughout.
+//
+// Two field types differ from the struct that used to be here, both so the module
+// can compile to WASM for the browser-side tools:
+//
+//   tenant_id            String, not Uuid. Import replaces it with the importing
+//                        request's tenant regardless, and every use here
+//                        stringifies it. Its format is checked by validation.
+//   keycloak_event_realm serde_json::Value, not RealmRepresentation. That type
+//                        comes from the keycloak crate, which pulls reqwest.
+//                        Deserialized into the typed form where it is used.
+pub use sequent_core::election_config::ImportElectionEventSchema;
 
 #[instrument(err)]
 pub async fn upsert_b3_and_elog(
@@ -579,7 +571,7 @@ pub async fn get_election_event_schema(
     // with a more obscure error when trying to deserialize data that is incompatible with the current version.
     let raw: serde_json::Value = serde_json::from_str(data_str)
         .map_err(|e| anyhow!("Failed to parse import data as JSON: {e}"))?;
-    let default_ver = default_version();
+    let default_ver = HISTORICAL_DEFAULT_VERSION.to_string();
     let imported_version = raw
         .get(VERSION_KEY)
         .and_then(|v| v.as_str())
@@ -670,10 +662,18 @@ pub async fn process_election_event_file(
         default_language = Some(data.election_event.get_default_language());
     }
 
+    // The bundle carries the realm opaquely; this is where it becomes typed.
+    let keycloak_event_realm: Option<RealmRepresentation> = data
+        .keycloak_event_realm
+        .clone()
+        .map(deserialize_value)
+        .transpose()
+        .with_context(|| "Error deserializing keycloak_event_realm")?;
+
     upsert_keycloak_realm(
         tenant_id.as_str(),
         &election_event_id,
-        data.keycloak_event_realm.clone(),
+        keycloak_event_realm,
         default_language
     )
     .await
@@ -1421,7 +1421,8 @@ pub async fn process_document(
             if file_name.contains(EDocuments::CERTIFICATES.to_file_name()) {
                 let pem_content = String::from_utf8(file_contents.clone())
                     .context("Failed to decode certificates PEM as UTF-8")?;
-                let tenant_uuid = election_event_schema.tenant_id;
+                let tenant_uuid = Uuid::parse_str(&election_event_schema.tenant_id)
+                    .context("Invalid tenant_id in the imported bundle")?;
                 let election_event_uuid = Uuid::parse_str(&election_event_schema.election_event.id)
                     .context("Failed to parse election event UUID")?;
                 let pem_chunks = split_pem_bundle(&pem_content);


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2958.** Base branch is
`feat/meta-12769-unified-election-config/main`, so this diff shows only what is
added on top.

Moves `ImportElectionEventSchema` out of windmill into
`sequent-core::election_config::schema`, so the tools that *write* an import
bundle describe it the same way the importer reads it. Until now each reproduced
it: janitor in Handlebars templates, the Election Architect in a hand-built
TypeScript object that was not even the importable shape.

windmill re-exports it, so its own call sites are unchanged.

## Two field types differ, both to keep the module WASM-compatible

| Field | Was | Now | Why |
|---|---|---|---|
| `tenant_id` | `Uuid` | `String` | Making it a `Uuid` pulls that crate into `default_features` and `getrandom` into the WASM build. Import replaces this value with the importing request's tenant regardless of what it says, and every use in windmill stringified it already. |
| `keycloak_event_realm` | `RealmRepresentation` | `serde_json::Value` | That type comes from the `keycloak` crate, which pulls `reqwest`. |

Neither loses anything real:

- The export path still runs `parse_uuid_v4`, so an export cannot emit a malformed
  tenant id. Validation will report one as a readable problem where a `Uuid` field
  produced an opaque serde error.
- serde round-trips the realm exactly — a test asserts that, including keys this
  crate has never heard of. windmill deserializes it into the typed form at the one
  place it talks to Keycloak. Validating a realm needs a live Keycloak anyway, so
  it was never something the shared validation could check.

## Tests

Five new, covering what the format guarantees rather than the struct's shape:

- a minimal bundle deserializes;
- a missing `version` falls back to the historical default, so bundles predating
  the field still import;
- the realm round-trips untouched, unknown keys included;
- a missing non-`Option` field is rejected — the failure the shared validation
  exists to pre-empt;
- `tenant_id` survives unaltered so `replace_ids` can map it.

The missing-field test builds its input by removing the key from the parsed tree
rather than by editing the JSON text: a string replacement that stopped matching
would silently pass instead of failing, which is exactly what happened on the
first attempt.

## Verified

- `cargo check -p sequent-core --features default_features` and `cargo check -p windmill` clean.
- `cargo test -p sequent-core --lib --features default_features election_config` — 11 passed.
- `cargo test -p windmill --lib` — 235 passed, 2 ignored, unchanged from `main`.
- `cargo fmt --check` clean on both crates.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

`<empty>` — refactor, no user-visible change.
