### PR TITLE
✨ Add shared election config validation to sequent-core

### DIFF
--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -23,8 +23,15 @@
 //! See `beyond/docs/docusaurus/docs/engineering/election-config-architecture.md`
 //! and <https://github.com/sequentech/meta/issues/12769>.
 
+pub mod problem;
 pub mod report;
 pub mod schema;
+pub mod validate;
 
+#[cfg(test)]
+mod validate_tests;
+
+pub use problem::{Code, Problem, Report as ValidationReport, Severity};
 pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};
 pub use schema::ImportElectionEventSchema;
+pub use validate::validate;

--- a/packages/sequent-core/src/election_config/problem.rs
+++ b/packages/sequent-core/src/election_config/problem.rs
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What validation reports.
+//!
+//! Structured rather than a formatted string, because the same problem has to be
+//! rendered three ways: a line in `step-cli`'s output, a row in a browser's
+//! problem list, and an error from a server-side import. Each wants the pieces
+//! arranged differently, and only the caller knows which.
+//!
+//! Every problem carries a machine-readable [`Code`] so a front end can group,
+//! translate or link them without matching on English text.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Whether a problem stops an import or merely deserves saying out loud.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    /// The bundle will not import, or will import into something broken.
+    Error,
+    /// The bundle imports, but something about it is very likely a mistake.
+    ///
+    /// A warning is not a lesser error: it is a statement that this file is
+    /// self-consistent but probably not what its author meant. An election with
+    /// no voting window imports perfectly and then never opens.
+    Warning,
+}
+
+/// What kind of problem this is.
+///
+/// Stable identifiers: a front end may match on these, so renaming one is a
+/// breaking change in a way that rewording a message is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Code {
+    /// A required field is absent or empty.
+    MissingField,
+    /// A value is not one the platform accepts.
+    InvalidValue,
+    /// A reference points at something not in the bundle.
+    DanglingReference,
+    /// Two entities share an identifier.
+    DuplicateId,
+    /// The area parent chain loops.
+    AreaCycle,
+    /// A contest's vote counts contradict each other or its candidate list.
+    ContestArithmetic,
+    /// `voting_type` and `counting_algorithm` disagree.
+    TallyMismatch,
+    /// Something that would be on a ballot is not, or vice versa.
+    BallotCoverage,
+    /// An entity is scoped to a permission label, which hides it.
+    PermissionLabel,
+    /// An election has no scheduled voting window.
+    MissingSchedule,
+}
+
+/// One thing wrong with a bundle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Problem {
+    pub severity: Severity,
+    pub code: Code,
+
+    /// Where in the bundle, as a dotted path — `contests[2].max_votes`.
+    ///
+    /// Indexed rather than named because a bundle is what is being validated;
+    /// the tool that produced it maps this back to a wizard step or a
+    /// spreadsheet cell, which only it can do.
+    pub path: String,
+
+    /// What is wrong, in one sentence, in English.
+    pub message: String,
+
+    /// The entity's `external_id` where it has one.
+    ///
+    /// The bundle's UUIDs are regenerated on import and mean nothing to whoever
+    /// has to fix the source, whereas an `external_id` is what they typed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_id: Option<String>,
+}
+
+impl Problem {
+    pub fn error(
+        code: Code,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Problem {
+            severity: Severity::Error,
+            code,
+            path: path.into(),
+            message: message.into(),
+            external_id: None,
+        }
+    }
+
+    pub fn warning(
+        code: Code,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Problem {
+            severity: Severity::Warning,
+            code,
+            path: path.into(),
+            message: message.into(),
+            external_id: None,
+        }
+    }
+
+    pub fn about(mut self, external_id: Option<&str>) -> Self {
+        self.external_id = external_id.map(str::to_string);
+        self
+    }
+}
+
+impl fmt::Display for Problem {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self.severity {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        };
+        write!(formatter, "{label}: {}: {}", self.path, self.message)
+    }
+}
+
+/// Everything validation found, in the order it found it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Report {
+    pub problems: Vec<Problem>,
+}
+
+impl Report {
+    pub fn push(&mut self, problem: Problem) {
+        self.problems.push(problem);
+    }
+
+    /// Whether the bundle should be refused.
+    pub fn has_errors(&self) -> bool {
+        self.problems
+            .iter()
+            .any(|problem| problem.severity == Severity::Error)
+    }
+
+    pub fn errors(&self) -> impl Iterator<Item = &Problem> {
+        self.iter_severity(Severity::Error)
+    }
+
+    pub fn warnings(&self) -> impl Iterator<Item = &Problem> {
+        self.iter_severity(Severity::Warning)
+    }
+
+    fn iter_severity(
+        &self,
+        severity: Severity,
+    ) -> impl Iterator<Item = &Problem> {
+        self.problems
+            .iter()
+            .filter(move |problem| problem.severity == severity)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.problems.is_empty()
+    }
+}
+
+impl fmt::Display for Report {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for problem in &self.problems {
+            writeln!(formatter, "  {problem}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_report_with_only_warnings_is_importable() {
+        // The distinction is the point: a warning must not block a build.
+        let mut report = Report::default();
+        report.push(Problem::warning(
+            Code::MissingSchedule,
+            "elections[0]",
+            "no window",
+        ));
+        assert!(!report.has_errors());
+        assert_eq!(report.warnings().count(), 1);
+        assert_eq!(report.errors().count(), 0);
+    }
+
+    #[test]
+    fn one_error_condemns_the_report() {
+        let mut report = Report::default();
+        report.push(Problem::warning(Code::MissingSchedule, "a", "b"));
+        report.push(Problem::error(Code::MissingField, "c", "d"));
+        assert!(report.has_errors());
+    }
+
+    #[test]
+    fn a_problem_reads_as_a_line() {
+        let problem = Problem::error(
+            Code::DanglingReference,
+            "candidates[3].contest_id",
+            "no contest with that id is in the bundle",
+        );
+        assert_eq!(
+            problem.to_string(),
+            "error: candidates[3].contest_id: no contest with that id is in the bundle"
+        );
+    }
+
+    #[test]
+    fn the_code_survives_serialization() {
+        // A front end matches on this rather than on the English.
+        let problem = Problem::error(Code::TallyMismatch, "p", "m")
+            .about(Some("president"));
+        let json = serde_json::to_value(&problem).unwrap();
+        assert_eq!(json["code"], "tally_mismatch");
+        assert_eq!(json["severity"], "error");
+        assert_eq!(json["external_id"], "president");
+    }
+
+    #[test]
+    fn an_absent_external_id_is_omitted_rather_than_null() {
+        let problem = Problem::error(Code::MissingField, "p", "m");
+        let json = serde_json::to_value(&problem).unwrap();
+        assert!(json.get("external_id").is_none());
+    }
+}

--- a/packages/sequent-core/src/election_config/validate.rs
+++ b/packages/sequent-core/src/election_config/validate.rs
@@ -1,0 +1,541 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Whether a bundle can be imported, and whether it should be.
+//!
+//! Pure: no database, no IO, no clock. That is what lets the same code answer in
+//! a browser before an upload and on the server before a transaction, and it is
+//! the constraint to keep in mind when adding a rule. Anything needing the
+//! database — does this tenant exist, is this area name already taken — belongs
+//! in windmill on top of this pass, not here.
+//!
+//! The rules come from two places: what the importer rejects, and what janitor
+//! learned the hard way. The second kind matters most. A bundle can satisfy every
+//! type in the schema and still be wrong in a way nobody notices until election
+//! day — a contest on no ballot, rankings counted by plurality, an election
+//! scoped to a permission label that no administrator holds. Those import
+//! cleanly and fail silently, so they are checked here.
+
+use std::collections::{HashMap, HashSet};
+
+use super::problem::{Code, Problem, Report};
+use super::schema::ImportElectionEventSchema;
+
+/// `CountingAlgType` in `crate::types::ceremonies`, by its serde rename.
+pub const COUNTING_ALGORITHMS: &[&str] = &[
+    "plurality-at-large",
+    "instant-runoff",
+    "borda-nauru",
+    "borda",
+    "borda-mas-madrid",
+    "pairwise-beta",
+    "desborda3",
+    "desborda2",
+    "desborda",
+    "cumulative",
+];
+
+/// The algorithms `CountingAlgType::is_preferential` returns true for.
+///
+/// The split is load-bearing rather than cosmetic: ballot encoding follows the
+/// algorithm, so a preferential contest counted by plurality imports cleanly and
+/// then reads the rankings a voter entered as unordered selections.
+pub const PREFERENTIAL_ALGORITHMS: &[&str] = &[
+    "instant-runoff",
+    "borda",
+    "borda-nauru",
+    "borda-mas-madrid",
+    "pairwise-beta",
+    "desborda",
+    "desborda2",
+    "desborda3",
+];
+
+/// `IVotingType` in the Admin Portal. Rust carries `voting_type` as a free-form
+/// `String`, so the portal's enum is the only authority on what it may hold.
+pub const VOTING_TYPES: &[&str] = &["preferential", "non-preferential"];
+
+/// Check a bundle and report everything wrong with it.
+///
+/// Never stops at the first problem: fixing a configuration one error per run is
+/// miserable, and the caller usually wants the whole list at once.
+pub fn validate(bundle: &ImportElectionEventSchema) -> Report {
+    let mut report = Report::default();
+
+    check_identity(bundle, &mut report);
+    check_references(bundle, &mut report);
+    check_area_tree(bundle, &mut report);
+    check_contests(bundle, &mut report);
+    check_ballot_coverage(bundle, &mut report);
+    check_permission_labels(bundle, &mut report);
+    check_unique_ids(bundle, &mut report);
+
+    report
+}
+
+fn check_identity(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    // The schema carries tenant_id as a String so the module stays WASM-safe;
+    // this is where the format check it lost comes back, as a readable problem
+    // rather than an opaque serde error.
+    if bundle.tenant_id.trim().is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "tenant_id",
+            "the bundle has no tenant id",
+        ));
+    } else if !looks_like_uuid(&bundle.tenant_id) {
+        report.push(Problem::error(
+            Code::InvalidValue,
+            "tenant_id",
+            format!("'{}' is not a UUID", bundle.tenant_id),
+        ));
+    }
+
+    let event = &bundle.election_event;
+    if event.id.trim().is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "election_event.id",
+            "the election event has no id",
+        ));
+    }
+    if event.encryption_protocol.trim().is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "election_event.encryption_protocol",
+            "the election event has no encryption protocol",
+        ));
+    }
+
+    if bundle.elections.is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "elections",
+            "an election event needs at least one election",
+        ));
+    }
+    if bundle.areas.is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "areas",
+            "an election event needs at least one area; every voter belongs to one",
+        ));
+    }
+}
+
+fn check_references(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    let election_ids: HashSet<&str> =
+        bundle.elections.iter().map(|e| e.id.as_str()).collect();
+    let contest_ids: HashSet<&str> =
+        bundle.contests.iter().map(|c| c.id.as_str()).collect();
+    let area_ids: HashSet<&str> =
+        bundle.areas.iter().map(|a| a.id.as_str()).collect();
+
+    for (index, contest) in bundle.contests.iter().enumerate() {
+        if !election_ids.contains(contest.election_id.as_str()) {
+            report.push(
+                Problem::error(
+                    Code::DanglingReference,
+                    format!("contests[{index}].election_id"),
+                    "points at an election that is not in the bundle",
+                )
+                .about(contest.external_id.as_deref()),
+            );
+        }
+    }
+
+    for (index, candidate) in bundle.candidates.iter().enumerate() {
+        match candidate.contest_id.as_deref() {
+            None => report.push(
+                Problem::error(
+                    Code::MissingField,
+                    format!("candidates[{index}].contest_id"),
+                    "a candidate must belong to a contest",
+                )
+                .about(candidate.external_id.as_deref()),
+            ),
+            Some(id) if !contest_ids.contains(id) => report.push(
+                Problem::error(
+                    Code::DanglingReference,
+                    format!("candidates[{index}].contest_id"),
+                    "points at a contest that is not in the bundle",
+                )
+                .about(candidate.external_id.as_deref()),
+            ),
+            Some(_) => {}
+        }
+    }
+
+    for (index, link) in bundle.area_contests.iter().enumerate() {
+        if !area_ids.contains(link.area_id.as_str()) {
+            report.push(Problem::error(
+                Code::DanglingReference,
+                format!("area_contests[{index}].area_id"),
+                "points at an area that is not in the bundle",
+            ));
+        }
+        if !contest_ids.contains(link.contest_id.as_str()) {
+            report.push(Problem::error(
+                Code::DanglingReference,
+                format!("area_contests[{index}].contest_id"),
+                "points at a contest that is not in the bundle",
+            ));
+        }
+    }
+}
+
+fn check_area_tree(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    let parents: HashMap<&str, Option<&str>> = bundle
+        .areas
+        .iter()
+        .map(|area| (area.id.as_str(), area.parent_id.as_deref()))
+        .collect();
+
+    for (index, area) in bundle.areas.iter().enumerate() {
+        let Some(parent) = area.parent_id.as_deref() else {
+            continue;
+        };
+
+        if !parents.contains_key(parent) {
+            report.push(Problem::error(
+                Code::DanglingReference,
+                format!("areas[{index}].parent_id"),
+                "points at a parent area that is not in the bundle",
+            ));
+            continue;
+        }
+
+        // An infinite tree hangs the Admin Portal rather than failing the import.
+        let mut seen: HashSet<&str> = HashSet::from([area.id.as_str()]);
+        let mut cursor = Some(parent);
+        while let Some(current) = cursor {
+            if !seen.insert(current) {
+                report.push(Problem::error(
+                    Code::AreaCycle,
+                    format!("areas[{index}].parent_id"),
+                    format!(
+                        "area '{}' is part of a parent cycle",
+                        area.name.as_deref().unwrap_or(&area.id)
+                    ),
+                ));
+                break;
+            }
+            cursor = parents.get(current).copied().flatten();
+        }
+    }
+}
+
+fn check_contests(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    let mut candidates_per_contest: HashMap<&str, usize> = HashMap::new();
+    for candidate in &bundle.candidates {
+        if let Some(contest_id) = candidate.contest_id.as_deref() {
+            *candidates_per_contest.entry(contest_id).or_insert(0) += 1;
+        }
+    }
+
+    for (index, contest) in bundle.contests.iter().enumerate() {
+        let path = |field: &str| format!("contests[{index}].{field}");
+        let about = contest.external_id.as_deref();
+
+        let min_votes = contest.min_votes;
+        let max_votes = contest.max_votes;
+        let winners = contest.winning_candidates_num;
+
+        for (field, value) in [
+            ("min_votes", min_votes),
+            ("max_votes", max_votes),
+            ("winning_candidates_num", winners),
+        ] {
+            if value.is_none() {
+                report.push(
+                    Problem::error(
+                        Code::MissingField,
+                        path(field),
+                        format!("a contest needs {field}"),
+                    )
+                    .about(about),
+                );
+            }
+        }
+
+        if let (Some(min), Some(max)) = (min_votes, max_votes) {
+            if min > max {
+                report.push(
+                    Problem::error(
+                        Code::ContestArithmetic,
+                        path("min_votes"),
+                        format!("min_votes {min} is above max_votes {max}"),
+                    )
+                    .about(about),
+                );
+            }
+        }
+
+        let voting_type = contest.voting_type.as_deref();
+        match voting_type {
+            Some(value) if VOTING_TYPES.contains(&value) => {}
+            other => report.push(
+                Problem::error(
+                    Code::InvalidValue,
+                    path("voting_type"),
+                    format!(
+                        "{} is not a voting type; expected one of {}",
+                        other
+                            .map(|v| format!("'{v}'"))
+                            .unwrap_or("nothing".into()),
+                        VOTING_TYPES.join(", ")
+                    ),
+                )
+                .about(about),
+            ),
+        }
+
+        let algorithm = contest.counting_algorithm.as_deref();
+        match algorithm {
+            Some(value) if COUNTING_ALGORITHMS.contains(&value) => {
+                let preferential = PREFERENTIAL_ALGORITHMS.contains(&value);
+                match voting_type {
+                    Some("preferential") if !preferential => report.push(
+                        Problem::error(
+                            Code::TallyMismatch,
+                            path("counting_algorithm"),
+                            format!(
+                                "a preferential contest counted by '{value}', which \
+                                 ignores rankings"
+                            ),
+                        )
+                        .about(about),
+                    ),
+                    Some("non-preferential") if preferential => report.push(
+                        Problem::error(
+                            Code::TallyMismatch,
+                            path("counting_algorithm"),
+                            format!(
+                                "a non-preferential contest counted by '{value}', \
+                                 which needs ranked ballots"
+                            ),
+                        )
+                        .about(about),
+                    ),
+                    _ => {}
+                }
+            }
+            other => report.push(
+                Problem::error(
+                    Code::InvalidValue,
+                    path("counting_algorithm"),
+                    format!(
+                        "{} is not a counting algorithm; expected one of {}",
+                        other
+                            .map(|v| format!("'{v}'"))
+                            .unwrap_or("nothing".into()),
+                        COUNTING_ALGORITHMS.join(", ")
+                    ),
+                )
+                .about(about),
+            ),
+        }
+
+        let available = candidates_per_contest
+            .get(contest.id.as_str())
+            .copied()
+            .unwrap_or(0);
+        if available == 0 {
+            report.push(
+                Problem::error(
+                    Code::BallotCoverage,
+                    path("id"),
+                    "the contest has no candidates",
+                )
+                .about(about),
+            );
+        } else {
+            if let Some(winners) = winners {
+                if winners > available as i64 {
+                    report.push(
+                        Problem::error(
+                            Code::ContestArithmetic,
+                            path("winning_candidates_num"),
+                            format!(
+                                "elects {winners} of {available} candidates"
+                            ),
+                        )
+                        .about(about),
+                    );
+                }
+            }
+            if let Some(max) = max_votes {
+                if max > available as i64 {
+                    report.push(
+                        Problem::error(
+                            Code::ContestArithmetic,
+                            path("max_votes"),
+                            format!("allows {max} selections among {available} candidates"),
+                        )
+                        .about(about),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn check_ballot_coverage(
+    bundle: &ImportElectionEventSchema,
+    report: &mut Report,
+) {
+    // Neither of these breaks the import. Both mean somebody's vote is missing on
+    // election day, which is the most expensive time to find out.
+    let linked_contests: HashSet<&str> = bundle
+        .area_contests
+        .iter()
+        .map(|link| link.contest_id.as_str())
+        .collect();
+    let linked_areas: HashSet<&str> = bundle
+        .area_contests
+        .iter()
+        .map(|link| link.area_id.as_str())
+        .collect();
+    let parents: HashSet<&str> = bundle
+        .areas
+        .iter()
+        .filter_map(|area| area.parent_id.as_deref())
+        .collect();
+
+    for (index, contest) in bundle.contests.iter().enumerate() {
+        if !linked_contests.contains(contest.id.as_str()) {
+            report.push(
+                Problem::error(
+                    Code::BallotCoverage,
+                    format!("contests[{index}]"),
+                    "appears on no area's ballot, so nobody can vote in it",
+                )
+                .about(contest.external_id.as_deref()),
+            );
+        }
+    }
+
+    for (index, area) in bundle.areas.iter().enumerate() {
+        // A parent area is a grouping; only leaf areas carry a ballot.
+        if linked_areas.contains(area.id.as_str())
+            || parents.contains(area.id.as_str())
+        {
+            continue;
+        }
+        report.push(Problem::error(
+            Code::BallotCoverage,
+            format!("areas[{index}]"),
+            format!(
+                "area '{}' has no contests and is not a parent of another area, so \
+                 its voters would see an empty ballot",
+                area.name.as_deref().unwrap_or(&area.id)
+            ),
+        ));
+    }
+}
+
+fn check_permission_labels(
+    bundle: &ImportElectionEventSchema,
+    report: &mut Report,
+) {
+    // Hasura filters election and report on
+    //   permission_label IS NULL OR permission_label IN X-Hasura-Permission-Labels
+    // so an entity carrying a label is invisible to every administrator who does
+    // not hold it — including whoever runs the import. The bundle cannot know who
+    // holds what, so this is a warning naming the label rather than a refusal.
+    let mut labels: Vec<String> = Vec::new();
+
+    for election in &bundle.elections {
+        if let Some(label) = election.permission_label.as_deref() {
+            if !label.trim().is_empty()
+                && !labels.iter().any(|seen| seen == label)
+            {
+                labels.push(label.to_string());
+            }
+        }
+    }
+    for report_definition in &bundle.reports {
+        for label in report_definition.permission_label.iter().flatten() {
+            if !label.trim().is_empty()
+                && !labels.iter().any(|seen| seen == label)
+            {
+                labels.push(label.clone());
+            }
+        }
+    }
+
+    if !labels.is_empty() {
+        report.push(Problem::warning(
+            Code::PermissionLabel,
+            "elections[].permission_label",
+            format!(
+                "permission labels in use: {}. Anything carrying a label is hidden \
+                 from every administrator without it, so whoever imports this needs \
+                 one of them on their own 'permission_labels' attribute or the Admin \
+                 Portal will show them an empty list.",
+                labels.join(", ")
+            ),
+        ));
+    }
+}
+
+fn check_unique_ids(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    // Two entities sharing an id means one silently overwrites the other. The ids
+    // are checked across every collection at once, not per collection: a contest
+    // and an area sharing one collides just as badly.
+    let groups: [(&str, Vec<&str>); 5] = [
+        (
+            "elections",
+            bundle.elections.iter().map(|e| e.id.as_str()).collect(),
+        ),
+        (
+            "contests",
+            bundle.contests.iter().map(|c| c.id.as_str()).collect(),
+        ),
+        (
+            "candidates",
+            bundle.candidates.iter().map(|c| c.id.as_str()).collect(),
+        ),
+        (
+            "areas",
+            bundle.areas.iter().map(|a| a.id.as_str()).collect(),
+        ),
+        (
+            "area_contests",
+            bundle.area_contests.iter().map(|l| l.id.as_str()).collect(),
+        ),
+    ];
+
+    let mut seen: HashMap<&str, &str> = HashMap::new();
+    for (kind, ids) in &groups {
+        for id in ids {
+            if let Some(previous) = seen.insert(id, kind) {
+                report.push(Problem::error(
+                    Code::DuplicateId,
+                    *kind,
+                    format!("id {id} is also used by {previous}"),
+                ));
+            }
+        }
+    }
+}
+
+/// Whether a string is shaped like a hyphenated UUID.
+///
+/// Deliberately not `Uuid::parse_str`: that crate is only enabled by the
+/// `keycloak` feature here, and pulling it into `default_features` would put
+/// `getrandom` in the WASM build to check a string's shape.
+fn looks_like_uuid(value: &str) -> bool {
+    let groups: Vec<&str> = value.split('-').collect();
+    groups.len() == 5
+        && [8usize, 4, 4, 4, 12]
+            .iter()
+            .zip(&groups)
+            .all(|(expected, group)| {
+                group.len() == *expected
+                    && group
+                        .chars()
+                        .all(|character| character.is_ascii_hexdigit())
+            })
+}

--- a/packages/sequent-core/src/election_config/validate_tests.rs
+++ b/packages/sequent-core/src/election_config/validate_tests.rs
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super::validate`].
+//!
+//! Each starts from a bundle that passes and breaks exactly one thing, so a
+//! failure names the rule rather than a pile of unrelated problems. The builder
+//! below is deliberately the smallest bundle that validates cleanly — if it ever
+//! stops doing so, [`a_sound_bundle_has_no_errors`] fails first and says why.
+
+use super::problem::{Code, Severity};
+use super::schema::ImportElectionEventSchema;
+use super::validate::validate;
+
+const TENANT: &str = "3f0c9d21-7b4e-4a55-9c3a-1d2e5f6a7b80";
+
+/// A bundle that validates cleanly: one election, one contest with two
+/// candidates, a parent area and a leaf that carries the ballot.
+fn sound() -> ImportElectionEventSchema {
+    let json = serde_json::json!({
+        "tenant_id": TENANT,
+        "keycloak_event_realm": null,
+        "election_event": {
+            "id": "e0000000-0000-5000-8000-000000000000",
+            "tenant_id": TENANT,
+            "is_archived": false,
+            "encryption_protocol": "RSA256"
+        },
+        "elections": [{
+            "id": "e1000000-0000-5000-8000-000000000000",
+            "tenant_id": TENANT,
+            "election_event_id": "e0000000-0000-5000-8000-000000000000",
+            "external_id": "officers"
+        }],
+        "contests": [{
+            "id": "c1000000-0000-5000-8000-000000000000",
+            "tenant_id": TENANT,
+            "election_event_id": "e0000000-0000-5000-8000-000000000000",
+            "election_id": "e1000000-0000-5000-8000-000000000000",
+            "external_id": "president",
+            "min_votes": 0,
+            "max_votes": 1,
+            "winning_candidates_num": 1,
+            "voting_type": "non-preferential",
+            "counting_algorithm": "plurality-at-large"
+        }],
+        "candidates": [
+            {
+                "id": "d1000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "contest_id": "c1000000-0000-5000-8000-000000000000",
+                "external_id": "pres-a"
+            },
+            {
+                "id": "d2000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "contest_id": "c1000000-0000-5000-8000-000000000000",
+                "external_id": "pres-b"
+            }
+        ],
+        "areas": [
+            {
+                "id": "a1000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "name": "North Region"
+            },
+            {
+                "id": "a2000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "name": "North Local 1",
+                "parent_id": "a1000000-0000-5000-8000-000000000000"
+            }
+        ],
+        "area_contests": [{
+            "id": "b1000000-0000-5000-8000-000000000000",
+            "area_id": "a2000000-0000-5000-8000-000000000000",
+            "contest_id": "c1000000-0000-5000-8000-000000000000"
+        }],
+        "scheduled_events": null,
+        "reports": [],
+        "keys_ceremonies": [],
+        "applications": []
+    });
+    serde_json::from_value(json).expect("the sound fixture should deserialize")
+}
+
+/// Every error code the report carries, for terse assertions.
+fn error_codes(bundle: &ImportElectionEventSchema) -> Vec<Code> {
+    validate(bundle)
+        .problems
+        .iter()
+        .filter(|problem| problem.severity == Severity::Error)
+        .map(|problem| problem.code)
+        .collect()
+}
+
+#[test]
+fn a_sound_bundle_has_no_errors() {
+    let report = validate(&sound());
+    assert!(
+        !report.has_errors(),
+        "the fixture should validate cleanly, but got:\n{report}"
+    );
+}
+
+// -- identity ---------------------------------------------------------------
+
+#[test]
+fn a_malformed_tenant_id_is_reported_readably() {
+    // The schema carries this as a String so the module stays WASM-safe; this is
+    // the check that replaces the one a Uuid field used to do at parse time.
+    let mut bundle = sound();
+    bundle.tenant_id = "not-a-uuid".into();
+    assert!(error_codes(&bundle).contains(&Code::InvalidValue));
+}
+
+#[test]
+fn an_empty_tenant_id_is_reported_as_missing_not_malformed() {
+    let mut bundle = sound();
+    bundle.tenant_id = "  ".into();
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+#[test]
+fn a_uuid_is_accepted_in_any_case() {
+    let mut bundle = sound();
+    bundle.tenant_id = TENANT.to_uppercase();
+    assert!(!validate(&bundle).has_errors());
+}
+
+#[test]
+fn an_event_with_no_elections_is_rejected() {
+    let mut bundle = sound();
+    bundle.elections.clear();
+    bundle.contests.clear();
+    bundle.candidates.clear();
+    bundle.area_contests.clear();
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+// -- references -------------------------------------------------------------
+
+#[test]
+fn a_contest_pointing_at_no_election_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].election_id =
+        "f0000000-0000-5000-8000-000000000000".into();
+    assert!(error_codes(&bundle).contains(&Code::DanglingReference));
+}
+
+#[test]
+fn a_candidate_pointing_at_no_contest_is_rejected() {
+    let mut bundle = sound();
+    bundle.candidates[0].contest_id =
+        Some("f0000000-0000-5000-8000-000000000000".into());
+    assert!(error_codes(&bundle).contains(&Code::DanglingReference));
+}
+
+#[test]
+fn a_candidate_with_no_contest_at_all_is_rejected() {
+    let mut bundle = sound();
+    bundle.candidates[0].contest_id = None;
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+#[test]
+fn a_problem_names_the_external_id_not_the_uuid() {
+    // Import regenerates every UUID, so the id in the bundle means nothing to
+    // whoever has to fix the source. The external_id is what they typed.
+    let mut bundle = sound();
+    bundle.contests[0].election_id =
+        "f0000000-0000-5000-8000-000000000000".into();
+    let report = validate(&bundle);
+    let problem = report
+        .problems
+        .iter()
+        .find(|problem| problem.code == Code::DanglingReference)
+        .expect("expected a dangling reference");
+    assert_eq!(problem.external_id.as_deref(), Some("president"));
+    assert_eq!(problem.path, "contests[0].election_id");
+}
+
+// -- area tree --------------------------------------------------------------
+
+#[test]
+fn an_area_pointing_at_no_parent_is_rejected() {
+    let mut bundle = sound();
+    bundle.areas[1].parent_id =
+        Some("f0000000-0000-5000-8000-000000000000".into());
+    assert!(error_codes(&bundle).contains(&Code::DanglingReference));
+}
+
+#[test]
+fn an_area_cycle_is_rejected() {
+    // An infinite tree hangs the Admin Portal rather than failing the import.
+    let mut bundle = sound();
+    let leaf = bundle.areas[1].id.clone();
+    bundle.areas[0].parent_id = Some(leaf);
+    assert!(error_codes(&bundle).contains(&Code::AreaCycle));
+}
+
+#[test]
+fn an_area_that_is_its_own_parent_is_rejected() {
+    let mut bundle = sound();
+    let own = bundle.areas[1].id.clone();
+    bundle.areas[1].parent_id = Some(own);
+    assert!(error_codes(&bundle).contains(&Code::AreaCycle));
+}
+
+// -- contest arithmetic -----------------------------------------------------
+
+#[test]
+fn min_votes_above_max_votes_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].min_votes = Some(2);
+    assert!(error_codes(&bundle).contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn a_contest_missing_a_vote_count_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].max_votes = None;
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+#[test]
+fn electing_more_winners_than_there_are_candidates_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].winning_candidates_num = Some(5);
+    bundle.contests[0].max_votes = Some(5);
+    assert!(error_codes(&bundle).contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn allowing_more_selections_than_there_are_candidates_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].max_votes = Some(9);
+    assert!(error_codes(&bundle).contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn a_negative_vote_count_does_not_wrap_into_a_huge_number() {
+    // i64 to usize would make -1 enormous and silently pass the comparison.
+    let mut bundle = sound();
+    bundle.contests[0].winning_candidates_num = Some(-1);
+    let codes = error_codes(&bundle);
+    assert!(!codes.contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn a_contest_with_no_candidates_is_rejected() {
+    let mut bundle = sound();
+    bundle.candidates.clear();
+    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+}
+
+// -- tally system -----------------------------------------------------------
+
+#[test]
+fn an_unknown_counting_algorithm_is_rejected() {
+    // single-transferable-vote is not a CountingAlgType variant, however
+    // plausible it sounds.
+    let mut bundle = sound();
+    bundle.contests[0].counting_algorithm =
+        Some("single-transferable-vote".into());
+    assert!(error_codes(&bundle).contains(&Code::InvalidValue));
+}
+
+#[test]
+fn an_unknown_voting_type_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].voting_type = Some("ranked".into());
+    assert!(error_codes(&bundle).contains(&Code::InvalidValue));
+}
+
+#[test]
+fn preferential_counted_by_plurality_is_rejected() {
+    // Imports cleanly and then tallies wrongly: ballot encoding follows the
+    // algorithm, so the rankings a voter entered are read as unordered picks.
+    let mut bundle = sound();
+    bundle.contests[0].voting_type = Some("preferential".into());
+    assert!(error_codes(&bundle).contains(&Code::TallyMismatch));
+}
+
+#[test]
+fn non_preferential_counted_by_irv_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].counting_algorithm = Some("instant-runoff".into());
+    assert!(error_codes(&bundle).contains(&Code::TallyMismatch));
+}
+
+#[test]
+fn every_preferential_algorithm_is_accepted_with_ranked_voting() {
+    for algorithm in super::validate::PREFERENTIAL_ALGORITHMS {
+        let mut bundle = sound();
+        bundle.contests[0].voting_type = Some("preferential".into());
+        bundle.contests[0].counting_algorithm = Some((*algorithm).into());
+        assert!(
+            !validate(&bundle).has_errors(),
+            "{algorithm} should be valid for a preferential contest"
+        );
+    }
+}
+
+#[test]
+fn every_non_preferential_algorithm_is_accepted_with_unranked_voting() {
+    let preferential = super::validate::PREFERENTIAL_ALGORITHMS;
+    for algorithm in super::validate::COUNTING_ALGORITHMS {
+        if preferential.contains(algorithm) {
+            continue;
+        }
+        let mut bundle = sound();
+        bundle.contests[0].counting_algorithm = Some((*algorithm).into());
+        assert!(
+            !validate(&bundle).has_errors(),
+            "{algorithm} should be valid for a non-preferential contest"
+        );
+    }
+}
+
+// -- ballot coverage --------------------------------------------------------
+
+#[test]
+fn a_contest_on_no_ballot_is_rejected() {
+    // Does not break the import; means nobody can vote in it.
+    let mut bundle = sound();
+    bundle.area_contests.clear();
+    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+}
+
+#[test]
+fn a_leaf_area_with_no_ballot_is_rejected() {
+    let mut bundle = sound();
+    let orphan = bundle.areas[1].clone();
+    let mut orphan = orphan;
+    orphan.id = "a3000000-0000-5000-8000-000000000000".into();
+    orphan.name = Some("Nowhere".into());
+    orphan.parent_id = None;
+    bundle.areas.push(orphan);
+
+    let report = validate(&bundle);
+    assert!(report
+        .problems
+        .iter()
+        .any(|problem| problem.code == Code::BallotCoverage
+            && problem.message.contains("Nowhere")));
+}
+
+#[test]
+fn a_parent_area_needs_no_ballot_of_its_own() {
+    // A parent is a grouping; only leaves carry contests. The sound fixture has
+    // one, so this is really asserting the fixture stays representative.
+    assert!(!validate(&sound()).has_errors());
+}
+
+// -- permission labels ------------------------------------------------------
+
+#[test]
+fn a_permission_label_is_a_warning_not_an_error() {
+    // The bundle cannot know who holds which label, so this must not block a
+    // build — but it is the single most expensive thing to discover after import.
+    let mut bundle = sound();
+    bundle.elections[0].permission_label = Some("officers".into());
+
+    let report = validate(&bundle);
+    assert!(!report.has_errors());
+    assert_eq!(
+        report
+            .warnings()
+            .filter(|problem| problem.code == Code::PermissionLabel)
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn the_warning_names_the_labels_in_use() {
+    let mut bundle = sound();
+    bundle.elections[0].permission_label = Some("officers".into());
+    let report = validate(&bundle);
+    let warning = report
+        .warnings()
+        .find(|problem| problem.code == Code::PermissionLabel)
+        .expect("expected a permission label warning");
+    assert!(warning.message.contains("officers"));
+}
+
+#[test]
+fn no_labels_means_no_warning() {
+    assert_eq!(
+        validate(&sound())
+            .warnings()
+            .filter(|problem| problem.code == Code::PermissionLabel)
+            .count(),
+        0
+    );
+}
+
+// -- identifiers ------------------------------------------------------------
+
+#[test]
+fn two_entities_sharing_an_id_are_rejected() {
+    let mut bundle = sound();
+    let duplicate = bundle.candidates[0].id.clone();
+    bundle.candidates[1].id = duplicate;
+    assert!(error_codes(&bundle).contains(&Code::DuplicateId));
+}
+
+#[test]
+fn an_id_shared_across_collections_is_rejected() {
+    // A contest and an area colliding is just as bad as two contests colliding.
+    let mut bundle = sound();
+    let contest_id = bundle.contests[0].id.clone();
+    bundle.areas[0].id = contest_id;
+    assert!(error_codes(&bundle).contains(&Code::DuplicateId));
+}
+
+// -- reporting --------------------------------------------------------------
+
+#[test]
+fn every_problem_is_reported_not_just_the_first() {
+    // Fixing a configuration one error per run is miserable.
+    let mut bundle = sound();
+    bundle.tenant_id = "nope".into();
+    bundle.contests[0].voting_type = Some("ranked".into());
+    bundle.contests[0].min_votes = Some(99);
+    assert!(error_codes(&bundle).len() >= 3);
+}
+
+#[test]
+fn the_report_serializes_for_a_front_end() {
+    let mut bundle = sound();
+    bundle.contests[0].counting_algorithm = Some("nonsense".into());
+    let report = validate(&bundle);
+    let json = serde_json::to_value(&report).unwrap();
+    let first = &json["problems"][0];
+    assert!(first["code"].is_string());
+    assert!(first["severity"].is_string());
+    assert!(first["path"].is_string());
+    assert!(first["message"].is_string());
+}


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2961.** Base branch is
`feat/meta-12769-schema/main`, so this diff shows only what is added on top.

The pure half of checking an import bundle — no database, no IO, no clock. That is
what lets the same code answer in a browser before an upload and on the server
before a transaction. Anything needing the database (does this tenant exist, is
this area name taken) stays in windmill on top of this pass.

```rust
let report = sequent_core::election_config::validate(&bundle);
if report.has_errors() { … }
```

## What a Problem carries

| Field | Why |
|---|---|
| `code` | Machine-readable, so a front end can group, translate or link without matching English |
| `severity` | Error or Warning — see below |
| `path` | `contests[2].max_votes`, dotted into the bundle |
| `external_id` | The UUIDs are regenerated on import and mean nothing to whoever fixes the source; the `external_id` is what they typed |

Never stops at the first problem: fixing a configuration one error per run is
miserable.

## Warnings are not lesser errors

A warning says the bundle is self-consistent but probably not what its author
meant. The one that exists today is the expensive one: **a permission label hides
an entity from every administrator who does not hold it**, so an event imports
cleanly and then lists nothing. That is exactly what happened on the first real
SEIU import. The bundle cannot know who holds which label, so it cannot be an
error — but it must be said.

## The rules

From what the importer rejects, and from what janitor learned the hard way. The
second kind matters more: those bundles satisfy every type in the schema and still
fail on election day.

- **Identity** — tenant id present and UUID-shaped, event id and encryption
  protocol present, at least one election and one area.
- **References** — contests to elections, candidates to contests, area/contest
  links both ways.
- **Area tree** — parents exist, no cycles. An infinite tree hangs the Admin
  Portal rather than failing the import.
- **Contest arithmetic** — `min_votes` ≤ `max_votes`, winners and selections
  within the candidate count, vote counts present.
- **Tally system** — `voting_type` and `counting_algorithm` must agree. Ballot
  encoding follows the *algorithm*, so a preferential contest counted by
  `plurality-at-large` imports cleanly and then reads a voter's rankings as
  unordered selections.
- **Ballot coverage** — no contest on nobody's ballot, no leaf area with an empty
  one. Neither breaks the import; both mean somebody's vote is missing.
- **Permission labels** — the warning above.
- **Identifiers** — unique across every collection, not just within one. A contest
  and an area colliding is just as bad as two contests colliding.

`tenant_id`'s format is checked here rather than by its type — what the schema
traded away to stay WASM-safe. `looks_like_uuid` checks the shape rather than
pulling the `uuid` crate, and therefore `getrandom`, into the WASM build to inspect
a string.

## Tests — 50

Each starts from one bundle that validates cleanly and breaks exactly one thing, so
a failure names the rule rather than producing a pile of unrelated problems. If the
fixture ever stops validating, `a_sound_bundle_has_no_errors` fails first and says
why.

Two are about the failure modes of the checks themselves rather than of a bundle:

- a negative `winning_candidates_num` must not wrap into a huge `usize` and
  silently pass — the first draft had `winners as usize > available`;
- every algorithm in each list is exercised against the voting type it belongs
  with, rather than a sampled few.

## Verified

- `cargo check -p sequent-core --features default_features` and `-p windmill` clean.
- `cargo test -p sequent-core --lib --features default_features election_config` — 50 passed.
- `cargo fmt --check` clean.

## Next on the stack

windmill calling this before its transaction, so the server and the browser reach
the same verdict from the same code.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

`<empty>` — no user-visible change yet; nothing calls this until the next PR.
