### PR TITLE
✨ Build the bundle's CSV members in the shared core

### DIFF
--- a/packages/sequent-core/src/election_config/build.rs
+++ b/packages/sequent-core/src/election_config/build.rs
@@ -15,10 +15,12 @@
 //! problem carries the sheet and row it came from, because a bundle path is no
 //! use to whoever has to edit the file.
 //!
-//! This level builds the JSON document — the event and its elections, contests,
-//! candidates, areas and ballot links. The CSV members (voters, scheduled events,
-//! reports, admin users), the auth presets and the Keycloak realm are the next
-//! levels of the same port; `keycloak_event_realm` is left null until then.
+//! The CSV members and the files that travel beside a bundle are in
+//! `build_tables.rs`, a child module, so that this file stays readable; the two
+//! are one unit of code split across two files.
+//!
+//! The auth presets and the Keycloak realm are the next level of the same port;
+//! `keycloak_event_realm` is left null until then.
 
 use crate::election_config::ids::IdFactory;
 use crate::election_config::paths::{deep_merge, set_path, split_path};
@@ -27,9 +29,18 @@ use crate::election_config::render::TemplateSet;
 use crate::election_config::sheet::{
     normalise_sheet_name, Origin, Row, Workbook, SHEET_AREAS,
     SHEET_AREA_CONTESTS, SHEET_CANDIDATES, SHEET_CONTESTS, SHEET_ELECTIONS,
-    SHEET_ELECTION_EVENT, SHEET_PARAMETERS,
+    SHEET_ELECTION_EVENT, SHEET_PARAMETERS, SHEET_REPORTS,
+    SHEET_SCHEDULED_EVENTS,
 };
 use serde_json::{json, Map, Value};
+
+#[path = "build_tables.rs"]
+mod tables;
+
+pub use tables::{
+    CommunicationTemplate, JsonTable, PlainTable, EVENT_PROCESSORS,
+    VOTER_LEADING_COLUMNS,
+};
 
 /// Timestamp on every generated entity.
 ///
@@ -53,6 +64,21 @@ pub fn control_columns(sheet_key: &str) -> &'static [&'static str] {
         SHEET_CANDIDATES => &["contest.external_id"],
         SHEET_AREAS => &["parent.external_id"],
         SHEET_AREA_CONTESTS => &["area.external_id", "contest.external_id"],
+        SHEET_SCHEDULED_EVENTS => &[
+            "event_name",
+            "event_type",
+            "election.external_id",
+            "scheduled_datetime",
+        ],
+        SHEET_REPORTS => &[
+            "election.external_id",
+            "template.alias",
+            "report_type",
+            "cron_config",
+            "encryption_policy",
+            "password",
+            "permission_label",
+        ],
         _ => &[],
     }
 }
@@ -166,6 +192,30 @@ pub struct Bundle {
 
     /// The `export_election_event-<id>.json` document.
     pub export: Value,
+
+    /// `export_voters-<id>.csv`.
+    pub voters: PlainTable,
+
+    /// `export_scheduled_events-<id>.csv`, the JSON-in-CSV member.
+    ///
+    /// Where the voting window actually lives: `scheduled_events` in the JSON
+    /// document is not read by the importer.
+    pub scheduled_events: JsonTable,
+
+    /// `export_reports-<id>.csv`, or nothing when the source names no reports.
+    pub reports: Option<PlainTable>,
+
+    /// Admin users, tenant-scoped rather than part of the event import.
+    ///
+    /// A secret: it carries clear-text passwords when the source does.
+    pub admin_users: Option<PlainTable>,
+
+    /// The role/permission matrix, transposed into the platform's own shape.
+    pub role_permissions: Option<PlainTable>,
+
+    /// Communication and report templates, loaded through the Admin Portal
+    /// rather than imported — the event zip has no member for them.
+    pub templates: Vec<CommunicationTemplate>,
 
     /// Warnings. Not errors: the bundle imports, but something about it looks
     /// unintended.
@@ -309,6 +359,15 @@ impl<'a> Builder<'a> {
             "version": version,
         });
 
+        // Built after the entities, because every one of these resolves an
+        // external_id against them.
+        let voters = self.build_voters();
+        let scheduled_events = self.build_scheduled_events();
+        let reports = self.build_reports();
+        let admin_users = self.build_admin_users();
+        let role_permissions = self.build_role_permissions();
+        let templates = self.build_templates();
+
         if self.report.has_errors() {
             return Err(self.report);
         }
@@ -320,6 +379,12 @@ impl<'a> Builder<'a> {
             event_id: self.event_id,
             event_external_id: self.event_external_id,
             export,
+            voters,
+            scheduled_events,
+            reports,
+            admin_users,
+            role_permissions,
+            templates,
             warnings: self.report,
         })
     }
