### PR TITLE
✨ Validate an import bundle with the shared rules before importing it

### DIFF
--- a/packages/sequent-core/examples/validate_bundle.rs
+++ b/packages/sequent-core/examples/validate_bundle.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Validate an election event bundle from a file.
+//!
+//! `cargo run -p sequent-core --features default_features --example validate_bundle -- <path>`
+//!
+//! A thin harness for checking a real export against the shared rules; the same
+//! call step-cli and the browser make.
+
+use sequent_core::election_config::{validate, ImportElectionEventSchema};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args()
+        .nth(1)
+        .ok_or("usage: validate_bundle <path>")?;
+    let text = std::fs::read_to_string(&path)?;
+    let bundle: ImportElectionEventSchema = serde_json::from_str(&text)?;
+
+    let report = validate(&bundle);
+    print!("{report}");
+    println!(
+        "{} error(s), {} warning(s)",
+        report.errors().count(),
+        report.warnings().count()
+    );
+    if report.has_errors() {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/packages/sequent-core/src/election_config/validate.rs
+++ b/packages/sequent-core/src/election_config/validate.rs
@@ -343,10 +343,10 @@ fn check_contests(bundle: &ImportElectionEventSchema, report: &mut Report) {
             .unwrap_or(0);
         if available == 0 {
             report.push(
-                Problem::error(
+                Problem::warning(
                     Code::BallotCoverage,
                     path("id"),
-                    "the contest has no candidates",
+                    "the contest has no candidates, so nobody can vote in it",
                 )
                 .about(about),
             );
@@ -406,7 +406,7 @@ fn check_ballot_coverage(
     for (index, contest) in bundle.contests.iter().enumerate() {
         if !linked_contests.contains(contest.id.as_str()) {
             report.push(
-                Problem::error(
+                Problem::warning(
                     Code::BallotCoverage,
                     format!("contests[{index}]"),
                     "appears on no area's ballot, so nobody can vote in it",
@@ -423,7 +423,7 @@ fn check_ballot_coverage(
         {
             continue;
         }
-        report.push(Problem::error(
+        report.push(Problem::warning(
             Code::BallotCoverage,
             format!("areas[{index}]"),
             format!(

--- a/packages/sequent-core/src/election_config/validate_tests.rs
+++ b/packages/sequent-core/src/election_config/validate_tests.rs
@@ -253,10 +253,16 @@ fn a_negative_vote_count_does_not_wrap_into_a_huge_number() {
 }
 
 #[test]
-fn a_contest_with_no_candidates_is_rejected() {
+fn a_contest_with_no_candidates_is_a_warning_not_an_error() {
+    // An event still being configured has these, and the platform's own export of
+    // one has to re-import. See the round-trip test at the bottom.
     let mut bundle = sound();
     bundle.candidates.clear();
-    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+    let report = validate(&bundle);
+    assert!(!report.has_errors());
+    assert!(report
+        .warnings()
+        .any(|problem| problem.code == Code::BallotCoverage));
 }
 
 // -- tally system -----------------------------------------------------------
@@ -326,15 +332,19 @@ fn every_non_preferential_algorithm_is_accepted_with_unranked_voting() {
 // -- ballot coverage --------------------------------------------------------
 
 #[test]
-fn a_contest_on_no_ballot_is_rejected() {
+fn a_contest_on_no_ballot_is_a_warning_not_an_error() {
     // Does not break the import; means nobody can vote in it.
     let mut bundle = sound();
     bundle.area_contests.clear();
-    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+    let report = validate(&bundle);
+    assert!(!report.has_errors());
+    assert!(report
+        .warnings()
+        .any(|problem| problem.code == Code::BallotCoverage));
 }
 
 #[test]
-fn a_leaf_area_with_no_ballot_is_rejected() {
+fn a_leaf_area_with_no_ballot_is_a_warning_not_an_error() {
     let mut bundle = sound();
     let orphan = bundle.areas[1].clone();
     let mut orphan = orphan;
@@ -344,9 +354,9 @@ fn a_leaf_area_with_no_ballot_is_rejected() {
     bundle.areas.push(orphan);
 
     let report = validate(&bundle);
+    assert!(!report.has_errors());
     assert!(report
-        .problems
-        .iter()
+        .warnings()
         .any(|problem| problem.code == Code::BallotCoverage
             && problem.message.contains("Nowhere")));
 }
@@ -443,4 +453,40 @@ fn the_report_serializes_for_a_front_end() {
     assert!(first["severity"].is_string());
     assert!(first["path"].is_string());
     assert!(first["message"].is_string());
+}
+
+// -- round tripping ---------------------------------------------------------
+
+#[test]
+fn an_event_still_being_configured_can_be_re_imported() {
+    // The property that decides where the severity line falls. windmill refuses an
+    // import on errors, so anything the platform can itself export must validate
+    // without them — otherwise this check breaks disaster recovery to enforce a
+    // rule about authoring.
+    //
+    // A half-built event: a contest with no candidates yet, one not yet on a
+    // ballot, and an area nobody has assigned contests to.
+    let mut bundle = sound();
+    bundle.candidates.clear();
+    bundle.area_contests.clear();
+
+    let report = validate(&bundle);
+    assert!(
+        !report.has_errors(),
+        "a mid-configuration export must still import, but got:\n{report}"
+    );
+    assert!(
+        !report.is_empty(),
+        "it should still be reported, just not fatally"
+    );
+}
+
+#[test]
+fn an_inconsistent_bundle_is_still_refused() {
+    // The other side of that line: warnings are for consistent-but-odd, not for
+    // anything goes.
+    let mut bundle = sound();
+    bundle.candidates[0].contest_id =
+        Some("f0000000-0000-5000-8000-000000000000".into());
+    assert!(validate(&bundle).has_errors());
 }

--- a/packages/windmill/src/services/import/import_election_event.rs
+++ b/packages/windmill/src/services/import/import_election_event.rs
@@ -123,6 +123,7 @@ use sequent_core::util::temp_path::{generate_temp_file, get_file_size};
 //   keycloak_event_realm serde_json::Value, not RealmRepresentation. That type
 //                        comes from the keycloak crate, which pulls reqwest.
 //                        Deserialized into the typed form where it is used.
+use sequent_core::election_config;
 pub use sequent_core::election_config::ImportElectionEventSchema;
 
 #[instrument(err)]
@@ -580,7 +581,45 @@ pub async fn get_election_event_schema(
         .map_err(|_| anyhow!("Environment variable {ENV_VAR_APP_VERSION} should be set"))?;
     check_version_compatibility(imported_version, &current_version)?;
     let original_data: ImportElectionEventSchema = deserialize_str(data_str)?;
+    check_bundle(&original_data)?;
     replace_ids(data_str, &original_data, event_id, tenant_id.clone())
+}
+
+/// Run the shared validation, refusing the import if it found anything fatal.
+///
+/// The same code answers in the browser before an upload, so a bundle the
+/// configuration tools accepted reaches this and passes. When one does not, the
+/// operator gets every problem at once rather than the first — and the same
+/// wording they would have seen client-side.
+///
+/// Validates the bundle as written, before `replace_ids` rewrites the
+/// identifiers: a problem naming an id the author never chose is not much use to
+/// them.
+///
+/// This is deliberately additive. It does not replace the checks that follow —
+/// those need the database, and this pass by design does not touch it.
+#[instrument(err, skip_all)]
+fn check_bundle(data: &ImportElectionEventSchema) -> Result<()> {
+    let report = election_config::validate(data);
+
+    for problem in report.warnings() {
+        event!(Level::WARN, "election event import: {problem}");
+    }
+
+    if report.has_errors() {
+        let listing = report
+            .errors()
+            .map(|problem| format!("  {problem}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let count = report.errors().count();
+        let noun = if count == 1 { "problem" } else { "problems" };
+        return Err(anyhow!(
+            "The election event bundle cannot be imported; {count} {noun} found:\n{listing}"
+        ));
+    }
+
+    Ok(())
 }
 
 #[instrument(err, skip_all)]


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2962.** Base branch is
`feat/meta-12769-validate/main`, so this diff shows only what is added on top.

Makes the shared validation load-bearing: windmill runs it on the bundle before
importing, and refuses if anything fatal turns up. The operator gets every problem
at once, in the same wording the browser-side tools will show before an upload.

Validated as written, before `replace_ids` rewrites the identifiers — a problem
naming an id the author never chose is not much use to them.

Additive: the checks that follow need the database, and this pass by design does
not touch it. `check_only` is unaffected.

## The part that deserves scrutiny: ballot coverage is now a warning

Wiring validation into the import path means **a bundle that used to import can
now be refused** — including the platform's own export, re-imported for disaster
recovery.

Three rules were fatal and should not have been:

- a contest with no candidates yet,
- a contest not yet on any area's ballot,
- an area nobody has assigned contests to.

An event still being configured legitimately looks like that. Those bundles are
entirely self-consistent and import into a working event; they just mean nobody
votes there yet. Refusing them would break recovery in order to enforce a rule
about authoring, so they are warnings.

The line is now:

| | |
|---|---|
| **Error** | The bundle is internally inconsistent, or would be rejected or corrupted by the platform |
| **Warning** | The bundle is consistent, but the configuration looks unintended |

Authoring tools should treat warnings as blocking — `step-cli` and the SPAs will do
that with a strict mode, rather than by lying about the severity here. Two tests
pin the line from both sides: `an_event_still_being_configured_can_be_re_imported`
and `an_inconsistent_bundle_is_still_refused`.

## Checked against real data

Adds a `validate_bundle` example — the same call `step-cli` and the browser will
make — for checking an export from a shell:

```bash
cargo run -p sequent-core --features default_features --example validate_bundle -- export_election_event-….json
```

Run against the generated SEIU1000 bundle:

```
warning: elections[].permission_label: permission labels in use: statewide-officers,
dlc-officers-dburs, cburs. Anything carrying a label is hidden from every
administrator without it…
0 error(s), 1 warning(s)
```

That warning is the thing that made every election invisible on the first real
import of that event. The Rust validator and janitor's independently written
Python rules reach the same verdict on the same real bundle — which is the point of
sharing them.

## Verified

- `cargo check -p windmill` clean.
- `cargo test -p sequent-core --lib --features default_features election_config` — 52 passed.
- `cargo test -p windmill --lib` — 235 passed, 2 ignored, unchanged from `main`.
- `cargo fmt --check` clean on both crates.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

_To be added — the failure message an operator sees on a rejected import._
