### PR TITLE
✨ Read an authoring workbook in the shared core

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
  "attohttpc",
  "home",
  "log",
- "quick-xml",
+ "quick-xml 0.32.0",
  "rust-ini 0.21.3",
  "serde",
  "thiserror 1.0.69",
@@ -1762,6 +1762,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "calamine"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+dependencies = [
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "log",
+ "quick-xml 0.31.0",
+ "serde",
+ "zip 2.4.2",
+]
+
+[[package]]
 name = "cap-fs-ext"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -7724,6 +7749,16 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
@@ -8535,7 +8570,7 @@ dependencies = [
  "minidom",
  "native-tls",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.32.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9057,6 +9092,7 @@ dependencies = [
  "aws-smithy-types",
  "base64 0.22.1",
  "borsh",
+ "calamine",
  "cfg-if",
  "chrono",
  "console_error_panic_hook",
@@ -9113,6 +9149,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "web-sys",
+ "zip 2.4.2",
 ]
 
 [[package]]

--- a/packages/sequent-core/Cargo.toml
+++ b/packages/sequent-core/Cargo.toml
@@ -124,6 +124,10 @@ kuchiki = { version = "0.8", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 csv = "1.3.0"
 
+# reading authoring spreadsheets; optional so front ends with no workbook to read
+# do not carry it into their WASM bundle
+calamine = { version = "0.26", features = ["dates"], optional = true }
+
 
 # WASM plugin management
 wasmtime = {version = "41.0.2", optional = true}
@@ -132,6 +136,8 @@ wasmtime-wasi = {version = "41.0.2", optional = true}
 [dev-dependencies]
 ptree = "0.5"
 wasm-bindgen-test = "0.3.42"
+# writes the tiny .xlsx the reader's tests read, so no binary fixture is committed
+zip = "2.1"
 
 [features]
 wasmtest = ["wasm", "dep:web-sys", "strand/wasmtest"]
@@ -151,6 +157,10 @@ lambda_openwhisk = []
 lambda_aws_lambda = []
 plugins_wit = ["dep:wasmtime", "dep:wasmtime-wasi"]
 default_features = ["dep:strand", "dep:num-bigint", "dep:tempfile", "dep:ammonia"]
+# Reading .xlsx into an election_config::sheet::Workbook. Separate from
+# default_features because admin-portal and voting-portal have no workbook to
+# read and should not pay for a spreadsheet parser in their bundle.
+election_config_xlsx = ["default_features", "dep:calamine"]
 
 sqlite = ["dep:tokio", "dep:rusqlite"]
 time = ["dep:time"]

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -28,7 +28,13 @@ pub mod paths;
 pub mod problem;
 pub mod report;
 pub mod schema;
+pub mod sheet;
 pub mod validate;
+
+/// Reading `.xlsx`, behind its own feature so front ends with no workbook to read
+/// do not carry a spreadsheet library.
+#[cfg(feature = "election_config_xlsx")]
+pub mod xlsx;
 
 #[cfg(test)]
 mod validate_tests;
@@ -38,4 +44,5 @@ pub use paths::{coerce_cell, deep_merge, expand, Cell};
 pub use problem::{Code, Problem, Report as ValidationReport, Severity};
 pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};
 pub use schema::ImportElectionEventSchema;
+pub use sheet::{Origin, Row, Sheet, Workbook};
 pub use validate::validate;

--- a/packages/sequent-core/src/election_config/sheet.rs
+++ b/packages/sequent-core/src/election_config/sheet.rs
@@ -1,0 +1,772 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The shape of an authoring document: sheets of rows of coerced cells.
+//!
+//! One sheet per entity, header row first, one row per entity. This module does
+//! no interpretation beyond coercing cells and remembering where each row came
+//! from; resolving references and applying templates is a later step's job.
+//!
+//! Pure, and deliberately unaware of any spreadsheet library. Everything here
+//! works on [`Cell`]s, so a `.xlsx` reader, a CSV reader and a browser form all
+//! feed the same code — the `xlsx` module is the only one that needs a file
+//! format. Which means the whole of table shaping, the part with the awkward
+//! cases in it, is testable without a fixture file.
+//!
+//! Known gap: a problem found here carries its [`Origin`] flattened into
+//! `Problem::path`. A spreadsheet front end that wants to highlight the offending
+//! cell needs the sheet, row and column separately, which will mean a structured
+//! origin on `Problem` — worth doing when there is a UI to consume it, not
+//! before.
+
+use crate::election_config::paths::{coerce_cell, expand, Cell};
+use crate::election_config::problem::{Code, Problem};
+use serde_json::{Map, Value};
+use std::fmt;
+
+/// Sheet keys this module understands.
+///
+/// Normalised: case and internal whitespace are removed, so `Admin Users`,
+/// `admin users` and `AdminUsers` are one sheet. Authors rename tabs.
+pub const SHEET_ELECTION_EVENT: &str = "electionevent";
+pub const SHEET_ELECTIONS: &str = "elections";
+pub const SHEET_CONTESTS: &str = "contests";
+pub const SHEET_CANDIDATES: &str = "candidates";
+pub const SHEET_AREAS: &str = "areas";
+pub const SHEET_AREA_CONTESTS: &str = "areacontests";
+pub const SHEET_VOTERS: &str = "voters";
+pub const SHEET_SCHEDULED_EVENTS: &str = "scheduledevents";
+pub const SHEET_PARAMETERS: &str = "parameters";
+pub const SHEET_ADMIN_USERS: &str = "adminusers";
+pub const SHEET_PERMISSIONS: &str = "permissions";
+pub const SHEET_TEMPLATES: &str = "templates";
+pub const SHEET_REPORTS: &str = "reports";
+
+/// Every sheet that carries meaning. Anything else is reported as unread, which
+/// is how a renamed or misspelled tab gets noticed instead of silently ignored.
+pub const KNOWN_SHEETS: &[&str] = &[
+    SHEET_ELECTION_EVENT,
+    SHEET_ELECTIONS,
+    SHEET_CONTESTS,
+    SHEET_CANDIDATES,
+    SHEET_AREAS,
+    SHEET_AREA_CONTESTS,
+    SHEET_VOTERS,
+    SHEET_SCHEDULED_EVENTS,
+    SHEET_PARAMETERS,
+    SHEET_ADMIN_USERS,
+    SHEET_PERMISSIONS,
+    SHEET_TEMPLATES,
+    SHEET_REPORTS,
+];
+
+/// Columns whose cells hold `||`-separated lists, for one sheet.
+///
+/// Per sheet rather than global, because the same column name has different
+/// arity in different places: `Election::permission_label` is `Option<String>`
+/// while `Report::permission_label` is `Option<Vec<String>>`. Treating the name
+/// as multi-valued everywhere turns the first into a list and fails
+/// deserialization — which is exactly the bug this shape prevents.
+pub fn multi_value_columns(sheet_key: &str) -> &'static [&'static str] {
+    match sheet_key {
+        SHEET_VOTERS => &["authorized-election-ids"],
+        SHEET_ADMIN_USERS => &["permission_labels", "authorized-election-ids"],
+        SHEET_REPORTS => &["permission_label"],
+        _ => &[],
+    }
+}
+
+/// `"Admin Users"` -> `"adminusers"`.
+pub fn normalise_sheet_name(name: &str) -> String {
+    name.chars()
+        .filter(|character| !character.is_whitespace())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+/// Where in the source document something is, for a message someone can act on.
+///
+/// A bundle path like `elections[3].title` is no help to whoever has to fix the
+/// spreadsheet; the sheet name and the row number as the spreadsheet shows it
+/// are.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Origin {
+    pub sheet: String,
+    pub row: usize,
+    pub column: Option<String>,
+}
+
+impl fmt::Display for Origin {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "sheet '{}' row {}", self.sheet, self.row)?;
+        if let Some(column) = &self.column {
+            write!(formatter, " column '{column}'")?;
+        }
+        Ok(())
+    }
+}
+
+/// One entity's worth of cells, plus where it came from.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Row {
+    pub sheet: String,
+
+    /// Row number as the spreadsheet shows it, so a message is actionable.
+    pub number: usize,
+
+    /// Non-blank cells only, keyed by raw dotted header, in column order.
+    ///
+    /// Ordered rather than a map because two columns writing the same path have
+    /// to resolve left to right, the way someone reading the sheet would expect.
+    /// Blank cells are absent rather than null: the author said nothing about
+    /// them, so a template default survives.
+    pub cells: Vec<(String, Value)>,
+}
+
+impl Row {
+    pub fn origin(&self, column: Option<&str>) -> Origin {
+        Origin {
+            sheet: self.sheet.clone(),
+            row: self.number,
+            column: column.map(str::to_string),
+        }
+    }
+
+    pub fn get(&self, column: &str) -> Option<&Value> {
+        self.cells
+            .iter()
+            .find(|(header, _)| header == column)
+            .map(|(_, value)| value)
+    }
+
+    /// The cell as text, for the reference columns that are always strings.
+    pub fn text(&self, column: &str) -> Option<&str> {
+        self.get(column).and_then(Value::as_str)
+    }
+
+    /// The cell, or a problem naming the empty one.
+    pub fn require(&self, column: &str) -> Result<&Value, Problem> {
+        self.get(column).ok_or_else(|| {
+            Problem::error(
+                Code::MissingField,
+                self.origin(Some(column)).to_string(),
+                format!("'{column}' is required and this row leaves it empty"),
+            )
+        })
+    }
+
+    /// Cells minus `exclude`, in column order.
+    ///
+    /// Used to strip the reference and control columns before the rest of the
+    /// row is merged onto a rendered template as dotted-path overrides.
+    pub fn without(&self, exclude: &[&str]) -> Vec<(String, Value)> {
+        self.cells
+            .iter()
+            .filter(|(header, _)| !exclude.contains(&header.as_str()))
+            .cloned()
+            .collect()
+    }
+
+    /// The row as a nested object, ready to deep-merge onto a template.
+    pub fn overrides(
+        &self,
+        exclude: &[&str],
+    ) -> Result<Map<String, Value>, Problem> {
+        expand(&self.without(exclude)).map_err(|problem| Problem {
+            // Re-point at the cell: `expand` only knows the header.
+            path: self.origin(Some(problem.path.as_str())).to_string(),
+            ..problem
+        })
+    }
+}
+
+/// One worksheet, read and coerced.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Sheet {
+    /// Name as it appears in the document, for messages.
+    pub name: String,
+
+    /// Normalised name, for lookup.
+    pub key: String,
+
+    /// Headers in column order. A blank header is kept as an empty string so
+    /// column positions still line up with the cells beneath them.
+    pub headers: Vec<String>,
+
+    pub rows: Vec<Row>,
+}
+
+impl Sheet {
+    /// Shape a grid of cells into a sheet: first row is headers, rest are rows.
+    ///
+    /// Blank rows are dropped rather than trusted. A spreadsheet's stored
+    /// dimensions count rows that were merely visited — the SEIU1000 sample
+    /// reports a thousand rows for a sheet holding two — so emptiness has to be
+    /// decided from the cells.
+    pub fn from_grid(
+        name: impl Into<String>,
+        grid: &[Vec<Cell>],
+    ) -> Result<Self, Problem> {
+        let name: String = name.into();
+        let key = normalise_sheet_name(&name);
+
+        let Some(header_cells) = grid.first() else {
+            return Ok(Sheet {
+                name,
+                key,
+                ..Sheet::default()
+            });
+        };
+
+        let headers = read_headers(&name, header_cells)?;
+        let multi_value = multi_value_columns(&key);
+
+        let mut rows = Vec::new();
+        for (offset, cells) in grid.iter().skip(1).enumerate() {
+            // +1 for the header row, +1 because spreadsheets count from one.
+            let number = offset + 2;
+            if let Some(row) =
+                read_row(&name, number, &headers, cells, multi_value)
+            {
+                rows.push(row);
+            }
+        }
+
+        Ok(Sheet {
+            name,
+            key,
+            headers,
+            rows,
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+fn read_headers(
+    sheet_name: &str,
+    cells: &[Cell],
+) -> Result<Vec<String>, Problem> {
+    let mut headers: Vec<String> = Vec::with_capacity(cells.len());
+
+    for (index, cell) in cells.iter().enumerate() {
+        let header = match cell {
+            // A blank header means no column. Trailing blank columns are as
+            // common as trailing blank rows and mean nothing; keeping the
+            // placeholder preserves the positions of the ones that follow.
+            Cell::Blank => String::new(),
+            Cell::Text(text) => text.trim().to_string(),
+            other => {
+                match crate::election_config::paths::coerce_scalar_cell(other) {
+                    Some(Value::String(text)) => text,
+                    Some(value) => value.to_string(),
+                    None => String::new(),
+                }
+            }
+        };
+
+        if !header.is_empty() {
+            if let Some(first) = headers.iter().position(|seen| seen == &header)
+            {
+                return Err(Problem::error(
+                    Code::ConflictingColumns,
+                    format!("sheet '{sheet_name}'"),
+                    format!(
+                        "column '{header}' appears twice, at positions {} and {}. \
+                         Which one wins would be arbitrary.",
+                        first + 1,
+                        index + 1
+                    ),
+                ));
+            }
+        }
+        headers.push(header);
+    }
+
+    Ok(headers)
+}
+
+/// One data row, or `None` if it holds nothing.
+fn read_row(
+    sheet_name: &str,
+    number: usize,
+    headers: &[String],
+    cells: &[Cell],
+    multi_value: &[&str],
+) -> Option<Row> {
+    let mut values: Vec<(String, Value)> = Vec::new();
+
+    for (header, cell) in headers.iter().zip(cells) {
+        if header.is_empty() || cell.is_blank() {
+            continue;
+        }
+        if let Some(value) =
+            coerce_cell(cell, multi_value.contains(&header.as_str()))
+        {
+            values.push((header.clone(), value));
+        }
+    }
+
+    if values.is_empty() {
+        return None;
+    }
+    Some(Row {
+        sheet: sheet_name.to_string(),
+        number,
+        cells: values,
+    })
+}
+
+/// A whole authoring document: normalised sheets of coerced rows.
+#[derive(Debug, Clone, Default)]
+pub struct Workbook {
+    sheets: Vec<Sheet>,
+}
+
+impl Workbook {
+    /// Refuses two sheets that normalise to the same key.
+    ///
+    /// `Admin Users` beside `AdminUsers` is not a document with a duplicate tab;
+    /// it is a document where nobody knows which tab is live, and picking one
+    /// silently would eventually import the wrong voters.
+    pub fn new(sheets: Vec<Sheet>) -> Result<Self, Problem> {
+        for (index, sheet) in sheets.iter().enumerate() {
+            if let Some(earlier) =
+                sheets[..index].iter().find(|seen| seen.key == sheet.key)
+            {
+                return Err(Problem::error(
+                    Code::ConflictingColumns,
+                    format!("sheet '{}'", sheet.name),
+                    format!(
+                        "'{}' and '{}' are the same sheet once names are \
+                         normalised. Which one is meant cannot be guessed.",
+                        earlier.name, sheet.name
+                    ),
+                ));
+            }
+        }
+        Ok(Workbook { sheets })
+    }
+
+    pub fn sheet(&self, key: &str) -> Option<&Sheet> {
+        self.sheets.iter().find(|sheet| sheet.key == key)
+    }
+
+    /// The sheet's rows, or none.
+    ///
+    /// Absent and empty are the same thing to every caller: a document with no
+    /// `Reports` sheet and one with an empty `Reports` sheet both mean no
+    /// reports.
+    pub fn rows(&self, key: &str) -> &[Row] {
+        self.sheet(key).map_or(&[], |sheet| sheet.rows.as_slice())
+    }
+
+    pub fn has(&self, key: &str) -> bool {
+        self.sheet(key).is_some()
+    }
+
+    /// Sheets that carry no meaning here, so a caller can warn about a typo.
+    pub fn unread_sheets(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self
+            .sheets
+            .iter()
+            .filter(|sheet| !KNOWN_SHEETS.contains(&sheet.key.as_str()))
+            .map(|sheet| sheet.name.as_str())
+            .collect();
+        names.sort_unstable();
+        names
+    }
+
+    pub fn sheet_names(&self) -> Vec<&str> {
+        self.sheets
+            .iter()
+            .map(|sheet| sheet.name.as_str())
+            .collect()
+    }
+
+    pub fn sheets(&self) -> &[Sheet] {
+        &self.sheets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn text(value: &str) -> Cell {
+        Cell::text(value)
+    }
+
+    fn grid(rows: Vec<Vec<Cell>>) -> Vec<Vec<Cell>> {
+        rows
+    }
+
+    #[test]
+    fn a_tab_name_normalises_to_a_key() {
+        // Authors rename tabs, and "Admin Users" is the same sheet as
+        // "adminusers".
+        assert_eq!(normalise_sheet_name("Admin Users"), "adminusers");
+        assert_eq!(normalise_sheet_name("  ELECTIONS "), "elections");
+        assert_eq!(normalise_sheet_name("Area\tContests"), "areacontests");
+    }
+
+    #[test]
+    fn every_named_sheet_is_in_the_known_list() {
+        // A constant nobody added to the list would be read but reported unread.
+        for key in [
+            SHEET_ELECTION_EVENT,
+            SHEET_ELECTIONS,
+            SHEET_CONTESTS,
+            SHEET_CANDIDATES,
+            SHEET_AREAS,
+            SHEET_AREA_CONTESTS,
+            SHEET_VOTERS,
+            SHEET_SCHEDULED_EVENTS,
+            SHEET_PARAMETERS,
+            SHEET_ADMIN_USERS,
+            SHEET_PERMISSIONS,
+            SHEET_TEMPLATES,
+            SHEET_REPORTS,
+        ] {
+            assert!(
+                KNOWN_SHEETS.contains(&key),
+                "{key} missing from KNOWN_SHEETS"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_value_is_decided_per_sheet_not_globally() {
+        // Election::permission_label is Option<String> and
+        // Report::permission_label is Option<Vec<String>>. One name, two arities.
+        assert!(
+            multi_value_columns(SHEET_REPORTS).contains(&"permission_label")
+        );
+        assert!(
+            !multi_value_columns(SHEET_ELECTIONS).contains(&"permission_label")
+        );
+    }
+
+    #[test]
+    fn a_permission_label_stays_a_string_on_the_elections_sheet() {
+        // The regression this shape exists for: as a list it fails to
+        // deserialize into Option<String>.
+        let sheet = Sheet::from_grid(
+            "Elections",
+            &grid(vec![
+                vec![text("external_id"), text("permission_label")],
+                vec![text("board"), text("statewide-officers")],
+            ]),
+        )
+        .unwrap();
+        assert_eq!(
+            sheet.rows[0].get("permission_label"),
+            Some(&json!("statewide-officers"))
+        );
+    }
+
+    #[test]
+    fn the_same_column_on_the_reports_sheet_is_a_list() {
+        let sheet = Sheet::from_grid(
+            "Reports",
+            &grid(vec![
+                vec![text("external_id"), text("permission_label")],
+                vec![text("tally"), text("a || b")],
+            ]),
+        )
+        .unwrap();
+        assert_eq!(
+            sheet.rows[0].get("permission_label"),
+            Some(&json!(["a", "b"]))
+        );
+    }
+
+    #[test]
+    fn a_single_value_in_a_multi_value_column_is_still_a_list() {
+        let sheet = Sheet::from_grid(
+            "Reports",
+            &grid(vec![vec![text("permission_label")], vec![text("only")]]),
+        )
+        .unwrap();
+        assert_eq!(
+            sheet.rows[0].get("permission_label"),
+            Some(&json!(["only"]))
+        );
+    }
+
+    #[test]
+    fn blank_rows_are_dropped_rather_than_trusted() {
+        // A spreadsheet's stored dimensions count rows that were merely visited:
+        // the SEIU1000 sample claims a thousand rows for a sheet holding two.
+        let sheet = Sheet::from_grid(
+            "Elections",
+            &grid(vec![
+                vec![text("external_id")],
+                vec![text("board")],
+                vec![Cell::Blank],
+                vec![text("   ")],
+                vec![text("council")],
+                vec![Cell::Blank],
+            ]),
+        )
+        .unwrap();
+        assert_eq!(sheet.len(), 2);
+        assert_eq!(sheet.rows[0].text("external_id"), Some("board"));
+        assert_eq!(sheet.rows[1].text("external_id"), Some("council"));
+    }
+
+    #[test]
+    fn a_row_number_is_the_one_the_spreadsheet_shows() {
+        // Off by one here means an author looking at the wrong line.
+        let sheet = Sheet::from_grid(
+            "Elections",
+            &grid(vec![
+                vec![text("external_id")],
+                vec![text("first")],
+                vec![text("second")],
+            ]),
+        )
+        .unwrap();
+        assert_eq!(sheet.rows[0].number, 2);
+        assert_eq!(sheet.rows[1].number, 3);
+    }
+
+    #[test]
+    fn a_dropped_blank_row_does_not_shift_the_numbers_after_it() {
+        let sheet = Sheet::from_grid(
+            "Elections",
+            &grid(vec![
+                vec![text("external_id")],
+                vec![Cell::Blank],
+                vec![text("after the gap")],
+            ]),
+        )
+        .unwrap();
+        assert_eq!(sheet.rows[0].number, 3);
+    }
+
+    #[test]
+    fn a_blank_header_ends_the_table_without_shifting_the_rest() {
+        // Trailing blank columns are as common as trailing blank rows.
+        let sheet = Sheet::from_grid(
+            "Elections",
+            &grid(vec![
+                vec![text("a"), Cell::Blank, text("c")],
+                vec![text("1"), text("ignored"), text("3")],
+            ]),
+        )
+        .unwrap();
+        assert_eq!(sheet.headers, vec!["a", "", "c"]);
+        assert_eq!(sheet.rows[0].cells.len(), 2);
+        assert_eq!(sheet.rows[0].get("c"), Some(&json!("3")));
+    }
+
+    #[test]
+    fn a_duplicated_column_is_refused() {
+        // Which one wins would be arbitrary, and the author cannot see the
+        // difference.
+        let problem = Sheet::from_grid(
+            "Elections",
+            &grid(vec![vec![text("title"), text("title")]]),
+        )
+        .unwrap_err();
+        assert_eq!(problem.code, Code::ConflictingColumns);
+        assert!(problem.message.contains("positions 1 and 2"));
+    }
+
+    #[test]
+    fn a_header_that_differs_only_by_padding_is_still_a_duplicate() {
+        assert!(Sheet::from_grid(
+            "Elections",
+            &grid(vec![vec![text("title"), text("  title  ")]]),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn a_text_cell_that_looks_numeric_stays_text() {
+        // Deliberate, and the same as the Python: a spreadsheet hands over a
+        // number for a numeric cell, so text here means the author formatted the
+        // column as text — which is how member id 007 stays 007. A number typed
+        // as a number arrives as `Cell::Float` and does become an integer.
+        let sheet = Sheet::from_grid(
+            "Voters",
+            &grid(vec![
+                vec![text("member_id"), text("max_votes")],
+                vec![text("007"), Cell::Float(3.0)],
+            ]),
+        )
+        .unwrap();
+        assert_eq!(sheet.rows[0].get("member_id"), Some(&json!("007")));
+        assert_eq!(sheet.rows[0].get("max_votes"), Some(&json!(3)));
+    }
+
+    #[test]
+    fn a_numeric_header_is_read_as_a_name() {
+        // A year used as a column name is a name, not a number.
+        let sheet = Sheet::from_grid(
+            "Parameters",
+            &grid(vec![vec![Cell::Int(2027)], vec![text("x")]]),
+        )
+        .unwrap();
+        assert_eq!(sheet.headers, vec!["2027"]);
+    }
+
+    #[test]
+    fn an_empty_grid_is_an_empty_sheet_rather_than_an_error() {
+        let sheet = Sheet::from_grid("Reports", &grid(vec![])).unwrap();
+        assert!(sheet.is_empty());
+        assert_eq!(sheet.key, "reports");
+    }
+
+    #[test]
+    fn a_header_row_with_no_rows_under_it_is_empty_too() {
+        let sheet =
+            Sheet::from_grid("Reports", &grid(vec![vec![text("external_id")]]))
+                .unwrap();
+        assert!(sheet.is_empty());
+        assert_eq!(sheet.headers, vec!["external_id"]);
+    }
+
+    #[test]
+    fn short_rows_do_not_invent_cells() {
+        // Spreadsheets truncate trailing empties; zip stops at the shorter side.
+        let sheet = Sheet::from_grid(
+            "Elections",
+            &grid(vec![vec![text("a"), text("b"), text("c")], vec![text("1")]]),
+        )
+        .unwrap();
+        assert_eq!(sheet.rows[0].cells.len(), 1);
+        assert_eq!(sheet.rows[0].get("b"), None);
+    }
+
+    #[test]
+    fn a_row_hands_over_its_overrides_as_nested_json() {
+        let sheet = Sheet::from_grid(
+            "Contests",
+            &grid(vec![
+                vec![
+                    text("external_id"),
+                    text("election_id"),
+                    text("presentation.i18n.en.name"),
+                    text("max_votes"),
+                ],
+                vec![
+                    text("president"),
+                    text("board"),
+                    text("President"),
+                    Cell::Float(3.0),
+                ],
+            ]),
+        )
+        .unwrap();
+
+        let overrides = sheet.rows[0]
+            .overrides(&["external_id", "election_id"])
+            .unwrap();
+        assert_eq!(
+            Value::Object(overrides),
+            json!({
+                "presentation": {"i18n": {"en": {"name": "President"}}},
+                "max_votes": 3,
+            })
+        );
+    }
+
+    #[test]
+    fn a_shape_conflict_in_a_row_names_the_cell_not_just_the_column() {
+        // The author has to find it in the spreadsheet.
+        let problem = Sheet::from_grid(
+            "Contests",
+            &grid(vec![
+                vec![text("presentation"), text("presentation.i18n")],
+                vec![text("plain"), text("{}")],
+            ]),
+        )
+        .unwrap()
+        .rows[0]
+            .overrides(&[])
+            .unwrap_err();
+        assert_eq!(problem.code, Code::ConflictingColumns);
+        assert!(problem.path.contains("sheet 'Contests' row 2"));
+        assert!(problem.path.contains("presentation.i18n"));
+    }
+
+    #[test]
+    fn a_missing_required_cell_names_where_to_look() {
+        let sheet = Sheet::from_grid(
+            "Elections",
+            &grid(vec![
+                vec![text("external_id"), text("title")],
+                vec![text("board"), Cell::Blank],
+            ]),
+        )
+        .unwrap();
+        let problem = sheet.rows[0].require("title").unwrap_err();
+        assert_eq!(problem.code, Code::MissingField);
+        assert_eq!(problem.path, "sheet 'Elections' row 2 column 'title'");
+    }
+
+    #[test]
+    fn an_origin_reads_as_a_place() {
+        let row = Row {
+            sheet: "Voters".to_string(),
+            number: 47,
+            cells: vec![],
+        };
+        assert_eq!(row.origin(None).to_string(), "sheet 'Voters' row 47");
+        assert_eq!(
+            row.origin(Some("email")).to_string(),
+            "sheet 'Voters' row 47 column 'email'"
+        );
+    }
+
+    #[test]
+    fn an_absent_sheet_and_an_empty_one_read_the_same() {
+        // Callers treat both as "no reports", so neither may be a special case.
+        let workbook = Workbook::new(vec![Sheet::from_grid(
+            "Reports",
+            &grid(vec![vec![text("external_id")]]),
+        )
+        .unwrap()])
+        .unwrap();
+        assert!(workbook.rows(SHEET_REPORTS).is_empty());
+        assert!(workbook.rows(SHEET_VOTERS).is_empty());
+        assert!(workbook.has(SHEET_REPORTS));
+        assert!(!workbook.has(SHEET_VOTERS));
+    }
+
+    #[test]
+    fn two_tabs_that_normalise_alike_are_refused() {
+        // Not a duplicate tab: a document where nobody knows which tab is live.
+        let problem = Workbook::new(vec![
+            Sheet::from_grid("Admin Users", &grid(vec![])).unwrap(),
+            Sheet::from_grid("AdminUsers", &grid(vec![])).unwrap(),
+        ])
+        .unwrap_err();
+        assert!(problem.message.contains("the same sheet"));
+    }
+
+    #[test]
+    fn sheets_nobody_reads_are_listed_so_a_typo_shows_up() {
+        let workbook = Workbook::new(vec![
+            Sheet::from_grid("Elections", &grid(vec![])).unwrap(),
+            Sheet::from_grid("Electons", &grid(vec![])).unwrap(),
+            Sheet::from_grid("Read Me", &grid(vec![])).unwrap(),
+        ])
+        .unwrap();
+        assert_eq!(workbook.unread_sheets(), vec!["Electons", "Read Me"]);
+        assert_eq!(
+            workbook.sheet_names(),
+            vec!["Elections", "Electons", "Read Me"]
+        );
+    }
+}

--- a/packages/sequent-core/src/election_config/xlsx.rs
+++ b/packages/sequent-core/src/election_config/xlsx.rs
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Reading an `.xlsx` file into a [`Workbook`].
+//!
+//! The only part of this module that knows a file format. It converts `calamine`
+//! cells into [`Cell`]s and hands the grid to [`Sheet::from_grid`]; every
+//! decision about headers, blank rows and coercion is there, where it can be
+//! tested without a fixture file.
+//!
+//! Behind the `election_config_xlsx` feature so the front ends that have no
+//! workbook to read do not carry a spreadsheet library into their WASM bundle.
+//! Reads from bytes rather than a path, so the same call serves `step-cli` and a
+//! browser holding the result of a file input.
+
+use crate::election_config::paths::Cell;
+use crate::election_config::problem::{Code, Problem};
+use crate::election_config::sheet::{Sheet, Workbook};
+use calamine::{Data, Reader, Xlsx};
+use std::io::Cursor;
+
+/// Read an `.xlsx` from bytes.
+///
+/// Formulas are read as their cached result, which is what a spreadsheet stores
+/// alongside them. A file written by a tool that does not compute formulas has
+/// no cached result, so the cell reads as blank and turns up as a missing
+/// required value — better than a formula string reaching the output.
+pub fn read_xlsx(bytes: &[u8]) -> Result<Workbook, Problem> {
+    let mut book: Xlsx<_> = Xlsx::new(Cursor::new(bytes)).map_err(|error| {
+        Problem::error(
+            Code::InvalidValue,
+            "workbook",
+            format!("this does not read as an .xlsx file: {error}"),
+        )
+    })?;
+
+    let names = book.sheet_names().to_vec();
+    let mut sheets = Vec::with_capacity(names.len());
+
+    for name in names {
+        let range = book.worksheet_range(&name).map_err(|error| {
+            Problem::error(
+                Code::InvalidValue,
+                format!("sheet '{name}'"),
+                format!("could not be read: {error}"),
+            )
+        })?;
+
+        let grid: Vec<Vec<Cell>> = range
+            .rows()
+            .map(|row| row.iter().map(cell_from_data).collect())
+            .collect();
+
+        sheets.push(Sheet::from_grid(name, &grid)?);
+    }
+
+    Workbook::new(sheets)
+}
+
+/// Narrow one spreadsheet cell to the neutral vocabulary.
+fn cell_from_data(data: &Data) -> Cell {
+    match data {
+        Data::Empty => Cell::Blank,
+        Data::String(text) => Cell::text(text.as_str()),
+        Data::Float(value) => Cell::Float(*value),
+        Data::Int(value) => Cell::Int(*value),
+        Data::Bool(value) => Cell::Bool(*value),
+
+        // A duration is asked about before being converted, because
+        // `as_datetime` will cheerfully turn one into an instant near the 1900
+        // epoch — 0.5 becomes 1899-12-31T12:00 — which is a plausible-looking
+        // timestamp and completely wrong. No schema field wants a duration, so
+        // the number is handed over for validation to object to instead.
+        Data::DateTime(excel) if excel.is_duration() => {
+            Cell::Float(excel.as_f64())
+        }
+        Data::DateTime(excel) => match excel.as_datetime() {
+            Some(naive) => Cell::DateTime(naive),
+            // A serial number outside the calendar. Same reasoning: visible
+            // rather than dropped.
+            None => Cell::Float(excel.as_f64()),
+        },
+
+        // Already text in the file. Left as text on purpose: these are written
+        // in ISO 8601, which is what the platform wants anyway, and reparsing
+        // them only adds a way to get the timezone wrong.
+        Data::DateTimeIso(text) => Cell::text(text.as_str()),
+        Data::DurationIso(text) => Cell::text(text.as_str()),
+
+        // A formula that evaluated to an error — #REF!, #DIV/0!. Blank would
+        // hide it; the text makes it show up as an invalid value naming the
+        // cell.
+        Data::Error(error) => Cell::text(format!("{error}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::election_config::sheet::{SHEET_ELECTIONS, SHEET_REPORTS};
+    use calamine::{CellErrorType, ExcelDateTime, ExcelDateTimeType};
+    use serde_json::{json, Value};
+
+    #[test]
+    fn an_empty_cell_is_blank() {
+        assert_eq!(cell_from_data(&Data::Empty), Cell::Blank);
+    }
+
+    #[test]
+    fn a_cell_holding_only_spaces_is_blank_too() {
+        // Someone typed a space; the intent is still nothing.
+        assert_eq!(cell_from_data(&Data::String("   ".into())), Cell::Blank);
+    }
+
+    #[test]
+    fn the_native_types_pass_straight_through() {
+        assert_eq!(cell_from_data(&Data::Int(7)), Cell::Int(7));
+        assert_eq!(cell_from_data(&Data::Float(1.5)), Cell::Float(1.5));
+        assert_eq!(cell_from_data(&Data::Bool(true)), Cell::Bool(true));
+        assert_eq!(
+            cell_from_data(&Data::String("board".into())),
+            Cell::Text("board".to_string())
+        );
+    }
+
+    #[test]
+    fn a_date_cell_becomes_an_instant_with_its_time_intact() {
+        // The time matters as much as the date: it is what opens and closes a
+        // voting window.
+        let excel = ExcelDateTime::new(
+            46318.677_083_333_336,
+            ExcelDateTimeType::DateTime,
+            false,
+        );
+        let Cell::DateTime(naive) = cell_from_data(&Data::DateTime(excel))
+        else {
+            panic!("expected a datetime");
+        };
+        assert_eq!(naive.to_string(), "2026-10-23 16:15:00");
+    }
+
+    #[test]
+    fn a_duration_keeps_its_number_rather_than_becoming_a_bogus_1899_instant() {
+        // `as_datetime` turns 0.5 into 1899-12-31T12:00 — plausible-looking and
+        // entirely wrong — so the kind is asked about first.
+        let excel =
+            ExcelDateTime::new(0.5, ExcelDateTimeType::TimeDelta, false);
+        assert_eq!(cell_from_data(&Data::DateTime(excel)), Cell::Float(0.5));
+    }
+
+    #[test]
+    fn an_iso_timestamp_stays_the_text_it_already_is() {
+        // ISO 8601 is what the platform wants; reparsing only risks the zone.
+        assert_eq!(
+            cell_from_data(&Data::DateTimeIso("2026-10-24T16:15:00Z".into())),
+            Cell::Text("2026-10-24T16:15:00Z".to_string())
+        );
+    }
+
+    #[test]
+    fn a_formula_error_is_visible_rather_than_blank() {
+        // Blank would hide a broken formula and produce a bundle missing a field
+        // nobody meant to leave out.
+        assert_eq!(
+            cell_from_data(&Data::Error(CellErrorType::Ref)),
+            Cell::Text("#REF!".to_string())
+        );
+    }
+
+    #[test]
+    fn bytes_that_are_not_a_spreadsheet_are_refused_with_a_readable_message() {
+        let problem = read_xlsx(b"this is not a spreadsheet").unwrap_err();
+        assert_eq!(problem.code, Code::InvalidValue);
+        assert!(problem.message.contains("does not read as an .xlsx"));
+    }
+
+    /// The smallest real `.xlsx` this can be tested against: written here rather
+    /// than committed, so there is no binary fixture to keep in step with the
+    /// code, and no chance of a client's data ending up in the repository.
+    fn tiny_xlsx(sheets: &[(&str, &[&[&str]])]) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+
+        let mut buffer = Vec::new();
+        {
+            let mut zip = zip::ZipWriter::new(Cursor::new(&mut buffer));
+            let options = SimpleFileOptions::default();
+
+            zip.start_file("[Content_Types].xml", options).unwrap();
+            let mut content_types = String::from(
+                r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>"#,
+            );
+            for index in 1..=sheets.len() {
+                content_types.push_str(&format!(
+                    r#"<Override PartName="/xl/worksheets/sheet{index}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>"#
+                ));
+            }
+            content_types.push_str("</Types>");
+            zip.write_all(content_types.as_bytes()).unwrap();
+
+            zip.start_file("_rels/.rels", options).unwrap();
+            zip.write_all(
+                br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            )
+            .unwrap();
+
+            zip.start_file("xl/workbook.xml", options).unwrap();
+            let mut workbook = String::from(
+                r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets>"#,
+            );
+            for (index, (name, _)) in sheets.iter().enumerate() {
+                let id = index + 1;
+                workbook.push_str(&format!(
+                    r#"<sheet name="{name}" sheetId="{id}" r:id="rId{id}"/>"#
+                ));
+            }
+            workbook.push_str("</sheets></workbook>");
+            zip.write_all(workbook.as_bytes()).unwrap();
+
+            zip.start_file("xl/_rels/workbook.xml.rels", options)
+                .unwrap();
+            let mut rels = String::from(
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+            );
+            for index in 1..=sheets.len() {
+                rels.push_str(&format!(
+                    r#"<Relationship Id="rId{index}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet{index}.xml"/>"#
+                ));
+            }
+            rels.push_str("</Relationships>");
+            zip.write_all(rels.as_bytes()).unwrap();
+
+            for (index, (_, rows)) in sheets.iter().enumerate() {
+                zip.start_file(
+                    format!("xl/worksheets/sheet{}.xml", index + 1),
+                    options,
+                )
+                .unwrap();
+                let mut xml = String::from(
+                    r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>"#,
+                );
+                for (row_index, row) in rows.iter().enumerate() {
+                    xml.push_str(&format!(r#"<row r="{}">"#, row_index + 1));
+                    for (column_index, value) in row.iter().enumerate() {
+                        let reference = format!(
+                            "{}{}",
+                            (b'A' + column_index as u8) as char,
+                            row_index + 1
+                        );
+                        if value.is_empty() {
+                            continue;
+                        }
+                        // Numbers are written as numbers, the way a spreadsheet
+                        // stores them, so the float-to-integer coercion is
+                        // actually exercised. Anything else is an inline string,
+                        // which avoids needing a shared-string table. A value
+                        // wrapped in single quotes is forced to text, for the
+                        // codes an author formats as text on purpose.
+                        if let Some(literal) = value.strip_prefix('\'') {
+                            xml.push_str(&format!(
+                                r#"<c r="{reference}" t="inlineStr"><is><t>{literal}</t></is></c>"#
+                            ));
+                        } else if value.parse::<f64>().is_ok() {
+                            xml.push_str(&format!(
+                                r#"<c r="{reference}"><v>{value}</v></c>"#
+                            ));
+                        } else {
+                            xml.push_str(&format!(
+                                r#"<c r="{reference}" t="inlineStr"><is><t>{value}</t></is></c>"#
+                            ));
+                        }
+                    }
+                    xml.push_str("</row>");
+                }
+                xml.push_str("</sheetData></worksheet>");
+                zip.write_all(xml.as_bytes()).unwrap();
+            }
+
+            zip.finish().unwrap();
+        }
+        buffer
+    }
+
+    #[test]
+    fn a_real_xlsx_reads_into_normalised_sheets() {
+        let bytes = tiny_xlsx(&[
+            (
+                "Elections",
+                &[
+                    &["external_id", "presentation.i18n.en.name", "max_votes"],
+                    &["board", "Board", "3"],
+                    &["", "", ""],
+                    &["council", "Council", "1"],
+                ],
+            ),
+            ("Read Me", &[&["This tab is documentation"]]),
+        ]);
+
+        let workbook = read_xlsx(&bytes).unwrap();
+
+        // Tab names normalise, so lookup does not depend on how a tab is spelled.
+        assert_eq!(workbook.rows(SHEET_ELECTIONS).len(), 2);
+        assert_eq!(workbook.rows(SHEET_REPORTS).len(), 0);
+
+        // The blank row in the middle is dropped without shifting the numbering:
+        // "council" is on line 4 of the spreadsheet.
+        let council = &workbook.rows(SHEET_ELECTIONS)[1];
+        assert_eq!(council.number, 4);
+        assert_eq!(council.text("external_id"), Some("council"));
+
+        // Coercion has happened: "3" is a number by the time it is a bundle.
+        let board = &workbook.rows(SHEET_ELECTIONS)[0];
+        assert_eq!(board.get("max_votes"), Some(&json!(3)));
+        assert_eq!(
+            Value::Object(board.overrides(&["external_id"]).unwrap()),
+            json!({
+                "presentation": {"i18n": {"en": {"name": "Board"}}},
+                "max_votes": 3,
+            })
+        );
+
+        // And the documentation tab is reported rather than silently ignored.
+        assert_eq!(workbook.unread_sheets(), vec!["Read Me"]);
+    }
+
+    #[test]
+    fn a_code_formatted_as_text_keeps_its_leading_zeros() {
+        // The reason a text cell is never reparsed as a number: member id 007 is
+        // not 7, and turning it into one would silently fail to match a voter.
+        let bytes = tiny_xlsx(&[(
+            "Voters",
+            &[&["external_id", "member_id"], &["v1", "'007"]],
+        )]);
+        let workbook = read_xlsx(&bytes).unwrap();
+        assert_eq!(
+            workbook.rows("voters")[0].get("member_id"),
+            Some(&json!("007"))
+        );
+    }
+}


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2971.** Base branch is
`feat/meta-12769-paths/main`, so this diff shows only what is added on top.

Sheets of rows of coerced cells, and the `.xlsx` reader that produces them — the
last piece that existed only in janitor's Python, and the one `step-cli` and a
browser both need before either can build a bundle.

## Split in two on purpose

`election_config::sheet` is **pure and knows no file format**. It takes grids of
`Cell` and does the header row, the duplicate-column check, blank-row trimming and
the per-sheet multi-value decision.

`election_config::xlsx` is the **only** part that needs a spreadsheet library, and
does nothing but narrow `calamine`'s cells to `Cell`.

So the awkward cases are all testable without a fixture file. The reader's own
tests build a real `.xlsx` in memory rather than committing a binary — nothing to
keep in step with the code, and no route for a client's data into the repository.

Behind a new **`election_config_xlsx`** feature: admin-portal and voting-portal
enable `default_features` for their WASM build and have no workbook to read, so
they should not carry a spreadsheet parser in their bundle. Reads from bytes rather
than a path, so the same call serves `step-cli` and a browser holding a file input.

## What the tests pinned down

**A duration cell is asked about before being converted.** `calamine`'s
`as_datetime` turns `0.5` into `1899-12-31T12:00` — a plausible-looking timestamp
and entirely wrong — so `is_duration()` is checked first and the number handed over
for validation to object to. Found by a test that assumed the opposite.

**A text cell that looks numeric stays text**, matching the Python. A spreadsheet
hands over a number for a numeric cell, so text here means the author formatted the
column as text — which is how member id `007` stays `007` instead of silently
failing to match a voter. A number typed as a number arrives as a float and does
become an integer.

**Blank rows are dropped rather than trusted.** A spreadsheet's stored dimensions
count rows that were merely visited: the SEIU1000 sample claims a thousand rows for
a sheet holding two. Dropping one must not shift the numbers after it, because the
number is what an author looks at.

**Two tabs that normalise to the same key are refused.** `Admin Users` beside
`AdminUsers` is not a document with a duplicate tab; it is one where nobody knows
which tab is live, and picking silently would eventually import the wrong voters. A
duplicated column is refused for the same reason: which one wins would be arbitrary
and invisible.

**Sheets nobody reads are listed** rather than ignored, so a misspelled tab gets
noticed.

**Absent and empty read the same.** No `Reports` sheet and an empty `Reports` sheet
both mean no reports, so no caller has to special-case either.

**`Origin` carries the sheet name and the row number as the spreadsheet shows
them.** A bundle path like `elections[3].title` is no use to whoever has to fix the
file.

## Known gap

A problem found while reading carries its `Origin` flattened into `Problem::path`.
A front end that wants to highlight the offending cell needs sheet, row and column
separately, which means a structured origin on `Problem` — worth doing when there
is a UI to consume it, not before. Noted in the module docs.

## Verified

- `cargo test -p sequent-core --lib --features election_config_xlsx election_config` — **133 passed**, 0 failed (99 before, 34 new).
- `cargo check -p sequent-core --features default_features` clean — the feature gate holds, `calamine` is not pulled in without it.
- `cargo check -p windmill` clean.
- `cargo fmt --check -p sequent-core` clean; `cargo clippy --lib --tests` silent on this module.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

_Not applicable — this level is a library module with no UI._
