### PR TITLE
✨ Build the bundle's JSON document in the shared core

### DIFF
--- a/packages/sequent-core/src/election_config/build.rs
+++ b/packages/sequent-core/src/election_config/build.rs
@@ -1,0 +1,1095 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Turning a source document's rows into an import bundle.
+//!
+//! Each entity is a rendered template with the row's dotted-path columns
+//! deep-merged over it, identified by a [`super::ids::IdFactory`] uuid5, and
+//! joined to the others by `external_id`. Nothing here reaches for a clock or a
+//! filesystem, so the same build runs in `step-cli` and in a browser and produces
+//! the same bytes.
+//!
+//! Problems accumulate rather than stopping at the first one: an author fixing a
+//! spreadsheet wants the whole list, not one round trip per mistake. Every
+//! problem carries the sheet and row it came from, because a bundle path is no
+//! use to whoever has to edit the file.
+//!
+//! This level builds the JSON document — the event and its elections, contests,
+//! candidates, areas and ballot links. The CSV members (voters, scheduled events,
+//! reports, admin users), the auth presets and the Keycloak realm are the next
+//! levels of the same port; `keycloak_event_realm` is left null until then.
+
+use crate::election_config::ids::IdFactory;
+use crate::election_config::paths::{deep_merge, set_path, split_path};
+use crate::election_config::problem::{Code, Problem, Report};
+use crate::election_config::render::TemplateSet;
+use crate::election_config::sheet::{
+    normalise_sheet_name, Origin, Row, Workbook, SHEET_AREAS,
+    SHEET_AREA_CONTESTS, SHEET_CANDIDATES, SHEET_CONTESTS, SHEET_ELECTIONS,
+    SHEET_ELECTION_EVENT, SHEET_PARAMETERS,
+};
+use serde_json::{json, Map, Value};
+
+/// Timestamp on every generated entity.
+///
+/// Fixed rather than "now" so that regenerating an unchanged source produces
+/// byte-identical output. A real timestamp would make every regeneration a diff
+/// with no information in it, and the importer overwrites these anyway.
+pub const DEFAULT_CREATED_AT: &str = "2026-01-01T00:00:00.000000Z";
+
+/// Bundle format version written when neither a base export nor an option says
+/// otherwise.
+pub const DEFAULT_VERSION: &str = "v10.0.0";
+
+/// Columns the builder consumes itself.
+///
+/// These are not dotted paths into the entity and must not be merged into it —
+/// `election.external_id` is how a contest names its election, not a field called
+/// `external_id` on an object called `election`.
+pub fn control_columns(sheet_key: &str) -> &'static [&'static str] {
+    match sheet_key {
+        SHEET_CONTESTS => &["election.external_id"],
+        SHEET_CANDIDATES => &["contest.external_id"],
+        SHEET_AREAS => &["parent.external_id"],
+        SHEET_AREA_CONTESTS => &["area.external_id", "contest.external_id"],
+        _ => &[],
+    }
+}
+
+/// Parameters whose key opens with one of these is a dotted patch into that
+/// target rather than free-form metadata.
+pub const PARAMETER_PREFIXES: &[&str] = &[
+    "keycloak_event_realm.",
+    "keycloak_admin_realm.",
+    "election_event.",
+];
+
+/// Parameters the builder acts on directly rather than carrying as metadata.
+pub const HANDLED_PARAMETERS: &[&str] = &["tenant_id", "login_custom_css"];
+
+/// Fields of a base entity that describe *that* event rather than the platform's
+/// defaults, and so must not leak into a new one.
+///
+/// `bulletin_board_reference` and `public_key` point at the base event's own
+/// board and keys; `statistics` and `status` describe a run that already
+/// happened. Carrying any of them over produces an event that looks configured
+/// and is not.
+const SCRUB_EVENT: &[&str] = &[
+    "id",
+    "tenant_id",
+    "external_id",
+    "bulletin_board_reference",
+    "public_key",
+    "statistics",
+    "status",
+    "created_at",
+    "updated_at",
+];
+
+const SCRUB_ELECTION: &[&str] = &[
+    "id",
+    "tenant_id",
+    "election_event_id",
+    "external_id",
+    "keys_ceremony_id",
+    "statistics",
+    "status",
+    "created_at",
+    "last_updated_at",
+];
+
+const SCRUB_CONTEST: &[&str] = &[
+    "id",
+    "tenant_id",
+    "election_event_id",
+    "election_id",
+    "external_id",
+    "created_at",
+    "last_updated_at",
+];
+
+const SCRUB_CANDIDATE: &[&str] = &[
+    "id",
+    "tenant_id",
+    "election_event_id",
+    "contest_id",
+    "external_id",
+    "created_at",
+    "last_updated_at",
+];
+
+const SCRUB_AREA: &[&str] = &[
+    "id",
+    "tenant_id",
+    "election_event_id",
+    "parent_id",
+    "name",
+    "description",
+    "created_at",
+    "last_updated_at",
+];
+
+/// What a caller may vary about a build.
+#[derive(Debug, Clone, Default)]
+pub struct BuildOptions {
+    /// The tenant id to write into the file.
+    ///
+    /// Import does not read this as a destination: `replace_ids` maps the file's
+    /// value onto the tenant of the importing request unconditionally. It still
+    /// matters for `export_permissions-<tenant>.csv`, which is a tenant-config
+    /// artifact whose name nothing rewrites.
+    pub tenant_id: Option<String>,
+
+    /// An existing export to inherit platform defaults from.
+    ///
+    /// Merged *under* the templates, so it contributes fields the templates do
+    /// not know about — a newer platform version's additions, for instance —
+    /// without overriding anything the author wrote.
+    pub base_export: Option<Value>,
+
+    /// Name for the generated archive. Derived from the event's `external_id`
+    /// when absent.
+    pub slug: Option<String>,
+
+    /// Timestamp for every entity. [`DEFAULT_CREATED_AT`] when absent.
+    pub created_at: Option<String>,
+}
+
+/// A built bundle: the JSON document and what was worth saying about it.
+#[derive(Debug, Clone)]
+pub struct Bundle {
+    pub slug: String,
+    pub tenant_id: String,
+    pub event_id: String,
+    pub event_external_id: String,
+
+    /// The `export_election_event-<id>.json` document.
+    pub export: Value,
+
+    /// Warnings. Not errors: the bundle imports, but something about it looks
+    /// unintended.
+    pub warnings: Report,
+}
+
+/// Build a bundle from a source document.
+///
+/// Returns every problem at once on failure, so one run tells an author
+/// everything they need to fix.
+pub fn build(
+    workbook: &Workbook,
+    templates: &TemplateSet,
+    options: &BuildOptions,
+) -> Result<Bundle, Report> {
+    Builder::new(workbook, templates, options)?.build()
+}
+
+struct Builder<'a> {
+    workbook: &'a Workbook,
+    templates: &'a TemplateSet,
+    base_export: Value,
+    created_at: String,
+
+    report: Report,
+
+    /// `(type, key) -> value` from the Parameters sheet, in sheet order.
+    parameters: Vec<(String, String, Value)>,
+
+    event_row: Row,
+    event_external_id: String,
+    event_id: String,
+    tenant_id: String,
+    slug: String,
+    ids: IdFactory,
+
+    /// `external_id` -> generated UUID, per entity kind.
+    election_ids: Vec<(String, String)>,
+    contest_ids: Vec<(String, String)>,
+    area_ids: Vec<(String, String)>,
+    area_names: Vec<(String, String)>,
+}
+
+impl<'a> Builder<'a> {
+    fn new(
+        workbook: &'a Workbook,
+        templates: &'a TemplateSet,
+        options: &BuildOptions,
+    ) -> Result<Self, Report> {
+        let mut report = Report::default();
+        let event_row = event_row(workbook).map_err(|problem| {
+            let mut report = Report::default();
+            report.push(problem);
+            report
+        })?;
+
+        let event_external_id = match event_row.text("external_id") {
+            Some(id) if !id.trim().is_empty() => id.trim().to_string(),
+            _ => {
+                report.push(Problem::error(
+                    Code::MissingField,
+                    event_row.origin(Some("external_id")).to_string(),
+                    "the election event needs an external_id: every generated \
+                     identifier is derived from it",
+                ));
+                return Err(report);
+            }
+        };
+
+        // Unwrap is sound: the id was just checked to be non-empty.
+        let ids = IdFactory::new(&event_external_id)
+            .expect("a non-empty external_id always yields a factory");
+        let event_id = ids.uid("election_event", &[&event_external_id]);
+
+        let base_export = options.base_export.clone().unwrap_or(Value::Null);
+        let mut builder = Builder {
+            workbook,
+            templates,
+            base_export,
+            created_at: options
+                .created_at
+                .clone()
+                .unwrap_or_else(|| DEFAULT_CREATED_AT.to_string()),
+            report,
+            parameters: Vec::new(),
+            event_row,
+            event_external_id: event_external_id.clone(),
+            event_id,
+            tenant_id: String::new(),
+            slug: options
+                .slug
+                .clone()
+                .unwrap_or_else(|| slugify(&event_external_id)),
+            ids,
+            election_ids: Vec::new(),
+            contest_ids: Vec::new(),
+            area_ids: Vec::new(),
+            area_names: Vec::new(),
+        };
+
+        builder.parameters = builder.read_parameters();
+        builder.tenant_id =
+            builder.resolve_tenant_id(options.tenant_id.as_deref());
+        Ok(builder)
+    }
+
+    fn build(mut self) -> Result<Bundle, Report> {
+        let elections = self.build_elections();
+        let contests = self.build_contests();
+        let candidates = self.build_candidates();
+        let areas = self.build_areas();
+        let area_contests = self.build_area_contests();
+        let event = self.build_election_event();
+
+        let version = self
+            .base_export
+            .get("version")
+            .and_then(Value::as_str)
+            .unwrap_or(DEFAULT_VERSION)
+            .to_string();
+
+        let export = json!({
+            "tenant_id": self.tenant_id,
+            // Filled in by the realm level of this port.
+            "keycloak_event_realm": Value::Null,
+            "election_event": event,
+            "elections": elections,
+            "contests": contests,
+            "candidates": candidates,
+            "areas": areas,
+            "area_contests": area_contests,
+            // The voting window travels in export_scheduled_events.csv, which is
+            // the member import_election_event.rs actually reads.
+            "scheduled_events": Value::Null,
+            // Reports likewise come from export_reports.csv: insert_reports is
+            // only ever reached from process_reports_file, so a populated array
+            // here would be silently dropped.
+            "reports": [],
+            "keys_ceremonies": [],
+            "applications": [],
+            "version": version,
+        });
+
+        if self.report.has_errors() {
+            return Err(self.report);
+        }
+
+        // Only warnings are left, and they travel with the bundle.
+        Ok(Bundle {
+            slug: self.slug,
+            tenant_id: self.tenant_id,
+            event_id: self.event_id,
+            event_external_id: self.event_external_id,
+            export,
+            warnings: self.report,
+        })
+    }
+
+    // -- problems ---------------------------------------------------------
+
+    /// Record a problem and keep going, so one run reports every issue.
+    fn problem(
+        &mut self,
+        origin: Origin,
+        code: Code,
+        message: impl Into<String>,
+    ) {
+        self.report
+            .push(Problem::error(code, origin.to_string(), message));
+    }
+
+    fn warn(&mut self, path: impl Into<String>, message: impl Into<String>) {
+        self.report
+            .push(Problem::warning(Code::InvalidValue, path, message));
+    }
+
+    // -- parameters -------------------------------------------------------
+
+    fn read_parameters(&mut self) -> Vec<(String, String, Value)> {
+        let mut parameters = Vec::new();
+        let mut warnings = Vec::new();
+
+        for row in self.workbook.rows(SHEET_PARAMETERS) {
+            let Some(key) = row.get("key") else {
+                // A row with a comment but no key is a note to the author.
+                continue;
+            };
+            let key = value_as_text(key).trim().to_string();
+            if key.is_empty() {
+                continue;
+            }
+
+            match row.get("value") {
+                Some(value) => {
+                    let kind = row
+                        .get("type")
+                        .map(|kind| value_as_text(kind).trim().to_string())
+                        .unwrap_or_default();
+                    parameters.push((kind, key, value.clone()));
+                }
+                None => {
+                    // A key with no value is a placeholder the author left
+                    // blank, e.g. an IdP metadata URL pending the client.
+                    warnings.push((
+                        row.origin(Some("value")).to_string(),
+                        format!(
+                            "parameter '{key}' has no value and is ignored"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        for (path, message) in warnings {
+            self.warn(path, message);
+        }
+        parameters
+    }
+
+    /// Look a parameter up by key, whatever its `type` column says.
+    ///
+    /// The type column is documentation for the author; nothing downstream
+    /// distinguishes an `event` parameter from a `settings` one.
+    fn parameter(&self, key: &str) -> Option<&Value> {
+        self.parameters
+            .iter()
+            .find(|(_, name, _)| name == key)
+            .map(|(_, _, value)| value)
+    }
+
+    /// Parameters whose key is a dotted path under `prefix`.
+    fn parameter_patches(&self, prefix: &str) -> Vec<(String, Value)> {
+        self.parameters
+            .iter()
+            .filter_map(|(_, key, value)| {
+                key.strip_prefix(prefix)
+                    .map(|path| (path.to_string(), value.clone()))
+            })
+            .collect()
+    }
+
+    /// Parameters nothing acts on, to be carried in the event's annotations.
+    ///
+    /// Recorded rather than dropped: a row someone put in the spreadsheet meant
+    /// something to them, and silently ignoring it is how a setting goes missing
+    /// on election day.
+    fn uninterpreted_parameters(&self) -> Vec<(String, Value)> {
+        self.parameters
+            .iter()
+            .filter(|(_, key, _)| {
+                !HANDLED_PARAMETERS.contains(&key.as_str())
+                    && !PARAMETER_PREFIXES
+                        .iter()
+                        .any(|prefix| key.starts_with(prefix))
+            })
+            .map(|(kind, key, value)| {
+                let name = if kind.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{kind}.{key}")
+                };
+                (name, value.clone())
+            })
+            .collect()
+    }
+
+    fn resolve_tenant_id(&self, explicit: Option<&str>) -> String {
+        if let Some(explicit) = explicit.filter(|id| !id.is_empty()) {
+            return explicit.to_string();
+        }
+        if let Some(from_parameters) = self.parameter("tenant_id") {
+            let text = value_as_text(from_parameters);
+            if !text.is_empty() {
+                return text;
+            }
+        }
+        if let Some(from_base) =
+            self.base_export.get("tenant_id").and_then(Value::as_str)
+        {
+            if !from_base.is_empty() {
+                return from_base.to_string();
+            }
+        }
+        self.ids.tenant_id()
+    }
+
+    // -- entities ---------------------------------------------------------
+
+    /// Render a template, then merge the row's dotted paths over it.
+    fn render(
+        &mut self,
+        template: &str,
+        row: Option<&Row>,
+        context: Value,
+    ) -> Map<String, Value> {
+        let rendered = match self.templates.render_json(template, &context) {
+            Ok(rendered) => rendered,
+            Err(problem) => {
+                // A template that does not render is a bug in the template, not
+                // in the document, so it is reported as-is.
+                self.report.push(problem);
+                return Map::new();
+            }
+        };
+
+        let Some(row) = row else {
+            return rendered;
+        };
+
+        let excluded = control_columns(&normalise_sheet_name(&row.sheet));
+        match row.overrides(excluded) {
+            Ok(overrides) => {
+                match deep_merge(
+                    Value::Object(rendered),
+                    Value::Object(overrides),
+                ) {
+                    Value::Object(merged) => merged,
+                    // deep_merge of two objects is an object.
+                    _ => unreachable!("merging two objects yields an object"),
+                }
+            }
+            Err(problem) => {
+                self.report.push(problem);
+                rendered
+            }
+        }
+    }
+
+    /// The first entity of `key` in the base export, scrubbed, if there is one.
+    fn base(&self, key: &str, scrub: &[&str]) -> Option<Map<String, Value>> {
+        let value = self.base_export.get(key)?;
+        let object = match value {
+            Value::Object(object) => object.clone(),
+            Value::Array(items) => match items.first() {
+                Some(Value::Object(object)) => object.clone(),
+                _ => return None,
+            },
+            _ => return None,
+        };
+        if object.is_empty() {
+            return None;
+        }
+
+        let mut scrubbed = object;
+        for field in scrub {
+            scrubbed.remove(*field);
+        }
+        Some(scrubbed)
+    }
+
+    /// Merge a scrubbed base entity under `entity`, then reassert identity.
+    ///
+    /// Identity always comes from this build, never from the base: a base export
+    /// naming its own ids is the whole reason the fields are scrubbed, and
+    /// reasserting them makes that impossible to get wrong by adding a field.
+    fn under_base(
+        &self,
+        entity: Map<String, Value>,
+        key: &str,
+        scrub: &[&str],
+        identity: &[(&str, &str)],
+    ) -> Map<String, Value> {
+        let Some(base) = self.base(key, scrub) else {
+            return entity;
+        };
+        let merged = deep_merge(Value::Object(base), Value::Object(entity));
+        let mut merged = match merged {
+            Value::Object(object) => object,
+            _ => unreachable!("merging two objects yields an object"),
+        };
+        for (field, value) in identity {
+            merged.insert((*field).to_string(), json!(value));
+        }
+        merged
+    }
+
+    fn build_election_event(&mut self) -> Value {
+        let context = json!({
+            "id": self.event_id,
+            "tenant_id": self.tenant_id,
+            "created_at": self.created_at,
+        });
+        let row = self.event_row.clone();
+        let event = self.render("election_event", Some(&row), context);
+
+        let event_id = self.event_id.clone();
+        let tenant_id = self.tenant_id.clone();
+        let mut event = self.under_base(
+            event,
+            "election_event",
+            SCRUB_EVENT,
+            &[("id", &event_id), ("tenant_id", &tenant_id)],
+        );
+
+        event.insert("external_id".to_string(), json!(self.event_external_id));
+
+        for (path, value) in self.parameter_patches("election_event.") {
+            if let Err(problem) =
+                set_path(&mut event, &split_path(&path), value)
+            {
+                self.report.push(problem);
+            }
+        }
+
+        let carried = self.uninterpreted_parameters();
+        if !carried.is_empty() {
+            let mut annotations = match event.get("annotations") {
+                Some(Value::Object(existing)) => existing.clone(),
+                _ => Map::new(),
+            };
+            let mut names: Vec<String> = Vec::new();
+            for (name, value) in carried {
+                names
+                    .push(name.rsplit('.').next().unwrap_or(&name).to_string());
+                annotations.insert(name, value);
+            }
+            event.insert("annotations".to_string(), Value::Object(annotations));
+
+            names.sort();
+            names.dedup();
+            self.warn(
+                "election_event.annotations",
+                format!(
+                    "these Parameters rows are recorded in \
+                     election_event.annotations but not interpreted: {}",
+                    names.join(", ")
+                ),
+            );
+        }
+
+        Value::Object(event)
+    }
+
+    fn build_elections(&mut self) -> Value {
+        let rows: Vec<Row> = self.workbook.rows(SHEET_ELECTIONS).to_vec();
+        let mut elections = Vec::new();
+        let mut seen: Vec<(String, usize)> = Vec::new();
+
+        for row in &rows {
+            let Some(external_id) =
+                self.require_external_id(row, "an election", &mut seen)
+            else {
+                continue;
+            };
+
+            let election_id = self.ids.uid("election", &[&external_id]);
+            self.election_ids
+                .push((external_id.clone(), election_id.clone()));
+
+            let context = json!({
+                "id": election_id,
+                "tenant_id": self.tenant_id,
+                "election_event_id": self.event_id,
+                "created_at": self.created_at,
+            });
+            let election = self.render("election", Some(row), context);
+
+            let event_id = self.event_id.clone();
+            let tenant_id = self.tenant_id.clone();
+            let mut election = self.under_base(
+                election,
+                "elections",
+                SCRUB_ELECTION,
+                &[
+                    ("id", &election_id),
+                    ("tenant_id", &tenant_id),
+                    ("election_event_id", &event_id),
+                ],
+            );
+            election.insert("external_id".to_string(), json!(external_id));
+            elections.push(Value::Object(election));
+        }
+
+        if elections.is_empty() {
+            self.problem(
+                sheet_origin("Elections"),
+                Code::MissingField,
+                "an election event needs at least one election",
+            );
+        }
+        Value::Array(elections)
+    }
+
+    fn build_contests(&mut self) -> Value {
+        let rows: Vec<Row> = self.workbook.rows(SHEET_CONTESTS).to_vec();
+        let mut contests = Vec::new();
+        let mut seen: Vec<(String, usize)> = Vec::new();
+
+        for row in &rows {
+            let Some(external_id) =
+                self.require_external_id(row, "a contest", &mut seen)
+            else {
+                continue;
+            };
+
+            let elections = self.election_ids.clone();
+            let Some(election_id) = self.resolve(
+                row,
+                "election.external_id",
+                &elections,
+                "election",
+            ) else {
+                continue;
+            };
+
+            let contest_id = self.ids.uid("contest", &[&external_id]);
+            self.contest_ids
+                .push((external_id.clone(), contest_id.clone()));
+
+            let context = json!({
+                "id": contest_id,
+                "tenant_id": self.tenant_id,
+                "election_event_id": self.event_id,
+                "election_id": election_id,
+                "created_at": self.created_at,
+            });
+            let contest = self.render("contest", Some(row), context);
+
+            let event_id = self.event_id.clone();
+            let tenant_id = self.tenant_id.clone();
+            let mut contest = self.under_base(
+                contest,
+                "contests",
+                SCRUB_CONTEST,
+                &[
+                    ("id", &contest_id),
+                    ("tenant_id", &tenant_id),
+                    ("election_event_id", &event_id),
+                    ("election_id", &election_id),
+                ],
+            );
+            contest.insert("external_id".to_string(), json!(external_id));
+            contests.push(Value::Object(contest));
+        }
+
+        if contests.is_empty() {
+            self.problem(
+                sheet_origin("Contests"),
+                Code::MissingField,
+                "an election event needs at least one contest",
+            );
+        }
+        Value::Array(contests)
+    }
+
+    fn build_candidates(&mut self) -> Value {
+        let rows: Vec<Row> = self.workbook.rows(SHEET_CANDIDATES).to_vec();
+        let mut candidates = Vec::new();
+        let mut seen: Vec<(String, usize)> = Vec::new();
+
+        for row in &rows {
+            let Some(external_id) =
+                self.require_external_id(row, "a candidate", &mut seen)
+            else {
+                continue;
+            };
+
+            let contests = self.contest_ids.clone();
+            let Some(contest_id) =
+                self.resolve(row, "contest.external_id", &contests, "contest")
+            else {
+                continue;
+            };
+
+            let candidate_id = self.ids.uid("candidate", &[&external_id]);
+            let context = json!({
+                "id": candidate_id,
+                "tenant_id": self.tenant_id,
+                "election_event_id": self.event_id,
+                "contest_id": contest_id,
+                "created_at": self.created_at,
+            });
+            let candidate = self.render("candidate", Some(row), context);
+
+            let event_id = self.event_id.clone();
+            let tenant_id = self.tenant_id.clone();
+            let mut candidate = self.under_base(
+                candidate,
+                "candidates",
+                SCRUB_CANDIDATE,
+                &[
+                    ("id", &candidate_id),
+                    ("tenant_id", &tenant_id),
+                    ("election_event_id", &event_id),
+                    ("contest_id", &contest_id),
+                ],
+            );
+            candidate.insert("external_id".to_string(), json!(external_id));
+            candidates.push(Value::Object(candidate));
+        }
+
+        Value::Array(candidates)
+    }
+
+    fn build_areas(&mut self) -> Value {
+        let rows: Vec<Row> = self.workbook.rows(SHEET_AREAS).to_vec();
+
+        // Two passes over the sheet: ids first, so a parent may appear below its
+        // own child. Authors do not sort their spreadsheets topologically.
+        let mut seen: Vec<(String, usize)> = Vec::new();
+        for row in &rows {
+            let Some(external_id) =
+                self.require_external_id(row, "an area", &mut seen)
+            else {
+                continue;
+            };
+            let area_id = self.ids.uid("area", &[&external_id]);
+            self.area_ids.push((external_id.clone(), area_id));
+
+            match row.get("name").map(value_as_text) {
+                Some(name) if !name.is_empty() => {
+                    self.area_names.push((external_id, name));
+                }
+                _ => self.problem(
+                    row.origin(Some("name")),
+                    Code::MissingField,
+                    "an area needs a name: the voters CSV identifies a \
+                     voter's area by name, not by id",
+                ),
+            }
+        }
+
+        // Names have to be unique for the same reason.
+        let names = self.area_names.clone();
+        for (index, (external_id, name)) in names.iter().enumerate() {
+            if let Some((earlier, _)) = names[..index]
+                .iter()
+                .find(|(_, seen_name)| seen_name == name)
+            {
+                self.problem(
+                    Origin {
+                        sheet: "Areas".to_string(),
+                        row: 0,
+                        column: Some("name".to_string()),
+                    },
+                    Code::DuplicateId,
+                    format!(
+                        "two areas are both named '{name}' ('{earlier}' and \
+                         '{external_id}'); the voters CSV resolves an area by \
+                         name, so names must be unique"
+                    ),
+                );
+            }
+        }
+
+        let mut areas = Vec::new();
+        for row in &rows {
+            let Some(external_id) = row.text("external_id").map(str::to_string)
+            else {
+                continue;
+            };
+            let Some(area_id) = lookup(&self.area_ids, &external_id) else {
+                continue;
+            };
+
+            let mut parent_id = None;
+            if row.get("parent.external_id").is_some() {
+                let areas_so_far = self.area_ids.clone();
+                let Some(resolved) = self.resolve(
+                    row,
+                    "parent.external_id",
+                    &areas_so_far,
+                    "area",
+                ) else {
+                    continue;
+                };
+                if resolved == area_id {
+                    self.problem(
+                        row.origin(Some("parent.external_id")),
+                        Code::AreaCycle,
+                        "an area cannot be its own parent",
+                    );
+                    continue;
+                }
+                parent_id = Some(resolved);
+            }
+
+            let context = json!({
+                "id": area_id,
+                "tenant_id": self.tenant_id,
+                "election_event_id": self.event_id,
+                "created_at": self.created_at,
+            });
+            let area = self.render("area", Some(row), context);
+
+            let event_id = self.event_id.clone();
+            let tenant_id = self.tenant_id.clone();
+            let mut area = self.under_base(
+                area,
+                "areas",
+                SCRUB_AREA,
+                &[
+                    ("id", &area_id),
+                    ("tenant_id", &tenant_id),
+                    ("election_event_id", &event_id),
+                ],
+            );
+            if let Some(parent_id) = parent_id {
+                area.insert("parent_id".to_string(), json!(parent_id));
+            }
+            areas.push(Value::Object(area));
+        }
+
+        if areas.is_empty() {
+            self.problem(
+                sheet_origin("Areas"),
+                Code::MissingField,
+                "an election event needs at least one area; every voter \
+                 belongs to one",
+            );
+        }
+        Value::Array(areas)
+    }
+
+    fn build_area_contests(&mut self) -> Value {
+        let rows: Vec<Row> = self.workbook.rows(SHEET_AREA_CONTESTS).to_vec();
+        let mut links = Vec::new();
+        let mut seen: Vec<((String, String), usize)> = Vec::new();
+
+        for row in &rows {
+            let areas = self.area_ids.clone();
+            let contests = self.contest_ids.clone();
+            let area_external = row
+                .text("area.external_id")
+                .map(str::trim)
+                .unwrap_or_default()
+                .to_string();
+            let contest_external = row
+                .text("contest.external_id")
+                .map(str::trim)
+                .unwrap_or_default()
+                .to_string();
+
+            let area_id = self.resolve(row, "area.external_id", &areas, "area");
+            let contest_id =
+                self.resolve(row, "contest.external_id", &contests, "contest");
+            let (Some(area_id), Some(contest_id)) = (area_id, contest_id)
+            else {
+                continue;
+            };
+
+            let key = (area_external, contest_external);
+            if let Some((_, earlier)) =
+                seen.iter().find(|(seen_key, _)| seen_key == &key)
+            {
+                let message = format!(
+                    "area '{}' is already linked to contest '{}' on row {earlier}",
+                    key.0, key.1
+                );
+                self.problem(row.origin(None), Code::DuplicateId, message);
+                continue;
+            }
+            seen.push((key.clone(), row.number));
+
+            let context = json!({
+                "id": self.ids.uid("area_contest", &[&key.0, &key.1]),
+                "area_id": area_id,
+                "contest_id": contest_id,
+            });
+            let link = self.render("area_contest", Some(row), context);
+            links.push(Value::Object(link));
+        }
+
+        if links.is_empty() {
+            self.problem(
+                sheet_origin("AreaContests"),
+                Code::BallotCoverage,
+                "no area is linked to any contest, so no voter would see a \
+                 ballot",
+            );
+        }
+        Value::Array(links)
+    }
+
+    // -- shared row handling ----------------------------------------------
+
+    /// The row's `external_id`, or a problem naming what is wrong with it.
+    fn require_external_id(
+        &mut self,
+        row: &Row,
+        what: &str,
+        seen: &mut Vec<(String, usize)>,
+    ) -> Option<String> {
+        let external_id = match row.get("external_id").map(value_as_text) {
+            Some(id) if !id.trim().is_empty() => id.trim().to_string(),
+            _ => {
+                self.problem(
+                    row.origin(Some("external_id")),
+                    Code::MissingField,
+                    format!("{what} needs an external_id"),
+                );
+                return None;
+            }
+        };
+
+        if let Some((_, earlier)) =
+            seen.iter().find(|(id, _)| id == &external_id)
+        {
+            let message = format!(
+                "external_id '{external_id}' is already used by row {earlier}"
+            );
+            self.problem(
+                row.origin(Some("external_id")),
+                Code::DuplicateId,
+                message,
+            );
+            return None;
+        }
+        seen.push((external_id.clone(), row.number));
+        Some(external_id)
+    }
+
+    /// `external_id` -> UUID, recording a problem when it does not resolve.
+    fn resolve(
+        &mut self,
+        row: &Row,
+        column: &str,
+        table: &[(String, String)],
+        kind: &str,
+    ) -> Option<String> {
+        let Some(raw) = row.get(column).map(value_as_text) else {
+            self.problem(
+                row.origin(Some(column)),
+                Code::MissingField,
+                // Phrased without an article on purpose: "a election" is what
+                // the obvious formatting gives, and this message is read by
+                // whoever has to fix the file.
+                format!(
+                    "'{column}' is required: it names the {kind} this row belongs to"
+                ),
+            );
+            return None;
+        };
+        let key = raw.trim();
+        match lookup(table, key) {
+            Some(resolved) => Some(resolved),
+            None => {
+                self.problem(
+                    row.origin(Some(column)),
+                    Code::DanglingReference,
+                    format!("no {kind} has external_id '{key}'"),
+                );
+                None
+            }
+        }
+    }
+}
+
+/// The one row of the ElectionEvent sheet.
+fn event_row(workbook: &Workbook) -> Result<Row, Problem> {
+    let rows = workbook.rows(SHEET_ELECTION_EVENT);
+    match rows.len() {
+        0 => Err(Problem::error(
+            Code::MissingField,
+            "sheet 'ElectionEvent'",
+            "this sheet is empty; it must hold exactly one row, with at least \
+             an 'external_id' column",
+        )),
+        1 => Ok(rows[0].clone()),
+        count => Err(Problem::error(
+            Code::InvalidValue,
+            "sheet 'ElectionEvent'",
+            format!(
+                "this sheet holds {count} rows; an import describes exactly \
+                 one election event"
+            ),
+        )),
+    }
+}
+
+fn sheet_origin(sheet: &str) -> Origin {
+    Origin {
+        sheet: sheet.to_string(),
+        row: 0,
+        column: None,
+    }
+}
+
+fn lookup(table: &[(String, String)], key: &str) -> Option<String> {
+    table
+        .iter()
+        .find(|(external_id, _)| external_id == key)
+        .map(|(_, id)| id.clone())
+}
+
+/// A JSON value as the text a reference column means.
+///
+/// A number typed into an id column is an id, not a number: `1001` as an
+/// `external_id` has to match `1001` written in a reference column, whichever way
+/// each cell happened to be formatted.
+fn value_as_text(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+/// A filesystem-safe name derived from the event's `external_id`.
+fn slugify(value: &str) -> String {
+    let mut slug = String::with_capacity(value.len());
+    for character in value.trim().chars() {
+        if character.is_ascii_alphanumeric() {
+            slug.extend(character.to_lowercase());
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+    }
+    let trimmed = slug.trim_matches('-');
+    if trimmed.is_empty() {
+        "election-event".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+#[path = "build_tests.rs"]
+mod build_tests;
+
+/// Whether a report holds an error whose message contains `needle`.
+#[cfg(test)]
+pub(crate) fn has_error_saying(report: &Report, needle: &str) -> bool {
+    report
+        .errors()
+        .any(|problem| problem.message.contains(needle))
+}

--- a/packages/sequent-core/src/election_config/build_tests.rs
+++ b/packages/sequent-core/src/election_config/build_tests.rs
@@ -1,0 +1,818 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`], in their own file because there are more of them than
+//! there is builder.
+
+use super::*;
+use crate::election_config::paths::Cell;
+use crate::election_config::sheet::Sheet;
+
+fn text(value: &str) -> Cell {
+    Cell::text(value)
+}
+
+/// A document that builds cleanly, for a test to break one thing about.
+///
+/// Deliberately minimal: one election, one contest with two candidates, two areas
+/// and the ballot links between them. Everything a test needs is either here or
+/// the point of the test.
+fn sound() -> Workbook {
+    workbook(vec![
+        (
+            "ElectionEvent",
+            vec![
+                vec![text("external_id"), text("presentation.i18n.en.name")],
+                vec![text("union-2027"), text("Union Election 2027")],
+            ],
+        ),
+        (
+            "Elections",
+            vec![
+                vec![text("external_id"), text("presentation.i18n.en.name")],
+                vec![text("statewide"), text("Statewide Officers")],
+            ],
+        ),
+        (
+            "Contests",
+            vec![
+                vec![
+                    text("external_id"),
+                    text("election.external_id"),
+                    text("presentation.i18n.en.name"),
+                    text("max_votes"),
+                ],
+                vec![
+                    text("president"),
+                    text("statewide"),
+                    text("President"),
+                    Cell::Int(1),
+                ],
+            ],
+        ),
+        (
+            "Candidates",
+            vec![
+                vec![
+                    text("external_id"),
+                    text("contest.external_id"),
+                    text("presentation.i18n.en.name"),
+                ],
+                vec![text("alice"), text("president"), text("Alice")],
+                vec![text("bob"), text("president"), text("Bob")],
+            ],
+        ),
+        (
+            "Areas",
+            vec![
+                vec![text("external_id"), text("name")],
+                vec![text("area-north"), text("North")],
+                vec![text("area-south"), text("South")],
+            ],
+        ),
+        (
+            "AreaContests",
+            vec![
+                vec![text("area.external_id"), text("contest.external_id")],
+                vec![text("area-north"), text("president")],
+                vec![text("area-south"), text("president")],
+            ],
+        ),
+    ])
+}
+
+fn workbook(sheets: Vec<(&str, Vec<Vec<Cell>>)>) -> Workbook {
+    Workbook::new(
+        sheets
+            .into_iter()
+            .map(|(name, grid)| Sheet::from_grid(name, &grid).unwrap())
+            .collect(),
+    )
+    .unwrap()
+}
+
+/// The sound document with one sheet replaced.
+fn with_sheet(name: &str, grid: Vec<Vec<Cell>>) -> Workbook {
+    let mut sheets: Vec<Sheet> = sound()
+        .sheets()
+        .iter()
+        .filter(|sheet| sheet.name != name)
+        .cloned()
+        .collect();
+    sheets.push(Sheet::from_grid(name, &grid).unwrap());
+    Workbook::new(sheets).unwrap()
+}
+
+fn built(workbook: &Workbook) -> Bundle {
+    let templates = TemplateSet::builtin().unwrap();
+    match build(workbook, &templates, &BuildOptions::default()) {
+        Ok(bundle) => bundle,
+        Err(report) => panic!("expected a clean build, got:\n{report}"),
+    }
+}
+
+fn refused(workbook: &Workbook) -> Report {
+    let templates = TemplateSet::builtin().unwrap();
+    match build(workbook, &templates, &BuildOptions::default()) {
+        Ok(_) => panic!("expected a refusal"),
+        Err(report) => report,
+    }
+}
+
+// -- the happy path -------------------------------------------------------
+
+#[test]
+fn a_sound_document_builds() {
+    let bundle = built(&sound());
+    assert_eq!(bundle.event_external_id, "union-2027");
+    assert_eq!(bundle.export["elections"].as_array().unwrap().len(), 1);
+    assert_eq!(bundle.export["contests"].as_array().unwrap().len(), 1);
+    assert_eq!(bundle.export["candidates"].as_array().unwrap().len(), 2);
+    assert_eq!(bundle.export["areas"].as_array().unwrap().len(), 2);
+    assert_eq!(bundle.export["area_contests"].as_array().unwrap().len(), 2);
+    assert!(!bundle.warnings.has_errors());
+}
+
+#[test]
+fn what_it_builds_is_a_bundle_the_platform_accepts() {
+    // The property that makes sharing this code worth anything: the document the
+    // builder produces deserializes into the importer's own struct and passes the
+    // importer's own validation. Two implementations that merely look similar
+    // would not.
+    let bundle = built(&sound());
+    let schema: crate::election_config::ImportElectionEventSchema =
+        serde_json::from_value(bundle.export.clone())
+            .expect("the built export must deserialize into the import schema");
+
+    let report = crate::election_config::validate(&schema);
+    assert!(
+        !report.has_errors(),
+        "a document that builds cleanly must also validate:\n{report}"
+    );
+}
+
+#[test]
+fn the_same_document_builds_the_same_bytes_twice() {
+    // Fixed timestamps and derived ids exist for this: a regenerated bundle must
+    // diff only where the author changed something.
+    let first = serde_json::to_string(&built(&sound()).export).unwrap();
+    let second = serde_json::to_string(&built(&sound()).export).unwrap();
+    assert_eq!(first, second);
+}
+
+#[test]
+fn the_references_resolve_to_the_ids_the_entities_carry() {
+    let bundle = built(&sound());
+    let election_id = bundle.export["elections"][0]["id"].as_str().unwrap();
+    let contest = &bundle.export["contests"][0];
+    let candidate = &bundle.export["candidates"][0];
+
+    assert_eq!(contest["election_id"].as_str().unwrap(), election_id);
+    assert_eq!(
+        candidate["contest_id"].as_str().unwrap(),
+        contest["id"].as_str().unwrap()
+    );
+    assert_eq!(
+        bundle.export["area_contests"][0]["contest_id"]
+            .as_str()
+            .unwrap(),
+        contest["id"].as_str().unwrap()
+    );
+}
+
+#[test]
+fn every_entity_belongs_to_the_event_and_the_tenant() {
+    let bundle = built(&sound());
+    for key in ["elections", "contests", "candidates", "areas"] {
+        for entity in bundle.export[key].as_array().unwrap() {
+            assert_eq!(
+                entity["election_event_id"].as_str().unwrap(),
+                bundle.event_id,
+                "{key}"
+            );
+            assert_eq!(
+                entity["tenant_id"].as_str().unwrap(),
+                bundle.tenant_id,
+                "{key}"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_column_becomes_a_nested_field() {
+    // The dotted-header mapping, end to end: a new column lands in the output
+    // with no code change, which is what keeps the builder client-agnostic.
+    let bundle = built(&sound());
+    assert_eq!(
+        bundle.export["contests"][0]["presentation"]["i18n"]["en"]["name"],
+        json!("President")
+    );
+    assert_eq!(bundle.export["contests"][0]["max_votes"], json!(1));
+}
+
+#[test]
+fn a_control_column_is_consumed_rather_than_merged() {
+    // `election.external_id` names a reference; it must not become a field called
+    // `external_id` on an object called `election`.
+    let bundle = built(&sound());
+    assert!(bundle.export["contests"][0].get("election").is_none());
+    assert!(bundle.export["areas"][0].get("parent").is_none());
+    assert!(bundle.export["area_contests"][0].get("area").is_none());
+}
+
+#[test]
+fn the_reports_and_scheduled_events_the_importer_ignores_are_left_alone() {
+    // Both travel in their own CSV. A populated array here is silently dropped,
+    // which is how a report goes missing without an error.
+    let bundle = built(&sound());
+    assert_eq!(bundle.export["reports"], json!([]));
+    assert_eq!(bundle.export["scheduled_events"], Value::Null);
+}
+
+// -- identity -------------------------------------------------------------
+
+#[test]
+fn an_event_with_no_external_id_stops_the_build_immediately() {
+    // Every generated id is derived from it, so there is nothing to build.
+    let report = refused(&with_sheet(
+        "ElectionEvent",
+        vec![
+            vec![text("external_id"), text("presentation.i18n.en.name")],
+            vec![Cell::Blank, text("Nameless")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "needs an external_id"));
+}
+
+#[test]
+fn an_empty_event_sheet_says_what_it_wanted() {
+    let report = refused(&with_sheet(
+        "ElectionEvent",
+        vec![vec![text("external_id")]],
+    ));
+    assert!(has_error_saying(&report, "exactly one row"));
+}
+
+#[test]
+fn two_event_rows_are_refused_rather_than_the_first_one_winning() {
+    // Picking one silently would import half of what someone meant.
+    let report = refused(&with_sheet(
+        "ElectionEvent",
+        vec![
+            vec![text("external_id")],
+            vec![text("one")],
+            vec![text("two")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "exactly one election event"));
+}
+
+#[test]
+fn a_duplicated_external_id_names_the_row_that_used_it_first() {
+    let report = refused(&with_sheet(
+        "Elections",
+        vec![
+            vec![text("external_id")],
+            vec![text("statewide")],
+            vec![text("statewide")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "already used by row 2"));
+}
+
+#[test]
+fn every_problem_is_reported_in_one_run() {
+    // An author fixing a spreadsheet wants the whole list, not one round trip per
+    // mistake.
+    let report = refused(&with_sheet(
+        "Candidates",
+        vec![
+            vec![text("external_id"), text("contest.external_id")],
+            vec![Cell::Blank, text("president")],
+            vec![text("alice"), text("no-such-contest")],
+            vec![text("bob"), Cell::Blank],
+        ],
+    ));
+    assert_eq!(report.errors().count(), 3, "{report}");
+}
+
+#[test]
+fn a_problem_names_the_sheet_and_row_to_look_at() {
+    let report = refused(&with_sheet(
+        "Contests",
+        vec![
+            vec![text("external_id"), text("election.external_id")],
+            vec![text("president"), text("no-such-election")],
+        ],
+    ));
+    let problem = report.errors().next().unwrap();
+    assert_eq!(
+        problem.path,
+        "sheet 'Contests' row 2 column 'election.external_id'"
+    );
+    assert_eq!(problem.code, Code::DanglingReference);
+}
+
+// -- references -----------------------------------------------------------
+
+#[test]
+fn a_contest_pointing_at_no_election_is_refused() {
+    let report = refused(&with_sheet(
+        "Contests",
+        vec![
+            vec![text("external_id"), text("election.external_id")],
+            vec![text("president"), text("nowhere")],
+        ],
+    ));
+    assert!(has_error_saying(
+        &report,
+        "no election has external_id 'nowhere'"
+    ));
+}
+
+#[test]
+fn a_missing_reference_column_is_refused_too() {
+    let report = refused(&with_sheet(
+        "Contests",
+        vec![vec![text("external_id")], vec![text("president")]],
+    ));
+    assert!(has_error_saying(
+        &report,
+        "'election.external_id' is required: it names the election this row \
+         belongs to"
+    ));
+}
+
+#[test]
+fn a_numeric_id_matches_the_same_number_written_as_text() {
+    // Whether a cell was formatted as a number is not something an author
+    // controls per column, and an id is an id.
+    let mut sheets: Vec<Sheet> = sound()
+        .sheets()
+        .iter()
+        .filter(|sheet| sheet.name != "Elections" && sheet.name != "Contests")
+        .cloned()
+        .collect();
+    sheets.push(
+        Sheet::from_grid(
+            "Elections",
+            &[vec![text("external_id")], vec![Cell::Int(1001)]],
+        )
+        .unwrap(),
+    );
+    sheets.push(
+        Sheet::from_grid(
+            "Contests",
+            &[
+                vec![text("external_id"), text("election.external_id")],
+                vec![text("president"), text("1001")],
+            ],
+        )
+        .unwrap(),
+    );
+    let bundle = built(&Workbook::new(sheets).unwrap());
+    assert_eq!(
+        bundle.export["contests"][0]["election_id"],
+        bundle.export["elections"][0]["id"]
+    );
+}
+
+// -- areas ----------------------------------------------------------------
+
+#[test]
+fn a_parent_may_appear_below_its_own_child() {
+    // Authors do not sort their spreadsheets topologically, so ids are collected
+    // in a first pass.
+    let bundle = built(&with_sheet(
+        "Areas",
+        vec![
+            vec![
+                text("external_id"),
+                text("name"),
+                text("parent.external_id"),
+            ],
+            vec![text("area-north"), text("North"), text("area-state")],
+            vec![text("area-south"), text("South"), text("area-state")],
+            vec![text("area-state"), text("Statewide"), Cell::Blank],
+        ],
+    ));
+    let north = &bundle.export["areas"][0];
+    let state = &bundle.export["areas"][2];
+    assert_eq!(north["parent_id"], state["id"]);
+    assert_eq!(state["parent_id"], Value::Null);
+}
+
+#[test]
+fn an_area_cannot_be_its_own_parent() {
+    let report = refused(&with_sheet(
+        "Areas",
+        vec![
+            vec![
+                text("external_id"),
+                text("name"),
+                text("parent.external_id"),
+            ],
+            vec![text("area-north"), text("North"), text("area-north")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "cannot be its own parent"));
+    assert_eq!(report.errors().next().unwrap().code, Code::AreaCycle);
+}
+
+#[test]
+fn an_area_needs_a_name_because_the_voters_csv_resolves_by_name() {
+    let report = refused(&with_sheet(
+        "Areas",
+        vec![
+            vec![text("external_id"), text("name")],
+            vec![text("area-north"), Cell::Blank],
+        ],
+    ));
+    assert!(has_error_saying(
+        &report,
+        "identifies a voter's area by name"
+    ));
+}
+
+#[test]
+fn two_areas_may_not_share_a_name() {
+    // The voters CSV resolves an area by name, so a duplicate silently assigns
+    // voters to whichever one the importer happens to find.
+    let report = refused(&with_sheet(
+        "Areas",
+        vec![
+            vec![text("external_id"), text("name")],
+            vec![text("area-north"), text("North")],
+            vec![text("area-south"), text("North")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "both named 'North'"));
+}
+
+// -- ballot coverage ------------------------------------------------------
+
+#[test]
+fn a_document_with_no_ballot_links_is_refused() {
+    let report = refused(&with_sheet(
+        "AreaContests",
+        vec![vec![text("area.external_id"), text("contest.external_id")]],
+    ));
+    assert!(has_error_saying(&report, "no voter would see a ballot"));
+}
+
+#[test]
+fn the_same_area_and_contest_may_not_be_linked_twice() {
+    // Both rows would mint the same id, and one would silently overwrite the
+    // other.
+    let report = refused(&with_sheet(
+        "AreaContests",
+        vec![
+            vec![text("area.external_id"), text("contest.external_id")],
+            vec![text("area-north"), text("president")],
+            vec![text("area-north"), text("president")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "already linked"));
+}
+
+#[test]
+fn an_event_with_no_elections_contests_or_areas_says_so_about_each() {
+    let mut sheets: Vec<Sheet> = vec![Sheet::from_grid(
+        "ElectionEvent",
+        &[vec![text("external_id")], vec![text("empty-event")]],
+    )
+    .unwrap()];
+    for name in ["Elections", "Contests", "Areas", "AreaContests"] {
+        sheets.push(
+            Sheet::from_grid(name, &[vec![text("external_id")]]).unwrap(),
+        );
+    }
+    let report = refused(&Workbook::new(sheets).unwrap());
+    assert!(has_error_saying(&report, "at least one election"));
+    assert!(has_error_saying(&report, "at least one contest"));
+    assert!(has_error_saying(&report, "at least one area"));
+}
+
+// -- options --------------------------------------------------------------
+
+#[test]
+fn a_tenant_id_may_be_supplied() {
+    let templates = TemplateSet::builtin().unwrap();
+    let bundle = build(
+        &sound(),
+        &templates,
+        &BuildOptions {
+            tenant_id: Some("11111111-1111-4111-8111-111111111111".to_string()),
+            ..BuildOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(bundle.tenant_id, "11111111-1111-4111-8111-111111111111");
+    assert_eq!(
+        bundle.export["tenant_id"],
+        json!("11111111-1111-4111-8111-111111111111")
+    );
+}
+
+#[test]
+fn a_parameter_supplies_the_tenant_id_when_no_option_does() {
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("tenant_id"),
+                text("22222222-2222-4222-8222-222222222222"),
+            ],
+        ],
+    ));
+    assert_eq!(bundle.tenant_id, "22222222-2222-4222-8222-222222222222");
+}
+
+#[test]
+fn without_one_the_tenant_id_is_derived_and_stable() {
+    // Only a fallback, but it must not change between runs or every regeneration
+    // is a diff.
+    assert_eq!(built(&sound()).tenant_id, built(&sound()).tenant_id);
+}
+
+#[test]
+fn the_slug_comes_from_the_event_or_the_caller() {
+    assert_eq!(built(&sound()).slug, "union-2027");
+
+    let templates = TemplateSet::builtin().unwrap();
+    let bundle = build(
+        &sound(),
+        &templates,
+        &BuildOptions {
+            slug: Some("chosen".to_string()),
+            ..BuildOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(bundle.slug, "chosen");
+}
+
+#[test]
+fn a_slug_is_filesystem_safe_whatever_the_external_id_looks_like() {
+    assert_eq!(
+        slugify("SEIU 1000 / Leadership 2027"),
+        "seiu-1000-leadership-2027"
+    );
+    assert_eq!(slugify("  --already--  "), "already");
+    assert_eq!(slugify("!!!"), "election-event");
+    assert_eq!(slugify(""), "election-event");
+}
+
+#[test]
+fn a_created_at_may_be_supplied_and_reaches_every_entity() {
+    let templates = TemplateSet::builtin().unwrap();
+    let bundle = build(
+        &sound(),
+        &templates,
+        &BuildOptions {
+            created_at: Some("2030-06-01T00:00:00.000000Z".to_string()),
+            ..BuildOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        bundle.export["contests"][0]["created_at"],
+        json!("2030-06-01T00:00:00.000000Z")
+    );
+}
+
+// -- parameters -----------------------------------------------------------
+
+#[test]
+fn a_dotted_parameter_patches_the_event() {
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("event"),
+                text("election_event.presentation.theme"),
+                text("dark"),
+            ],
+        ],
+    ));
+    assert_eq!(
+        bundle.export["election_event"]["presentation"]["theme"],
+        json!("dark")
+    );
+}
+
+#[test]
+fn a_parameter_nothing_interprets_is_recorded_and_said_out_loud() {
+    // Dropping it silently is how a setting goes missing on election day.
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![text("client"), text("helpdesk_phone"), text("555-0100")],
+        ],
+    ));
+    assert_eq!(
+        bundle.export["election_event"]["annotations"]["client.helpdesk_phone"],
+        json!("555-0100")
+    );
+    assert!(bundle
+        .warnings
+        .warnings()
+        .any(|problem| problem.message.contains("helpdesk_phone")));
+}
+
+#[test]
+fn a_parameter_with_no_value_is_ignored_with_a_warning() {
+    // A placeholder an author left blank, pending something from the client.
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![text("settings"), text("saml_idp_metadata_url"), Cell::Blank],
+        ],
+    ));
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("has no value and is ignored")));
+    assert!(bundle.export["election_event"]
+        .get("annotations")
+        .and_then(
+            |annotations| annotations.get("settings.saml_idp_metadata_url")
+        )
+        .is_none());
+}
+
+#[test]
+fn a_row_with_no_key_is_a_note_to_the_author_and_is_skipped() {
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value"), text("comment")],
+            vec![
+                Cell::Blank,
+                Cell::Blank,
+                Cell::Blank,
+                text("ask the client"),
+            ],
+        ],
+    ));
+    assert!(bundle.warnings.is_empty(), "{}", bundle.warnings);
+}
+
+// -- base export ----------------------------------------------------------
+
+#[test]
+fn a_base_export_contributes_fields_the_templates_do_not_know() {
+    // What a base export is for: a newer platform version's additions arrive
+    // without a template change.
+    let templates = TemplateSet::builtin().unwrap();
+    let bundle = build(
+        &sound(),
+        &templates,
+        &BuildOptions {
+            base_export: Some(json!({
+                "election_event": {"a_new_field": "from the base"},
+                "version": "v11.0.0",
+            })),
+            ..BuildOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        bundle.export["election_event"]["a_new_field"],
+        json!("from the base")
+    );
+    assert_eq!(bundle.export["version"], json!("v11.0.0"));
+}
+
+#[test]
+fn a_base_export_never_supplies_identity() {
+    // The base names its own ids, its own board and its own keys. Carrying any of
+    // them over produces an event that looks configured and is not.
+    let templates = TemplateSet::builtin().unwrap();
+    let bundle = build(
+        &sound(),
+        &templates,
+        &BuildOptions {
+            base_export: Some(json!({
+                "election_event": {
+                    "id": "99999999-9999-4999-8999-999999999999",
+                    "tenant_id": "88888888-8888-4888-8888-888888888888",
+                    "external_id": "someone-elses-event",
+                    "bulletin_board_reference": "board-of-the-other-event",
+                    "public_key": "not our key",
+                    "statistics": {"votes": 4213},
+                    "status": "finished",
+                },
+            })),
+            ..BuildOptions::default()
+        },
+    )
+    .unwrap();
+
+    let event = &bundle.export["election_event"];
+    assert_eq!(event["id"].as_str().unwrap(), bundle.event_id);
+    assert_eq!(event["tenant_id"].as_str().unwrap(), bundle.tenant_id);
+    assert_eq!(event["external_id"], json!("union-2027"));
+
+    // The templates declare all four with platform defaults, so what scrubbing
+    // guarantees is that the base's own values are gone — a fresh board, no key,
+    // and a status describing an event that has not run.
+    assert_eq!(event["bulletin_board_reference"], Value::Null);
+    assert_eq!(event["public_key"], Value::Null);
+    assert_ne!(event["statistics"], json!({"votes": 4213}));
+    assert_ne!(event["status"], json!("finished"));
+    assert_eq!(event["status"]["voting_status"], json!("NOT_STARTED"));
+}
+
+#[test]
+fn a_base_export_does_not_override_what_the_author_wrote() {
+    // Merged under the templates, not over them.
+    let templates = TemplateSet::builtin().unwrap();
+    let bundle = build(
+        &sound(),
+        &templates,
+        &BuildOptions {
+            base_export: Some(json!({
+                "elections": [{"presentation": {"i18n": {"en": {"name": "Base name"}}}}],
+            })),
+            ..BuildOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        bundle.export["elections"][0]["presentation"]["i18n"]["en"]["name"],
+        json!("Statewide Officers")
+    );
+}
+
+#[test]
+fn a_base_export_with_nothing_useful_in_it_changes_nothing() {
+    let templates = TemplateSet::builtin().unwrap();
+    let with_base = build(
+        &sound(),
+        &templates,
+        &BuildOptions {
+            base_export: Some(json!({"elections": [], "election_event": {}})),
+            ..BuildOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        serde_json::to_string(&with_base.export).unwrap(),
+        serde_json::to_string(&built(&sound()).export).unwrap()
+    );
+}
+
+// -- templates ------------------------------------------------------------
+
+#[test]
+fn an_overridden_template_is_what_gets_built() {
+    // The split that keeps client configuration out of the code.
+    let templates = TemplateSet::with_overrides(&[(
+        "area",
+        r#"{"id": "{{id}}", "name": "", "description": "", "presentation": {"allow_early_voting": "early_voting_allowed"}}"#,
+    )])
+    .unwrap();
+    let bundle = build(&sound(), &templates, &BuildOptions::default()).unwrap();
+    assert_eq!(
+        bundle.export["areas"][0]["presentation"]["allow_early_voting"],
+        json!("early_voting_allowed")
+    );
+    // And the row's own columns still win over the override.
+    assert_eq!(bundle.export["areas"][0]["name"], json!("North"));
+}
+
+#[test]
+fn a_template_that_renders_broken_json_is_reported_not_panicked() {
+    let templates =
+        TemplateSet::with_overrides(&[("area", "{\"oops\": }")]).unwrap();
+    let report = build(&sound(), &templates, &BuildOptions::default())
+        .expect_err("a broken template must refuse the build");
+    assert!(has_error_saying(&report, "did not render valid JSON"));
+}
+
+// -- shape conflicts ------------------------------------------------------
+
+#[test]
+fn columns_that_disagree_about_a_shape_are_reported_against_the_cell() {
+    let report = refused(&with_sheet(
+        "Elections",
+        vec![
+            vec![
+                text("external_id"),
+                text("presentation"),
+                text("presentation.i18n"),
+            ],
+            vec![text("statewide"), text("plain"), text("{}")],
+        ],
+    ));
+    let problem = report.errors().next().unwrap();
+    assert_eq!(problem.code, Code::ConflictingColumns);
+    assert!(problem.path.contains("sheet 'Elections' row 2"));
+}

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -23,6 +23,11 @@
 //! See `beyond/docs/docusaurus/docs/engineering/election-config-architecture.md`
 //! and <https://github.com/sequentech/meta/issues/12769>.
 
+/// Turning a source document's rows into a bundle. Needs the templates, so it
+/// shares their feature.
+#[cfg(feature = "election_config_templates")]
+pub mod build;
+
 pub mod emit;
 pub mod ids;
 pub mod paths;
@@ -46,6 +51,8 @@ pub mod xlsx;
 #[cfg(test)]
 mod validate_tests;
 
+#[cfg(feature = "election_config_templates")]
+pub use build::{build, BuildOptions, Bundle};
 pub use emit::{json_csv, plain_csv, JsonField};
 pub use ids::IdFactory;
 pub use paths::{coerce_cell, deep_merge, expand, Cell};


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2974.** Base branch is
`feat/meta-12769-render/main`, so this diff shows only what is added on top.

Rows to entities: each one a rendered template with the row's dotted-path columns
deep-merged over it, identified by a uuid5, and joined to the others by
`external_id`. Nothing reaches for a clock or a filesystem, so the same build runs
in `step-cli` and in a browser and produces the same bytes.

## The test that makes sharing this worth anything

`what_it_builds_is_a_bundle_the_platform_accepts`: the document the builder
produces **deserializes into `ImportElectionEventSchema`** — the importer's own
struct — and **passes `validate()`** — the importer's own rules. Two
implementations that merely looked similar would not. Before this stack, janitor's
Python could and did produce bundles the platform quietly mangled.

## Problems accumulate, and each names a cell

An author fixing a spreadsheet wants the whole list, not one round trip per
mistake. A bundle path like `contests[3].election_id` is no use to whoever has to
edit the file, so every problem carries the sheet and row as the spreadsheet shows
them:

```
error: sheet 'Contests' row 2 column 'election.external_id': no election has external_id 'nowhere'
```

A test with three separate mistakes asserts all three are reported in one run.

## Decisions carried over, each now with a test saying why

**A control column is consumed, not merged.** `election.external_id` is how a
contest names its election, not a field called `external_id` on an object called
`election`.

**Areas are read in two passes**, so a parent may appear below its own child —
authors do not sort their spreadsheets topologically. An area may not be its own
parent.

**An area needs a name, and two areas may not share one**, because the voters CSV
resolves a voter's area *by name*. A duplicate silently assigns voters to whichever
one the importer finds first.

**A base export is merged under the templates, never over them**, and its identity
fields are scrubbed first: its ids, its bulletin board, its keys, and a
`statistics`/`status` block describing a run that already happened. Carrying any of
those over produces an event that looks configured and is not. Identity is
reasserted *after* the merge, so adding a field cannot reintroduce the bug.

**`reports` stays `[]` and `scheduled_events` stays `null`.** Both travel in their
own CSV; a populated array here is silently dropped, which is how a report goes
missing without an error.

**A parameter nothing interprets is recorded in `election_event.annotations` with a
warning**, not dropped — dropping it is how a setting goes missing on election day.
A parameter with no value is a placeholder the author left blank, and says so.

**An id typed as a number matches the same number written as text.** Whether a cell
was formatted as a number is not something an author controls per column.

## One message improved rather than ported

The Python's `"a election reference is required"` is now phrased without an article
to get wrong: `'election.external_id' is required: it names the election this row
belongs to`.

## What is not here yet

This level builds the JSON document. The CSV members (voters, scheduled events,
reports, admin users, permissions, communication templates), the auth presets and
the Keycloak realm are the next levels of the same port — `keycloak_event_realm` is
`null` until then. Said out loud in the module docs so nobody reads the omission as
a decision.

## Verified

- `cargo test -p sequent-core --lib --features election_config_xlsx,election_config_templates election_config` — **200 passed**, 0 failed (159 before, 41 new).
- `cargo check -p sequent-core --features default_features` clean — the feature gate holds.
- `cargo check -p windmill` clean.
- `cargo build` emits no warnings for this module; `cargo fmt --check` clean; `cargo clippy --lib --tests` silent on it.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

_Not applicable — this level is a library module with no UI._