@@ -327,7 +392,7 @@ impl<'a> Builder<'a> {
     // -- problems ---------------------------------------------------------
 
     /// Record a problem and keep going, so one run reports every issue.
-    fn problem(
+    pub(super) fn problem(
         &mut self,
         origin: Origin,
         code: Code,
@@ -337,7 +402,11 @@ impl<'a> Builder<'a> {
             .push(Problem::error(code, origin.to_string(), message));
     }
 
-    fn warn(&mut self, path: impl Into<String>, message: impl Into<String>) {
+    pub(super) fn warn(
+        &mut self,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) {
         self.report
             .push(Problem::warning(Code::InvalidValue, path, message));
     }
@@ -455,7 +524,7 @@ impl<'a> Builder<'a> {
     // -- entities ---------------------------------------------------------
 
     /// Render a template, then merge the row's dotted paths over it.
-    fn render(
+    pub(super) fn render(
         &mut self,
         template: &str,
         row: Option<&Row>,
@@ -979,7 +1048,7 @@ impl<'a> Builder<'a> {
     }
 
     /// `external_id` -> UUID, recording a problem when it does not resolve.
-    fn resolve(
+    pub(super) fn resolve(
         &mut self,
         row: &Row,
         column: &str,

--- a/packages/sequent-core/src/election_config/build_tables.rs
+++ b/packages/sequent-core/src/election_config/build_tables.rs
@@ -1,0 +1,1159 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The CSV members of a bundle, and the files that travel beside it.
+//!
+//! Four of a bundle's parts are not in the JSON document at all. Voters and
+//! scheduled events are always CSVs, reports are a CSV or nothing, and admin
+//! users, role permissions and communication templates are tenant- or
+//! portal-scoped rather than part of an event import.
+//!
+//! A child module of [`super`] so it can reach the builder's resolved ids while
+//! keeping [`super`] readable; the two are one unit of code split across two
+//! files.
+
+use super::{value_as_text, Builder};
+use crate::election_config::emit::{
+    scheduled_event_task_id, JsonField, MULTI_VALUE_SEPARATOR, REPORT_COLUMNS,
+    SCHEDULED_EVENT_COLUMNS,
+};
+use crate::election_config::problem::Code;
+use crate::election_config::sheet::{
+    Origin, Row, SHEET_ADMIN_USERS, SHEET_PERMISSIONS, SHEET_REPORTS,
+    SHEET_SCHEDULED_EVENTS, SHEET_TEMPLATES, SHEET_VOTERS,
+};
+use serde_json::{json, Value};
+
+/// Voter columns the builder derives or reorders.
+///
+/// Everything else on the sheet is passed through as a Keycloak user attribute,
+/// which is how a client adds a reporting breakout column without a code change.
+pub const VOTER_LEADING_COLUMNS: &[&str] = &[
+    "id",
+    "email",
+    "email_verified",
+    "enabled",
+    "first_name",
+    "last_name",
+    "username",
+    "area_name",
+    "authorized-election-ids",
+];
+
+/// `EventProcessors` in `crate::types::scheduled_event`.
+pub const EVENT_PROCESSORS: &[&str] = &[
+    "ALLOW_INIT_REPORT",
+    "CREATE_REPORT",
+    "SEND_TEMPLATE",
+    "START_VOTING_PERIOD",
+    "END_VOTING_PERIOD",
+    "ALLOW_VOTING_PERIOD_END",
+    "START_ENROLLMENT_PERIOD",
+    "END_ENROLLMENT_PERIOD",
+    "START_LOCKDOWN_PERIOD",
+    "END_LOCKDOWN_PERIOD",
+    "ALLOW_TALLY",
+];
+
+/// A CSV to be written: header plus already-stringified rows.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PlainTable {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+impl PlainTable {
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// The index of a column, for a caller that needs to read one back.
+    pub fn column(&self, name: &str) -> Option<usize> {
+        self.columns.iter().position(|column| column == name)
+    }
+}
+
+/// A CSV whose fields hold JSON literals — the scheduled-events shape.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct JsonTable {
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<JsonField>>,
+}
+
+impl JsonTable {
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+/// A voter-communication or report template from the Templates sheet.
+///
+/// Emitted as a file beside the bundle rather than imported: the event zip has no
+/// member for communication templates, so these are handed to whoever loads them
+/// through the Admin Portal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommunicationTemplate {
+    pub name: String,
+    pub alias: String,
+    pub document: String,
+    pub communication_method: Option<String>,
+    pub template_type: Option<String>,
+    pub selected_methods: Option<Value>,
+}
+
+impl CommunicationTemplate {
+    /// A filesystem-safe name for the template's own file.
+    pub fn file_name(&self) -> String {
+        let source = if self.alias.trim().is_empty() {
+            &self.name
+        } else {
+            &self.alias
+        };
+        let mut safe = String::with_capacity(source.len());
+        for character in source.trim().chars() {
+            if character.is_alphanumeric()
+                || character == '-'
+                || character == '_'
+            {
+                safe.extend(character.to_lowercase());
+            } else {
+                safe.push('-');
+            }
+        }
+        let trimmed = safe.trim_matches('-');
+        if trimmed.is_empty() {
+            "template.hbs".to_string()
+        } else {
+            format!("{trimmed}.hbs")
+        }
+    }
+}
+
+impl Builder<'_> {
+    // -- voters -----------------------------------------------------------
+
+    pub(super) fn build_voters(&mut self) -> PlainTable {
+        let Some(sheet) = self.workbook.sheet(SHEET_VOTERS).cloned() else {
+            return PlainTable::default();
+        };
+
+        // Anything the builder does not derive is carried through as a Keycloak
+        // user attribute. `area.external_id` is a reference, not an attribute.
+        let passthrough: Vec<String> = sheet
+            .headers
+            .iter()
+            .filter(|header| {
+                !header.is_empty()
+                    && !VOTER_LEADING_COLUMNS.contains(&header.as_str())
+                    && *header != "area.external_id"
+            })
+            .cloned()
+            .collect();
+
+        let mut columns: Vec<String> = VOTER_LEADING_COLUMNS
+            .iter()
+            .map(|column| (*column).to_string())
+            .collect();
+        columns.extend(passthrough.iter().cloned());
+        self.check_csv_headers(&columns, "Voters");
+
+        let mut rows: Vec<Vec<String>> = Vec::new();
+        let mut seen: Vec<(String, usize)> = Vec::new();
+
+        for row in &sheet.rows {
+            let Some(username) = self.require_unique(
+                row,
+                "username",
+                "a voter needs a username",
+                &mut seen,
+            ) else {
+                continue;
+            };
+
+            let Some(area_name) = self.voter_area_name(row) else {
+                continue;
+            };
+
+            let email = row.get("email").map(value_as_text).unwrap_or_default();
+
+            // An unverified address blocks delivery of the one-time code, and a
+            // census address is one the client asserts is correct. So the default
+            // follows whether there is an address at all.
+            let email_verified = match row.get("email_verified") {
+                Some(value) => csv_bool(value),
+                None => bool_text(!email.is_empty()),
+            };
+            let enabled = match row.get("enabled") {
+                Some(value) => csv_bool(value),
+                None => bool_text(true),
+            };
+
+            let mut values: Vec<(&str, String)> = vec![
+                ("id", self.ids.uid("voter", &[&username])),
+                ("email", email),
+                ("email_verified", email_verified),
+                ("enabled", enabled),
+                (
+                    "first_name",
+                    row.get("first_name")
+                        .map(value_as_text)
+                        .unwrap_or_default(),
+                ),
+                (
+                    "last_name",
+                    row.get("last_name").map(value_as_text).unwrap_or_default(),
+                ),
+                ("username", username),
+                ("area_name", area_name),
+                ("authorized-election-ids", self.voter_elections(row)),
+            ];
+
+            let carried: Vec<(&str, String)> = passthrough
+                .iter()
+                .map(|header| (header.as_str(), csv_scalar(row.get(header))))
+                .collect();
+            values.extend(carried);
+
+            rows.push(
+                columns
+                    .iter()
+                    .map(|column| {
+                        values
+                            .iter()
+                            .find(|(name, _)| name == column)
+                            .map(|(_, value)| value.clone())
+                            .unwrap_or_default()
+                    })
+                    .collect(),
+            );
+        }
+
+        let table = self.drop_empty_voter_columns(PlainTable { columns, rows });
+        self.check_voter_reachability(&table);
+        table
+    }
+
+    /// The area's *name*, which is what the voters CSV identifies an area by.
+    fn voter_area_name(&mut self, row: &Row) -> Option<String> {
+        let Some(external_id) = row.get("area.external_id").map(value_as_text)
+        else {
+            self.problem(
+                row.origin(Some("area.external_id")),
+                Code::MissingField,
+                "a voter needs an area",
+            );
+            return None;
+        };
+        let key = external_id.trim().to_string();
+
+        if let Some((_, name)) =
+            self.area_names.iter().find(|(id, _)| id == &key)
+        {
+            return Some(name.clone());
+        }
+
+        // A known area with no name has already been reported by the area
+        // builder; reporting it again per voter would bury the real message
+        // under one line per row.
+        if !self.area_ids.iter().any(|(id, _)| id == &key) {
+            self.problem(
+                row.origin(Some("area.external_id")),
+                Code::DanglingReference,
+                format!("no area has external_id '{key}'"),
+            );
+        }
+        None
+    }
+
+    /// Resolve `authorized-election-ids` from external ids to UUIDs.
+    ///
+    /// Blank means every election in the event: a voter with no restriction is
+    /// eligible for all of them, and writing an empty attribute would deny access
+    /// to all of them instead.
+    fn voter_elections(&mut self, row: &Row) -> String {
+        let Some(raw) = row.get("authorized-election-ids").cloned() else {
+            let all: Vec<&str> = self
+                .election_ids
+                .iter()
+                .map(|(_, id)| id.as_str())
+                .collect();
+            return all.join(MULTI_VALUE_SEPARATOR);
+        };
+
+        let requested: Vec<Value> = match raw {
+            Value::Array(items) => items,
+            single => vec![single],
+        };
+
+        let mut resolved: Vec<String> = Vec::new();
+        for item in requested {
+            let key = value_as_text(&item).trim().to_string();
+            if key.is_empty() {
+                continue;
+            }
+            match self.election_ids.iter().find(|(id, _)| id == &key) {
+                Some((_, election_id)) => {
+                    let election_id = election_id.clone();
+                    if !resolved.contains(&election_id) {
+                        resolved.push(election_id);
+                    }
+                }
+                None => self.problem(
+                    row.origin(Some("authorized-election-ids")),
+                    Code::DanglingReference,
+                    format!("no election has external_id '{key}'"),
+                ),
+            }
+        }
+        resolved.join(MULTI_VALUE_SEPARATOR)
+    }
+
+    /// Drop passthrough columns that are empty for every voter.
+    ///
+    /// An all-blank column carries nothing, and one of them is actively harmful:
+    /// `get_copy_from_query` treats the mere presence of a `password` header as
+    /// "hash a password for each of these voters", so a blank password column
+    /// would give every voter an empty credential.
+    fn drop_empty_voter_columns(&mut self, table: PlainTable) -> PlainTable {
+        let keep: Vec<usize> = (0..table.columns.len())
+            .filter(|index| {
+                VOTER_LEADING_COLUMNS.contains(&table.columns[*index].as_str())
+                    || table.rows.iter().any(|row| {
+                        row.get(*index).is_some_and(|value| !value.is_empty())
+                    })
+            })
+            .collect();
+
+        if keep.len() == table.columns.len() {
+            return table;
+        }
+
+        let dropped: Vec<&str> = (0..table.columns.len())
+            .filter(|index| !keep.contains(index))
+            .map(|index| table.columns[index].as_str())
+            .collect();
+        let message = format!(
+            "dropped voter columns that are blank for every voter: {}",
+            dropped.join(", ")
+        );
+        self.warn("voters", message);
+
+        PlainTable {
+            columns: keep
+                .iter()
+                .map(|index| table.columns[*index].clone())
+                .collect(),
+            rows: table
+                .rows
+                .iter()
+                .map(|row| {
+                    keep.iter().map(|index| row[*index].clone()).collect()
+                })
+                .collect(),
+        }
+    }
+
+    /// Warn when voters have no channel to receive a one-time code on.
+    ///
+    /// Not an error: credentials are sometimes distributed on paper. And under an
+    /// identity provider that authenticates the voter itself there is nothing to
+    /// send, which is why the presets level gates this — with no preset named,
+    /// checking is the safer default.
+    fn check_voter_reachability(&mut self, table: &PlainTable) {
+        if table.rows.is_empty() {
+            return;
+        }
+
+        // There is always at least one contact column: `email` is derived, so it
+        // is present whether or not the source has it. The Python this was ported
+        // from also carried a "no contact column at all" warning, which for the
+        // same reason could never fire — a census with no email column at all
+        // reaches the per-voter count below with every voter unreachable, which
+        // is the more useful message anyway.
+        let contact: Vec<usize> = table
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| {
+                *column == "email"
+                    || column.contains("mobile")
+                    || column.contains("phone")
+            })
+            .map(|(index, _)| index)
+            .collect();
+
+        let unreachable = table
+            .rows
+            .iter()
+            .filter(|row| {
+                !contact.iter().any(|index| {
+                    row.get(*index).is_some_and(|value| !value.is_empty())
+                })
+            })
+            .count();
+
+        if unreachable > 0 {
+            let message = format!(
+                "{unreachable} of {} voters have neither an email address nor \
+                 a mobile number and cannot be sent a one-time code",
+                table.rows.len()
+            );
+            self.warn("voters", message);
+        }
+    }
+
+    // -- scheduled events -------------------------------------------------
+
+    pub(super) fn build_scheduled_events(&mut self) -> JsonTable {
+        let rows_in: Vec<Row> =
+            self.workbook.rows(SHEET_SCHEDULED_EVENTS).to_vec();
+        let mut rows: Vec<Vec<JsonField>> = Vec::new();
+
+        // Kept alongside so the window check does not have to read the payload
+        // back out of the JSON it just wrote.
+        let mut scheduled: Vec<(String, Option<String>)> = Vec::new();
+
+        for row in &rows_in {
+            let Some(processor) = self.event_processor(row) else {
+                continue;
+            };
+
+            let Some(when) = row.get("scheduled_datetime").map(value_as_text)
+            else {
+                self.problem(
+                    row.origin(Some("scheduled_datetime")),
+                    Code::MissingField,
+                    format!("{processor} needs a scheduled_datetime"),
+                );
+                continue;
+            };
+
+            let mut election_id = None;
+            if row.get("election.external_id").is_some() {
+                let elections = self.election_ids.clone();
+                let Some(resolved) = self.resolve(
+                    row,
+                    "election.external_id",
+                    &elections,
+                    "election",
+                ) else {
+                    continue;
+                };
+                election_id = Some(resolved);
+            }
+
+            // Not a schema field, but it is how the author labels the row, and
+            // keeping it makes the emitted CSV readable next to the source.
+            let annotations = match row.get("event_name").map(value_as_text) {
+                Some(name) if !name.is_empty() => {
+                    JsonField::Value(json!({"janitor.event_name": name}))
+                }
+                _ => JsonField::Null,
+            };
+
+            let task_id = scheduled_event_task_id(
+                &self.tenant_id,
+                &self.event_id,
+                election_id.as_deref(),
+                &processor,
+            );
+
+            rows.push(vec![
+                JsonField::string(self.ids.uid(
+                    "scheduled_event",
+                    &[&processor, election_id.as_deref().unwrap_or("")],
+                )),
+                JsonField::string(self.tenant_id.clone()),
+                JsonField::string(self.event_id.clone()),
+                JsonField::string(self.created_at.clone()),
+                JsonField::Null, // stopped_at
+                JsonField::Null, // archived_at
+                JsonField::Null, // labels
+                annotations,
+                JsonField::string(processor.clone()),
+                JsonField::Value(json!({
+                    "cron": Value::Null,
+                    "scheduled_date": when,
+                })),
+                JsonField::Value(json!({"election_id": election_id})),
+                JsonField::string(task_id),
+            ]);
+            scheduled.push((processor, election_id));
+        }
+
+        if rows.is_empty() {
+            self.warn(
+                "scheduled_events",
+                "no scheduled events: the voting period will have to be opened \
+                 and closed by hand in the Admin Portal",
+            );
+        } else {
+            self.check_voting_windows(&scheduled);
+        }
+
+        JsonTable {
+            columns: SCHEDULED_EVENT_COLUMNS
+                .iter()
+                .map(|column| (*column).to_string())
+                .collect(),
+            rows,
+        }
+    }
+
+    /// The row's `event_type` as a processor name the platform knows.
+    fn event_processor(&mut self, row: &Row) -> Option<String> {
+        let Some(raw) = row.get("event_type").map(value_as_text) else {
+            self.problem(
+                row.origin(Some("event_type")),
+                Code::MissingField,
+                "a scheduled event needs an event_type",
+            );
+            return None;
+        };
+
+        // Authors write "start voting period" and "start-voting-period" as often
+        // as the constant.
+        let processor = raw.trim().to_uppercase().replace(['-', ' '], "_");
+
+        if !EVENT_PROCESSORS.contains(&processor.as_str()) {
+            let mut expected: Vec<&str> = EVENT_PROCESSORS.to_vec();
+            expected.sort_unstable();
+            let message = format!(
+                "'{}' is not an event processor; expected one of {}",
+                raw.trim(),
+                expected.join(", ")
+            );
+            self.problem(
+                row.origin(Some("event_type")),
+                Code::InvalidValue,
+                message,
+            );
+            return None;
+        }
+        Some(processor)
+    }
+
+    /// Warn about an election whose voting period never opens or never closes.
+    ///
+    /// A scheduled event with no election applies to the whole event, so an
+    /// election is covered either by its own row or by an event-wide one. An
+    /// uncovered election imports fine and then quietly never opens.
+    fn check_voting_windows(&mut self, scheduled: &[(String, Option<String>)]) {
+        let elections = self.election_ids.clone();
+        let mut warnings: Vec<String> = Vec::new();
+
+        for (external_id, election_id) in &elections {
+            let covered: Vec<&str> = scheduled
+                .iter()
+                .filter(|(_, scoped)| {
+                    scoped.is_none() || scoped.as_deref() == Some(election_id)
+                })
+                .map(|(processor, _)| processor.as_str())
+                .collect();
+
+            let missing: Vec<&str> =
+                ["START_VOTING_PERIOD", "END_VOTING_PERIOD"]
+                    .into_iter()
+                    .filter(|processor| !covered.contains(processor))
+                    .collect();
+
+            if missing.is_empty() {
+                continue;
+            }
+
+            let effects: Vec<&str> = missing
+                .iter()
+                .map(|processor| {
+                    if *processor == "START_VOTING_PERIOD" {
+                        "open"
+                    } else {
+                        "close"
+                    }
+                })
+                .collect();
+            warnings.push(format!(
+                "election '{external_id}' has no {} scheduled event; its \
+                 voting period will not {} on its own",
+                missing.join(" and no "),
+                effects.join(" or ")
+            ));
+        }
+
+        for warning in warnings {
+            self.warn("scheduled_events", warning);
+        }
+    }
+
+    // -- reports ----------------------------------------------------------
+
+    pub(super) fn build_reports(&mut self) -> Option<PlainTable> {
+        let rows_in: Vec<Row> = self.workbook.rows(SHEET_REPORTS).to_vec();
+        if rows_in.is_empty() {
+            return None;
+        }
+
+        let aliases: Vec<String> = self
+            .workbook
+            .rows(SHEET_TEMPLATES)
+            .iter()
+            .filter_map(|row| row.get("alias"))
+            .map(|alias| value_as_text(alias).trim().to_string())
+            .collect();
+
+        let mut rows: Vec<Vec<String>> = Vec::new();
+        for (index, row) in rows_in.iter().enumerate() {
+            let Some(report_type) = row.get("report_type").map(value_as_text)
+            else {
+                self.problem(
+                    row.origin(Some("report_type")),
+                    Code::MissingField,
+                    "a report needs a report_type",
+                );
+                continue;
+            };
+
+            let mut election_id = String::new();
+            if row.get("election.external_id").is_some() {
+                let elections = self.election_ids.clone();
+                let Some(resolved) = self.resolve(
+                    row,
+                    "election.external_id",
+                    &elections,
+                    "election",
+                ) else {
+                    continue;
+                };
+                election_id = resolved;
+            }
+
+            let alias = row.get("template.alias").map(value_as_text);
+            if let Some(alias) = &alias {
+                if !aliases.contains(&alias.trim().to_string()) {
+                    let message =
+                        format!("no Templates row has alias '{alias}'");
+                    self.problem(
+                        row.origin(Some("template.alias")),
+                        Code::DanglingReference,
+                        message,
+                    );
+                    continue;
+                }
+            }
+
+            let context = json!({
+                "id": self.ids.uid(
+                    "report",
+                    &[&report_type, &election_id, &(index + 1).to_string()],
+                ),
+                "tenant_id": self.tenant_id,
+                "election_event_id": self.event_id,
+                "created_at": self.created_at,
+                "report_type": report_type,
+            });
+            let rendered = self.render("report", Some(row), context);
+
+            if row.get("password").is_some() {
+                let path = row.origin(Some("password")).to_string();
+                self.warn(
+                    path,
+                    "the report password is written to the reports CSV in clear \
+                     text; treat the output as a secret",
+                );
+            }
+
+            // These come from the sheet's own columns rather than from
+            // dotted-path overrides: they are control columns, so the row was
+            // excluded from the merge and the rendered value is only the
+            // template's default. Reading the template instead is how
+            // `configured_password` silently became `unencrypted` once.
+            let cron_config = row
+                .get("cron_config")
+                .cloned()
+                .or_else(|| rendered.get("cron_config").cloned());
+            let policy = row
+                .get("encryption_policy")
+                .map(value_as_text)
+                .filter(|policy| !policy.is_empty())
+                .or_else(|| {
+                    rendered
+                        .get("encryption_policy")
+                        .map(value_as_text)
+                        .filter(|policy| !policy.is_empty())
+                })
+                .unwrap_or_else(|| "unencrypted".to_string());
+
+            rows.push(vec![
+                rendered.get("id").map(value_as_text).unwrap_or_default(),
+                election_id,
+                report_type,
+                alias.unwrap_or_default(),
+                csv_json(cron_config.as_ref()),
+                policy,
+                csv_scalar(row.get("password")),
+                // Option<Vec<String>>, split on "|" by process_reports_file.
+                join_multi(row.get("permission_label")),
+            ]);
+        }
+
+        if rows.is_empty() {
+            return None;
+        }
+        Some(PlainTable {
+            columns: REPORT_COLUMNS
+                .iter()
+                .map(|column| (*column).to_string())
+                .collect(),
+            rows,
+        })
+    }
+
+    // -- admin users, permissions, templates -------------------------------
+
+    pub(super) fn build_admin_users(&mut self) -> Option<PlainTable> {
+        let sheet = self.workbook.sheet(SHEET_ADMIN_USERS).cloned()?;
+        if sheet.rows.is_empty() {
+            return None;
+        }
+
+        let columns: Vec<String> = sheet
+            .headers
+            .iter()
+            .filter(|header| !header.is_empty())
+            .cloned()
+            .collect();
+        self.check_csv_headers(&columns, "Admin Users");
+
+        let mut rows: Vec<Vec<String>> = Vec::new();
+        let mut warned_password = false;
+
+        for row in &sheet.rows {
+            if row.get("username").is_none() {
+                self.problem(
+                    row.origin(Some("username")),
+                    Code::MissingField,
+                    "an admin user needs a username",
+                );
+                continue;
+            }
+            if row.get("password").is_some() && !warned_password {
+                warned_password = true;
+                self.warn(
+                    "admin_users",
+                    "Admin Users carries clear-text passwords; the emitted \
+                     admin_users CSV is a secret, not a deliverable",
+                );
+            }
+
+            rows.push(
+                columns
+                    .iter()
+                    .map(|header| match row.get(header) {
+                        // permission_labels arrives "||"-separated and leaves
+                        // "|"-separated, like every multi-valued attribute.
+                        Some(Value::Array(_)) => join_multi(row.get(header)),
+                        value => csv_scalar(value),
+                    })
+                    .collect(),
+            );
+        }
+
+        Some(PlainTable { columns, rows })
+    }
+
+    /// Transpose the permission matrix into the platform's own shape.
+    ///
+    /// `export_tenant_config.rs` writes `role,permissions` with permissions
+    /// joined by `|`; the source holds the transpose, one row per permission and
+    /// one column per role, marked with any non-empty cell. A matrix is what a
+    /// human can check at a glance, which is why the conversion lives here.
+    pub(super) fn build_role_permissions(&mut self) -> Option<PlainTable> {
+        let sheet = self.workbook.sheet(SHEET_PERMISSIONS).cloned()?;
+        if sheet.rows.is_empty() {
+            return None;
+        }
+
+        let roles: Vec<String> = sheet
+            .headers
+            .iter()
+            .skip(1)
+            .filter(|header| !header.is_empty())
+            .cloned()
+            .collect();
+
+        if roles.is_empty() {
+            self.problem(
+                Origin {
+                    sheet: sheet.name.clone(),
+                    row: 1,
+                    column: None,
+                },
+                Code::MissingField,
+                "the Permissions matrix has no role columns; expected the first \
+                 column to hold permissions and one further column per role",
+            );
+            return None;
+        }
+
+        let permission_column = sheet.headers[0].clone();
+        let mut granted: Vec<(String, Vec<String>)> = roles
+            .iter()
+            .map(|role| (role.clone(), Vec::new()))
+            .collect();
+
+        for row in &sheet.rows {
+            let Some(permission) =
+                row.get(&permission_column).map(value_as_text)
+            else {
+                continue;
+            };
+            for (role, permissions) in granted.iter_mut() {
+                if row.get(role).is_some() {
+                    permissions.push(permission.clone());
+                }
+            }
+        }
+
+        Some(PlainTable {
+            columns: vec!["role".to_string(), "permissions".to_string()],
+            rows: granted
+                .into_iter()
+                .map(|(role, permissions)| {
+                    vec![role, permissions.join(MULTI_VALUE_SEPARATOR)]
+                })
+                .collect(),
+        })
+    }
+
+    pub(super) fn build_templates(&mut self) -> Vec<CommunicationTemplate> {
+        let rows: Vec<Row> = self.workbook.rows(SHEET_TEMPLATES).to_vec();
+        let mut templates = Vec::new();
+        let mut seen: Vec<(String, usize)> = Vec::new();
+
+        for row in &rows {
+            let alias = row
+                .get("alias")
+                .or_else(|| row.get("name"))
+                .map(value_as_text)
+                .filter(|alias| !alias.is_empty());
+
+            let Some(alias) = alias else {
+                self.problem(
+                    row.origin(Some("alias")),
+                    Code::MissingField,
+                    "a template needs a name or an alias",
+                );
+                continue;
+            };
+
+            if let Some((_, earlier)) = seen.iter().find(|(id, _)| id == &alias)
+            {
+                let message =
+                    format!("alias '{alias}' is already used by row {earlier}");
+                self.problem(
+                    row.origin(Some("alias")),
+                    Code::DuplicateId,
+                    message,
+                );
+                continue;
+            }
+            seen.push((alias.clone(), row.number));
+
+            let Some(document) =
+                row.get("template.document").map(value_as_text)
+            else {
+                self.problem(
+                    row.origin(Some("template.document")),
+                    Code::MissingField,
+                    "a template needs a document",
+                );
+                continue;
+            };
+
+            templates.push(CommunicationTemplate {
+                name: row
+                    .get("name")
+                    .map(value_as_text)
+                    .filter(|name| !name.is_empty())
+                    .unwrap_or_else(|| alias.clone()),
+                alias,
+                document: unescape_document(&document),
+                communication_method: row
+                    .get("communication_method")
+                    .map(value_as_text),
+                template_type: row.get("type").map(value_as_text),
+                selected_methods: row.get("template.selected_methods").cloned(),
+            });
+        }
+        templates
+    }
+
+    // -- shared -----------------------------------------------------------
+
+    /// A required, unique value from one column.
+    fn require_unique(
+        &mut self,
+        row: &Row,
+        column: &str,
+        missing: &str,
+        seen: &mut Vec<(String, usize)>,
+    ) -> Option<String> {
+        let value = match row.get(column).map(value_as_text) {
+            Some(value) if !value.is_empty() => value,
+            _ => {
+                self.problem(
+                    row.origin(Some(column)),
+                    Code::MissingField,
+                    missing,
+                );
+                return None;
+            }
+        };
+
+        if let Some((_, earlier)) = seen.iter().find(|(id, _)| id == &value) {
+            let message =
+                format!("{column} '{value}' is already used by row {earlier}");
+            self.problem(row.origin(Some(column)), Code::DuplicateId, message);
+            return None;
+        }
+        seen.push((value.clone(), row.number));
+        Some(value)
+    }
+
+    /// Both CSV importers reject headers outside their `HEADER_RE`.
+    ///
+    /// Catching it here turns an opaque mid-import failure into a message naming
+    /// the column.
+    fn check_csv_headers(&mut self, columns: &[String], sheet: &str) {
+        let offenders: Vec<String> = columns
+            .iter()
+            .filter(|column| !is_importable_header(column))
+            .cloned()
+            .collect();
+
+        for column in offenders {
+            self.problem(
+                Origin {
+                    sheet: sheet.to_string(),
+                    row: 1,
+                    column: Some(column),
+                },
+                Code::InvalidValue,
+                "the importer rejects this column name; only letters, digits, \
+                 '.', '_' and '-' are allowed",
+            );
+        }
+    }
+}
+
+/// `^[a-zA-Z0-9._-]+$`, the pattern both CSV importers enforce.
+fn is_importable_header(column: &str) -> bool {
+    !column.is_empty()
+        && column.chars().all(|character| {
+            character.is_ascii_alphanumeric()
+                || character == '.'
+                || character == '_'
+                || character == '-'
+        })
+}
+
+fn bool_text(value: bool) -> String {
+    if value {
+        "true".to_string()
+    } else {
+        "false".to_string()
+    }
+}
+
+/// A cell meant as a flag.
+///
+/// Spreadsheets carry every spelling of yes: an author ticking a column with an
+/// `x` means the same as one typing `TRUE`.
+fn csv_bool(value: &Value) -> String {
+    match value {
+        Value::Bool(value) => bool_text(*value),
+        Value::String(text) => bool_text(matches!(
+            text.trim().to_lowercase().as_str(),
+            "true" | "1" | "yes" | "x"
+        )),
+        Value::Null => bool_text(false),
+        Value::Number(number) => bool_text(number.as_f64() != Some(0.0)),
+        _ => bool_text(true),
+    }
+}
+
+/// One cell of a plain CSV. Absent becomes empty, never the word "null".
+fn csv_scalar(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::Bool(flag)) => bool_text(*flag),
+        Some(Value::String(text)) => text.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+/// A cell holding JSON: text passes through, anything else is encoded.
+fn csv_json(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::String(text)) => text.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+/// A multi-valued cell, joined the way the importer splits it.
+fn join_multi(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(value_as_text)
+            .collect::<Vec<_>>()
+            .join(MULTI_VALUE_SEPARATOR),
+        other => csv_scalar(other),
+    }
+}
+
+/// Un-escape a document pasted into a spreadsheet cell.
+///
+/// The Templates sheet holds documents with literal `\n` and `\"`, because that
+/// is what survives a copy-paste out of a JSON export. Writing those through
+/// verbatim emits a template full of backslash-n instead of newlines.
+fn unescape_document(document: &str) -> String {
+    if !document.contains("\\n") && !document.contains("\\\"") {
+        return document.to_string();
+    }
+
+    // One pass, so that an escaped backslash before an n is not then read as a
+    // newline: "\\n" is a backslash followed by an n, not a line break.
+    let mut out = String::with_capacity(document.len());
+    let mut characters = document.chars();
+    while let Some(character) = characters.next() {
+        if character != '\\' {
+            out.push(character);
+            continue;
+        }
+        match characters.next() {
+            Some('n') => out.push('\n'),
+            Some('"') => out.push('"'),
+            Some('\\') => out.push('\\'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_header_the_importer_would_reject_is_caught_here() {
+        assert!(is_importable_header("permission_labels"));
+        assert!(is_importable_header("area.external_id"));
+        assert!(is_importable_header("mobile-number"));
+        // The ones that would fail mid-import, opaquely.
+        assert!(!is_importable_header("home address"));
+        assert!(!is_importable_header("años"));
+        assert!(!is_importable_header(""));
+    }
+
+    #[test]
+    fn every_spelling_of_yes_is_a_yes() {
+        // An author ticking a column with an x means what someone typing TRUE
+        // means.
+        for yes in ["true", "TRUE", "Yes", "x", "1"] {
+            assert_eq!(csv_bool(&json!(yes)), "true", "{yes}");
+        }
+        for no in ["false", "no", "", "0"] {
+            assert_eq!(csv_bool(&json!(no)), "false", "{no}");
+        }
+        assert_eq!(csv_bool(&json!(true)), "true");
+        assert_eq!(csv_bool(&json!(0)), "false");
+    }
+
+    #[test]
+    fn an_absent_cell_is_empty_and_never_the_word_null() {
+        // "null" in a plain CSV is a voter attribute holding the text null.
+        assert_eq!(csv_scalar(None), "");
+        assert_eq!(csv_scalar(Some(&Value::Null)), "");
+        assert_eq!(csv_scalar(Some(&json!("kept"))), "kept");
+        assert_eq!(csv_scalar(Some(&json!(7))), "7");
+        assert_eq!(csv_scalar(Some(&json!({"a": 1}))), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn a_multi_valued_cell_leaves_single_pipe_separated() {
+        // "||" going in, "|" coming out: the source's separator is not the
+        // importer's.
+        assert_eq!(join_multi(Some(&json!(["a", "b"]))), "a|b");
+        assert_eq!(join_multi(Some(&json!(["only"]))), "only");
+        assert_eq!(join_multi(Some(&json!([]))), "");
+        assert_eq!(join_multi(Some(&json!("plain"))), "plain");
+        assert_eq!(join_multi(None), "");
+    }
+
+    #[test]
+    fn a_pasted_document_gets_its_newlines_back() {
+        // What survives a copy-paste out of a JSON export.
+        assert_eq!(
+            unescape_document(r#"Dear {{name}},\n\nYour code is {{code}}."#),
+            "Dear {{name}},\n\nYour code is {{code}}."
+        );
+        assert_eq!(unescape_document(r#"say \"hi\""#), r#"say "hi""#);
+    }
+
+    #[test]
+    fn a_document_with_no_escapes_is_left_exactly_alone() {
+        let literal = "already\nreal\nnewlines and a \\ backslash";
+        assert_eq!(unescape_document(literal), literal);
+    }
+
+    #[test]
+    fn an_escaped_backslash_before_an_n_is_not_a_newline() {
+        // The bug a two-pass replace would have: "\\n" is a backslash and an n.
+        assert_eq!(unescape_document(r"a\\nb"), r"a\nb");
+    }
+
+    #[test]
+    fn a_template_file_name_is_safe_to_write() {
+        let template = |alias: &str, name: &str| CommunicationTemplate {
+            name: name.to_string(),
+            alias: alias.to_string(),
+            document: String::new(),
+            communication_method: None,
+            template_type: None,
+            selected_methods: None,
+        };
+        assert_eq!(
+            template("Voter Credentials", "").file_name(),
+            "voter-credentials.hbs"
+        );
+        assert_eq!(template("otp_email", "").file_name(), "otp_email.hbs");
+        // Falls back to the name, then to something writable.
+        assert_eq!(
+            template("", "Fallback Name").file_name(),
+            "fallback-name.hbs"
+        );
+        assert_eq!(template("///", "").file_name(), "template.hbs");
+    }
+
+    #[test]
+    fn the_scheduled_events_columns_are_the_ones_the_importer_reads() {
+        // Positional: a reordering here is a payload read as a task id.
+        assert_eq!(SCHEDULED_EVENT_COLUMNS[10], "event_payload");
+        assert_eq!(REPORT_COLUMNS[1], "election_id");
+        assert_eq!(REPORT_COLUMNS[7], "permission_label");
+    }
+}

--- a/packages/sequent-core/src/election_config/build_tests.rs
+++ b/packages/sequent-core/src/election_config/build_tests.rs
@@ -6,6 +6,7 @@
 //! there is builder.
 
 use super::*;
+use crate::election_config::emit::JsonField;
 use crate::election_config::paths::Cell;
 use crate::election_config::sheet::Sheet;
 
@@ -661,7 +662,14 @@ fn a_row_with_no_key_is_a_note_to_the_author_and_is_skipped() {
             ],
         ],
     ));
-    assert!(bundle.warnings.is_empty(), "{}", bundle.warnings);
+    assert!(
+        !bundle
+            .warnings
+            .warnings()
+            .any(|problem| problem.message.contains("parameter")),
+        "{}",
+        bundle.warnings
+    );
 }
 
 // -- base export ----------------------------------------------------------
@@ -815,4 +823,823 @@ fn columns_that_disagree_about_a_shape_are_reported_against_the_cell() {
     let problem = report.errors().next().unwrap();
     assert_eq!(problem.code, Code::ConflictingColumns);
     assert!(problem.path.contains("sheet 'Elections' row 2"));
+}
+
+// -- voters ---------------------------------------------------------------
+
+/// The sound document with a Voters sheet added.
+fn with_voters(grid: Vec<Vec<Cell>>) -> Workbook {
+    with_sheet("Voters", grid)
+}
+
+#[test]
+fn a_voter_row_becomes_a_csv_row_the_importer_understands() {
+    let bundle = built(&with_voters(vec![
+        vec![
+            text("username"),
+            text("email"),
+            text("first_name"),
+            text("last_name"),
+            text("area.external_id"),
+        ],
+        vec![
+            text("m-1001"),
+            text("alice@example.org"),
+            text("Alice"),
+            text("Adams"),
+            text("area-north"),
+        ],
+    ]));
+
+    let voters = &bundle.voters;
+    let column = |name: &str| voters.column(name).expect(name);
+    let row = &voters.rows[0];
+
+    assert_eq!(row[column("username")], "m-1001");
+    assert_eq!(row[column("email")], "alice@example.org");
+    // The area travels as a name, because that is what the importer resolves by.
+    assert_eq!(row[column("area_name")], "North");
+    assert!(!row[column("id")].is_empty());
+}
+
+#[test]
+fn a_voter_with_an_address_is_treated_as_verified() {
+    // An unverified address blocks delivery of the one-time code, and a census
+    // address is one the client asserts is correct.
+    let bundle = built(&with_voters(vec![
+        vec![text("username"), text("email"), text("area.external_id")],
+        vec![text("with"), text("a@example.org"), text("area-north")],
+        vec![text("without"), Cell::Blank, text("area-north")],
+    ]));
+    let verified = bundle.voters.column("email_verified").unwrap();
+    assert_eq!(bundle.voters.rows[0][verified], "true");
+    assert_eq!(bundle.voters.rows[1][verified], "false");
+}
+
+#[test]
+fn a_voter_is_enabled_unless_the_source_says_otherwise() {
+    let bundle = built(&with_voters(vec![
+        vec![text("username"), text("enabled"), text("area.external_id")],
+        vec![text("default"), Cell::Blank, text("area-north")],
+        vec![text("ticked"), text("x"), text("area-north")],
+        vec![text("off"), text("no"), text("area-north")],
+    ]));
+    let enabled = bundle.voters.column("enabled").unwrap();
+    assert_eq!(bundle.voters.rows[0][enabled], "true");
+    assert_eq!(bundle.voters.rows[1][enabled], "true");
+    assert_eq!(bundle.voters.rows[2][enabled], "false");
+}
+
+#[test]
+fn a_voter_with_no_election_restriction_is_authorized_for_all_of_them() {
+    // Writing an empty attribute would deny access to every election instead.
+    let bundle = built(&with_voters(vec![
+        vec![text("username"), text("area.external_id")],
+        vec![text("m-1001"), text("area-north")],
+    ]));
+    let column = bundle.voters.column("authorized-election-ids").unwrap();
+    assert_eq!(
+        bundle.voters.rows[0][column],
+        bundle.export["elections"][0]["id"].as_str().unwrap()
+    );
+}
+
+#[test]
+fn a_restricted_voter_gets_the_elections_named_resolved_to_ids() {
+    let bundle = built(&with_voters(vec![
+        vec![
+            text("username"),
+            text("authorized-election-ids"),
+            text("area.external_id"),
+        ],
+        vec![text("m-1001"), text("statewide"), text("area-north")],
+    ]));
+    let column = bundle.voters.column("authorized-election-ids").unwrap();
+    assert_eq!(
+        bundle.voters.rows[0][column],
+        bundle.export["elections"][0]["id"].as_str().unwrap()
+    );
+}
+
+#[test]
+fn a_voter_naming_an_election_nobody_configured_is_refused() {
+    let report = refused(&with_voters(vec![
+        vec![
+            text("username"),
+            text("authorized-election-ids"),
+            text("area.external_id"),
+        ],
+        vec![text("m-1001"), text("no-such-election"), text("area-north")],
+    ]));
+    assert!(has_error_saying(
+        &report,
+        "no election has external_id 'no-such-election'"
+    ));
+}
+
+#[test]
+fn a_voter_needs_a_username_and_an_area() {
+    let report = refused(&with_voters(vec![
+        vec![text("username"), text("area.external_id")],
+        vec![Cell::Blank, text("area-north")],
+        vec![text("m-1002"), Cell::Blank],
+        vec![text("m-1003"), text("nowhere")],
+    ]));
+    assert!(has_error_saying(&report, "a voter needs a username"));
+    assert!(has_error_saying(&report, "a voter needs an area"));
+    assert!(has_error_saying(
+        &report,
+        "no area has external_id 'nowhere'"
+    ));
+}
+
+#[test]
+fn two_voters_may_not_share_a_username() {
+    let report = refused(&with_voters(vec![
+        vec![text("username"), text("area.external_id")],
+        vec![text("m-1001"), text("area-north")],
+        vec![text("m-1001"), text("area-south")],
+    ]));
+    assert!(has_error_saying(&report, "already used by row 2"));
+}
+
+#[test]
+fn an_unknown_column_is_carried_through_as_a_voter_attribute() {
+    // How a client adds a reporting breakout column with no code change.
+    let bundle = built(&with_voters(vec![
+        vec![
+            text("username"),
+            text("area.external_id"),
+            text("local-number"),
+        ],
+        vec![text("m-1001"), text("area-north"), text("1000")],
+    ]));
+    let column = bundle.voters.column("local-number").expect("local-number");
+    assert_eq!(bundle.voters.rows[0][column], "1000");
+    // And it lands after the derived columns, not among them.
+    assert!(column >= VOTER_LEADING_COLUMNS.len());
+}
+
+#[test]
+fn a_passthrough_column_blank_for_every_voter_is_dropped() {
+    // Not cosmetic: get_copy_from_query treats the mere presence of a `password`
+    // header as "hash a password for each of these voters", so a blank one would
+    // give every voter an empty credential.
+    let bundle = built(&with_voters(vec![
+        vec![
+            text("username"),
+            text("area.external_id"),
+            text("password"),
+            text("local-number"),
+        ],
+        vec![
+            text("m-1001"),
+            text("area-north"),
+            Cell::Blank,
+            text("1000"),
+        ],
+    ]));
+    assert!(bundle.voters.column("password").is_none());
+    assert!(bundle.voters.column("local-number").is_some());
+    assert!(bundle
+        .warnings
+        .warnings()
+        .any(|problem| problem.message.contains("password")));
+}
+
+#[test]
+fn a_derived_column_is_kept_even_when_every_voter_leaves_it_blank() {
+    // The importer expects them, and an absent `email` header is not the same as
+    // an empty one.
+    let bundle = built(&with_voters(vec![
+        vec![text("username"), text("area.external_id")],
+        vec![text("m-1001"), text("area-north")],
+    ]));
+    for column in VOTER_LEADING_COLUMNS {
+        assert!(bundle.voters.column(column).is_some(), "{column}");
+    }
+}
+
+#[test]
+fn voters_with_no_way_to_receive_a_code_are_warned_about() {
+    // Not an error: credentials are sometimes distributed on paper.
+    let bundle = built(&with_voters(vec![
+        vec![text("username"), text("email"), text("area.external_id")],
+        vec![text("reachable"), text("a@example.org"), text("area-north")],
+        vec![text("not"), Cell::Blank, text("area-north")],
+    ]));
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("1 of 2 voters have neither an email address")));
+}
+
+#[test]
+fn a_census_with_no_contact_column_at_all_makes_every_voter_unreachable() {
+    // `email` is a derived column, so it is in the table whether or not the
+    // source has it — which is why there is no separate "no contact column"
+    // case. Every voter simply has an empty one.
+    let bundle = built(&with_voters(vec![
+        vec![text("username"), text("area.external_id")],
+        vec![text("m-1001"), text("area-north")],
+        vec![text("m-1002"), text("area-south")],
+    ]));
+    assert!(bundle.voters.column("email").is_some());
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("2 of 2 voters have neither an email address")));
+}
+
+#[test]
+fn a_column_name_the_importer_would_reject_is_caught_before_the_upload() {
+    // Otherwise it fails mid-import with nothing naming the column.
+    let report = refused(&with_voters(vec![
+        vec![
+            text("username"),
+            text("area.external_id"),
+            text("home address"),
+        ],
+        vec![text("m-1001"), text("area-north"), text("1 Main St")],
+    ]));
+    assert!(has_error_saying(
+        &report,
+        "the importer rejects this column name"
+    ));
+}
+
+// -- scheduled events -----------------------------------------------------
+
+fn with_schedule(grid: Vec<Vec<Cell>>) -> Workbook {
+    with_sheet("ScheduledEvents", grid)
+}
+
+#[test]
+fn a_voting_window_becomes_two_rows_of_the_scheduled_events_csv() {
+    let bundle = built(&with_schedule(vec![
+        vec![
+            text("event_type"),
+            text("scheduled_datetime"),
+            text("election.external_id"),
+        ],
+        vec![
+            text("START_VOTING_PERIOD"),
+            text("2027-03-01T16:00:00Z"),
+            text("statewide"),
+        ],
+        vec![
+            text("END_VOTING_PERIOD"),
+            text("2027-03-15T23:59:00Z"),
+            text("statewide"),
+        ],
+    ]));
+    assert_eq!(bundle.scheduled_events.len(), 2);
+
+    let row = &bundle.scheduled_events.rows[0];
+    assert_eq!(row.len(), 12);
+    assert_eq!(row[8], JsonField::string("START_VOTING_PERIOD"));
+    assert_eq!(
+        row[9],
+        JsonField::Value(json!({
+            "cron": Value::Null,
+            "scheduled_date": "2027-03-01T16:00:00Z",
+        }))
+    );
+    // A SQL NULL, written bare rather than as a quoted JSON null.
+    assert_eq!(row[4], JsonField::Null);
+}
+
+#[test]
+fn the_payload_names_the_election_and_the_task_id_matches_the_platform() {
+    // The platform looks its task up by this name; a different shape means a task
+    // that never fires.
+    let bundle = built(&with_schedule(vec![
+        vec![
+            text("event_type"),
+            text("scheduled_datetime"),
+            text("election.external_id"),
+        ],
+        vec![
+            text("START_VOTING_PERIOD"),
+            text("2027-03-01T16:00:00Z"),
+            text("statewide"),
+        ],
+    ]));
+    let election_id = bundle.export["elections"][0]["id"].as_str().unwrap();
+    let row = &bundle.scheduled_events.rows[0];
+
+    assert_eq!(
+        row[10],
+        JsonField::Value(json!({"election_id": election_id}))
+    );
+    assert_eq!(
+        row[11],
+        JsonField::string(format!(
+            "tenant_{}_event_{}_election_{election_id}_START_VOTING_PERIOD",
+            bundle.tenant_id, bundle.event_id
+        ))
+    );
+}
+
+#[test]
+fn an_event_wide_schedule_leaves_the_election_out_of_both() {
+    let bundle = built(&with_schedule(vec![
+        vec![text("event_type"), text("scheduled_datetime")],
+        vec![text("START_VOTING_PERIOD"), text("2027-03-01T16:00:00Z")],
+    ]));
+    let row = &bundle.scheduled_events.rows[0];
+    assert_eq!(row[10], JsonField::Value(json!({"election_id": null})));
+    assert_eq!(
+        row[11],
+        JsonField::string(format!(
+            "tenant_{}_event_{}_START_VOTING_PERIOD",
+            bundle.tenant_id, bundle.event_id
+        ))
+    );
+}
+
+#[test]
+fn an_author_may_write_an_event_type_the_way_they_speak_it() {
+    let bundle = built(&with_schedule(vec![
+        vec![text("event_type"), text("scheduled_datetime")],
+        vec![text("start voting period"), text("2027-03-01T16:00:00Z")],
+        vec![text("end-voting-period"), text("2027-03-15T23:59:00Z")],
+    ]));
+    assert_eq!(
+        bundle.scheduled_events.rows[0][8],
+        JsonField::string("START_VOTING_PERIOD")
+    );
+    assert_eq!(
+        bundle.scheduled_events.rows[1][8],
+        JsonField::string("END_VOTING_PERIOD")
+    );
+}
+
+#[test]
+fn an_event_type_nothing_processes_is_refused_with_the_list() {
+    let report = refused(&with_schedule(vec![
+        vec![text("event_type"), text("scheduled_datetime")],
+        vec![text("OPEN_THE_POLLS"), text("2027-03-01T16:00:00Z")],
+    ]));
+    assert!(has_error_saying(&report, "is not an event processor"));
+    assert!(has_error_saying(&report, "START_VOTING_PERIOD"));
+}
+
+#[test]
+fn a_scheduled_event_with_no_time_is_refused() {
+    let report = refused(&with_schedule(vec![
+        vec![text("event_type"), text("scheduled_datetime")],
+        vec![text("START_VOTING_PERIOD"), Cell::Blank],
+    ]));
+    assert!(has_error_saying(&report, "needs a scheduled_datetime"));
+}
+
+#[test]
+fn an_event_name_is_kept_as_an_annotation_so_the_csv_reads_like_the_source() {
+    let bundle = built(&with_schedule(vec![
+        vec![
+            text("event_name"),
+            text("event_type"),
+            text("scheduled_datetime"),
+        ],
+        vec![
+            text("Polls open"),
+            text("START_VOTING_PERIOD"),
+            text("2027-03-01T16:00:00Z"),
+        ],
+    ]));
+    assert_eq!(
+        bundle.scheduled_events.rows[0][7],
+        JsonField::Value(json!({"janitor.event_name": "Polls open"}))
+    );
+}
+
+#[test]
+fn an_election_whose_window_never_opens_is_warned_about() {
+    // It imports fine and then quietly never opens.
+    let bundle = built(&with_schedule(vec![
+        vec![
+            text("event_type"),
+            text("scheduled_datetime"),
+            text("election.external_id"),
+        ],
+        vec![
+            text("START_VOTING_PERIOD"),
+            text("2027-03-01T16:00:00Z"),
+            text("statewide"),
+        ],
+    ]));
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("no END_VOTING_PERIOD scheduled event")));
+}
+
+#[test]
+fn an_event_wide_window_covers_every_election() {
+    let bundle = built(&with_schedule(vec![
+        vec![text("event_type"), text("scheduled_datetime")],
+        vec![text("START_VOTING_PERIOD"), text("2027-03-01T16:00:00Z")],
+        vec![text("END_VOTING_PERIOD"), text("2027-03-15T23:59:00Z")],
+    ]));
+    assert!(
+        !bundle
+            .warnings
+            .warnings()
+            .any(|problem| problem.message.contains("voting period will not")),
+        "{}",
+        bundle.warnings
+    );
+}
+
+#[test]
+fn a_document_with_no_schedule_at_all_says_it_will_need_hands() {
+    let bundle = built(&sound());
+    assert!(bundle.scheduled_events.is_empty());
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("by hand in the Admin Portal")));
+}
+
+// -- reports --------------------------------------------------------------
+
+#[test]
+fn no_reports_sheet_means_no_reports_member() {
+    // Absent and empty are the same thing, and an empty CSV is not a valid one.
+    assert!(built(&sound()).reports.is_none());
+}
+
+#[test]
+fn a_report_row_becomes_a_positional_csv_row() {
+    let bundle = built(&with_sheet(
+        "Reports",
+        vec![
+            vec![
+                text("report_type"),
+                text("election.external_id"),
+                text("encryption_policy"),
+                text("permission_label"),
+            ],
+            vec![
+                text("tally"),
+                text("statewide"),
+                text("configured_password"),
+                text("statewide-officers || auditors"),
+            ],
+        ],
+    ));
+    let reports = bundle.reports.expect("a reports table");
+    let row = &reports.rows[0];
+
+    assert_eq!(row.len(), 8);
+    assert_eq!(
+        row[1],
+        bundle.export["elections"][0]["id"].as_str().unwrap()
+    );
+    assert_eq!(row[2], "tally");
+    // Read from the row, not from the template's default: this is the field that
+    // silently became `unencrypted` once.
+    assert_eq!(row[5], "configured_password");
+    // Option<Vec<String>>, split on "|" by process_reports_file.
+    assert_eq!(row[7], "statewide-officers|auditors");
+}
+
+#[test]
+fn a_report_with_no_policy_falls_back_to_unencrypted() {
+    let bundle = built(&with_sheet(
+        "Reports",
+        vec![vec![text("report_type")], vec![text("tally")]],
+    ));
+    let reports = bundle.reports.expect("a reports table");
+    assert_eq!(reports.rows[0][5], "unencrypted");
+}
+
+#[test]
+fn a_report_needs_a_type() {
+    let report = refused(&with_sheet(
+        "Reports",
+        vec![
+            vec![text("report_type"), text("election.external_id")],
+            vec![Cell::Blank, text("statewide")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "a report needs a report_type"));
+}
+
+#[test]
+fn a_report_naming_a_template_nobody_defined_is_refused() {
+    let report = refused(&with_sheet(
+        "Reports",
+        vec![
+            vec![text("report_type"), text("template.alias")],
+            vec![text("tally"), text("no-such-template")],
+        ],
+    ));
+    assert!(has_error_saying(
+        &report,
+        "no Templates row has alias 'no-such-template'"
+    ));
+}
+
+#[test]
+fn a_report_password_is_flagged_as_a_secret() {
+    let mut sheets: Vec<Sheet> = sound().sheets().to_vec();
+    sheets.push(
+        Sheet::from_grid(
+            "Reports",
+            &[
+                vec![text("report_type"), text("password")],
+                vec![text("tally"), text("s3cret")],
+            ],
+        )
+        .unwrap(),
+    );
+    let bundle = built(&Workbook::new(sheets).unwrap());
+    assert!(bundle
+        .warnings
+        .warnings()
+        .any(|problem| problem.message.contains("clear text")));
+}
+
+// -- admin users, permissions, templates ----------------------------------
+
+#[test]
+fn admin_users_keep_their_own_columns() {
+    // Not an event-import member: the sheet is the shape, whatever it holds.
+    let bundle = built(&with_sheet(
+        "Admin Users",
+        vec![
+            vec![text("username"), text("email"), text("permission_labels")],
+            vec![
+                text("admin1"),
+                text("admin@example.org"),
+                text("statewide-officers || auditors"),
+            ],
+        ],
+    ));
+    let admins = bundle.admin_users.expect("an admin users table");
+    assert_eq!(admins.columns, ["username", "email", "permission_labels"]);
+    // "||" in, "|" out.
+    assert_eq!(admins.rows[0][2], "statewide-officers|auditors");
+}
+
+#[test]
+fn an_admin_user_needs_a_username() {
+    let report = refused(&with_sheet(
+        "Admin Users",
+        vec![
+            vec![text("username"), text("email")],
+            vec![Cell::Blank, text("a@b.c")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "an admin user needs a username"));
+}
+
+#[test]
+fn admin_passwords_are_flagged_once_however_many_rows_carry_them() {
+    let bundle = built(&with_sheet(
+        "Admin Users",
+        vec![
+            vec![text("username"), text("password")],
+            vec![text("admin1"), text("s3cret")],
+            vec![text("admin2"), text("s3cret2")],
+        ],
+    ));
+    assert_eq!(
+        bundle
+            .warnings
+            .warnings()
+            .filter(|problem| problem.message.contains("clear-text passwords"))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn the_permission_matrix_is_transposed_into_the_platform_shape() {
+    // A matrix is what a human can check at a glance; role,permissions is what
+    // export_tenant_config.rs writes.
+    let bundle = built(&with_sheet(
+        "Permissions",
+        vec![
+            vec![text("permission"), text("admin"), text("auditor")],
+            vec![text("election:read"), text("x"), text("x")],
+            vec![text("election:write"), text("x"), Cell::Blank],
+        ],
+    ));
+    let permissions = bundle.role_permissions.expect("a permissions table");
+    assert_eq!(permissions.columns, ["role", "permissions"]);
+    assert_eq!(
+        permissions.rows,
+        vec![
+            vec![
+                "admin".to_string(),
+                "election:read|election:write".to_string()
+            ],
+            vec!["auditor".to_string(), "election:read".to_string()],
+        ]
+    );
+}
+
+#[test]
+fn a_permission_matrix_with_no_roles_says_what_it_expected() {
+    let report = refused(&with_sheet(
+        "Permissions",
+        vec![vec![text("permission")], vec![text("election:read")]],
+    ));
+    assert!(has_error_saying(&report, "has no role columns"));
+}
+
+#[test]
+fn a_template_becomes_a_file_beside_the_bundle() {
+    // The event zip has no member for communication templates.
+    let bundle = built(&with_sheet(
+        "Templates",
+        vec![
+            vec![
+                text("name"),
+                text("alias"),
+                text("type"),
+                text("communication_method"),
+                text("template.document"),
+            ],
+            vec![
+                text("Voter Credentials"),
+                text("voter_credentials"),
+                text("VOTER_CREDENTIALS"),
+                text("EMAIL"),
+                text(r"Dear {{name}},\n\nYour code is {{code}}."),
+            ],
+        ],
+    ));
+    assert_eq!(bundle.templates.len(), 1);
+    let template = &bundle.templates[0];
+    assert_eq!(template.alias, "voter_credentials");
+    assert_eq!(template.name, "Voter Credentials");
+    assert_eq!(template.template_type.as_deref(), Some("VOTER_CREDENTIALS"));
+    assert_eq!(template.communication_method.as_deref(), Some("EMAIL"));
+    // The literal \n a copy-paste out of a JSON export leaves behind.
+    assert_eq!(
+        template.document,
+        "Dear {{name}},\n\nYour code is {{code}}."
+    );
+    assert_eq!(template.file_name(), "voter_credentials.hbs");
+}
+
+#[test]
+fn a_template_falls_back_to_its_name_when_it_has_no_alias() {
+    let bundle = built(&with_sheet(
+        "Templates",
+        vec![
+            vec![text("name"), text("template.document")],
+            vec![text("Reminder"), text("hello")],
+        ],
+    ));
+    assert_eq!(bundle.templates[0].alias, "Reminder");
+    assert_eq!(bundle.templates[0].name, "Reminder");
+}
+
+#[test]
+fn a_template_needs_a_name_and_a_document() {
+    let report = refused(&with_sheet(
+        "Templates",
+        vec![
+            vec![text("name"), text("alias"), text("template.document")],
+            vec![Cell::Blank, Cell::Blank, text("orphan")],
+            vec![text("No document"), text("nodoc"), Cell::Blank],
+        ],
+    ));
+    assert!(has_error_saying(&report, "needs a name or an alias"));
+    assert!(has_error_saying(&report, "a template needs a document"));
+}
+
+#[test]
+fn two_templates_may_not_share_an_alias() {
+    let report = refused(&with_sheet(
+        "Templates",
+        vec![
+            vec![text("alias"), text("template.document")],
+            vec![text("otp"), text("one")],
+            vec![text("otp"), text("two")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "already used by row 2"));
+}
+
+// -- everything together --------------------------------------------------
+
+#[test]
+fn a_full_document_builds_every_member_and_still_validates() {
+    // The whole surface at once, because the members share resolved ids and a
+    // mistake in one shows up in another.
+    let mut sheets: Vec<Sheet> = sound().sheets().to_vec();
+    for (name, grid) in [
+        (
+            "Voters",
+            vec![
+                vec![
+                    text("username"),
+                    text("email"),
+                    text("area.external_id"),
+                    text("local-number"),
+                ],
+                vec![
+                    text("m-1001"),
+                    text("alice@example.org"),
+                    text("area-north"),
+                    text("1000"),
+                ],
+                vec![
+                    text("m-1002"),
+                    text("bob@example.org"),
+                    text("area-south"),
+                    text("2000"),
+                ],
+            ],
+        ),
+        (
+            "ScheduledEvents",
+            vec![
+                vec![text("event_type"), text("scheduled_datetime")],
+                vec![text("START_VOTING_PERIOD"), text("2027-03-01T16:00:00Z")],
+                vec![text("END_VOTING_PERIOD"), text("2027-03-15T23:59:00Z")],
+            ],
+        ),
+        (
+            "Templates",
+            vec![
+                vec![text("alias"), text("template.document")],
+                vec![text("tally_report"), text("Results for {{election}}")],
+            ],
+        ),
+        (
+            "Reports",
+            vec![
+                vec![text("report_type"), text("template.alias")],
+                vec![text("tally"), text("tally_report")],
+            ],
+        ),
+        (
+            "Admin Users",
+            vec![
+                vec![text("username"), text("permission_labels")],
+                vec![text("admin1"), text("statewide-officers")],
+            ],
+        ),
+        (
+            "Permissions",
+            vec![
+                vec![text("permission"), text("admin")],
+                vec![text("election:read"), text("x")],
+            ],
+        ),
+    ] {
+        sheets.push(Sheet::from_grid(name, &grid).unwrap());
+    }
+
+    let bundle = built(&Workbook::new(sheets).unwrap());
+
+    assert_eq!(bundle.voters.len(), 2);
+    assert_eq!(bundle.scheduled_events.len(), 2);
+    assert_eq!(bundle.reports.as_ref().map(PlainTable::len), Some(1));
+    assert_eq!(bundle.admin_users.as_ref().map(PlainTable::len), Some(1));
+    assert_eq!(
+        bundle.role_permissions.as_ref().map(PlainTable::len),
+        Some(1)
+    );
+    assert_eq!(bundle.templates.len(), 1);
+
+    // And the JSON document is still one the platform accepts.
+    let schema: crate::election_config::ImportElectionEventSchema =
+        serde_json::from_value(bundle.export.clone()).unwrap();
+    let report = crate::election_config::validate(&schema);
+    assert!(!report.has_errors(), "{report}");
+}
+
+#[test]
+fn the_csv_members_render_through_the_shared_writers() {
+    // The tables exist to be written by emit, so the join has to hold.
+    use crate::election_config::emit::{json_csv, plain_csv};
+
+    let bundle = built(&with_voters(vec![
+        vec![text("username"), text("email"), text("area.external_id")],
+        vec![
+            text("m-1001"),
+            text("alice@example.org"),
+            text("area-north"),
+        ],
+    ]));
+
+    let columns: Vec<&str> =
+        bundle.voters.columns.iter().map(String::as_str).collect();
+    let rendered = plain_csv(&columns, &bundle.voters.rows);
+    assert!(rendered.starts_with("id,email,email_verified"));
+    assert!(rendered.contains("alice@example.org"));
+    assert!(rendered.ends_with('\n'));
+
+    let schedule_columns: Vec<&str> = bundle
+        .scheduled_events
+        .columns
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let schedule = json_csv(&schedule_columns, &bundle.scheduled_events.rows);
+    assert!(schedule.starts_with("id,tenant_id,election_event_id"));
 }

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -52,7 +52,9 @@ pub mod xlsx;
 mod validate_tests;
 
 #[cfg(feature = "election_config_templates")]
-pub use build::{build, BuildOptions, Bundle};
+pub use build::{
+    build, BuildOptions, Bundle, CommunicationTemplate, JsonTable, PlainTable,
+};
 pub use emit::{json_csv, plain_csv, JsonField};
 pub use ids::IdFactory;
 pub use paths::{coerce_cell, deep_merge, expand, Cell};


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2975.** Base branch is
`feat/meta-12769-builder/main`, so this diff shows only what is added on top.

Four of a bundle's parts are not in the JSON document at all: voters and scheduled
events are always CSVs, reports are a CSV or nothing, and admin users, role
permissions and communication templates are tenant- or portal-scoped rather than
part of an event import. All of them resolve `external_id`s against the entities the
previous level built, which is why they live beside it — `build_tables.rs` is a
child module of `build.rs` so the two share the resolved ids while each file stays
readable.

**The scheduled-events table is where the voting window actually lives.**
`scheduled_events` in the JSON document is not read by the importer at all. Its rows
go out through `emit`'s `JsonField`, so a SQL NULL is a bare `null` and the payload
is a CSV-quoted JSON literal; the task id comes from the same function that mirrors
`generate_manage_date_task_name`, because a different shape means a task that never
fires.

## What the tests pin down

**A voter's area travels as a name**, because that is what the importer resolves by.

**A voter with no `authorized-election-ids` is authorized for all of them.** Writing
an empty attribute would deny access to every election instead.

**A voter with an email address is treated as verified.** An unverified address
blocks delivery of the one-time code, and a census address is one the client asserts
is correct.

**Any column the builder does not derive becomes a Keycloak user attribute** — how a
client adds a reporting breakout column with no code change.

**A passthrough column blank for every voter is dropped**, and that is not cosmetic:
`get_copy_from_query` treats the mere presence of a `password` header as "hash a
password for each of these voters", so a blank one would give every voter an empty
credential.

**A column name outside `^[a-zA-Z0-9._-]+$` is refused here**, because both CSV
importers reject it mid-import with nothing naming the column.

**An author may write an event type the way they say it** — `start voting period`
and `start-voting-period` both reach `START_VOTING_PERIOD`.

**An election whose window never opens or never closes is warned about.** It imports
fine and then quietly never opens. An event-wide row covers every election.

**A report's `encryption_policy` and `permission_label` are read from the row, not
from the rendered template.** They are control columns, so the row was excluded from
the merge and the template value is only a default — reading it instead is how
`configured_password` silently became `unencrypted` once.

**The permission matrix is transposed.** A matrix is what a human can check at a
glance; `role,permissions` is what `export_tenant_config.rs` writes.

**A template document gets its newlines back.** Literal `\n` and `\"` are what
survive a copy-paste out of a JSON export. Unescaped in one pass, so an escaped
backslash before an `n` does not become a line break.

## One dead branch removed rather than ported

The Python warns when a census has no email or mobile column at all — but `email` is
a *derived* column and is therefore always present, so that branch could never fire.
A census with no contact column reaches the per-voter count with every voter
unreachable, which is the more useful message anyway. A test says so.

## Verified

- `cargo test -p sequent-core --lib --features election_config_xlsx,election_config_templates election_config` — **250 passed**, 0 failed (200 before, 50 new). Includes an end-to-end test that builds every member from one document and asserts the JSON half still deserializes into `ImportElectionEventSchema` and passes `validate()`, plus one that renders the tables through `emit`'s writers.
- `cargo check -p sequent-core --features default_features` clean; `cargo check -p windmill` clean.
- `cargo build` emits no warnings for this module; `cargo fmt --check` clean; `cargo clippy --lib --tests` silent on it.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

_Not applicable — this level is a library module with no UI._
