### PR TITLE
✨ Configure the login page from the event, in the shared core

### DIFF
--- a/packages/sequent-core/src/election_config/branding.rs
+++ b/packages/sequent-core/src/election_config/branding.rs
@@ -1,0 +1,442 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What an election event already states about itself, expressed as realm
+//! settings.
+//!
+//! The languages an event enables, its name, and its login CSS all belong on the
+//! login page, and the platform copies none of them there: it syncs the default
+//! locale only under a force-default detection policy, never syncs
+//! `supportedLocales`, and has no path at all from an event name to a realm
+//! display name. Stating them twice in a source document would be a way to get
+//! them out of step, so they are derived from what the event already says.
+//!
+//! The language codes go through [`crate::util::locale::iso_639_2t_to_bcp47`] —
+//! the platform's own table, rather than a second copy of it. The Python this was
+//! ported from transcribed all 177 entries by hand, which is exactly the kind of
+//! duplication this work exists to remove.
+
+use crate::util::locale::iso_639_2t_to_bcp47;
+use serde_json::{json, Map, Value};
+
+/// The realm localization key the login theme renders.
+///
+/// See `sequent-theme/.../sequent.admin-portal/login/template.ftl`.
+pub const LOGIN_CUSTOM_CSS_KEY: &str = "loginCustomCss";
+
+/// Escape CSS for Keycloak's `${msg(...)}`, which is `java.text.MessageFormat`.
+///
+/// MessageFormat treats `{` and `}` as format-element delimiters and `'` as a
+/// quoting character. CSS is made of braces, and its `url('…')` is made of
+/// quotes, so pasting CSS in raw produces either a parse error or silently
+/// mangled output — a login page with no styling and nothing in the logs.
+///
+/// The escaping MessageFormat defines is: `''` for a literal single quote, and a
+/// brace is literal when quoted, so `{` becomes `'{'`.
+///
+/// Quotes are escaped **first**, so the quotes added around braces are not
+/// themselves doubled:
+///
+/// ```text
+/// a { b: url('x'); }   ->   a '{' b: url(''x''); '}'
+/// ```
+///
+/// which MessageFormat renders back as the original. The platform's own realm
+/// writes braces exactly this way.
+pub fn escape_message_format(text: &str) -> String {
+    text.replace('\'', "''")
+        .replace('{', "'{'")
+        .replace('}', "'}'")
+}
+
+/// Strip one enclosing pair of single quotes, if present.
+///
+/// Quoting an entire string is the other way to make MessageFormat treat it
+/// literally, so realm values are often passed around already wrapped that way.
+/// Accepting both means a value copied out of a working realm and a value typed
+/// as plain CSS both do the right thing.
+pub fn unwrap_quoted(text: &str) -> &str {
+    let stripped = text.trim();
+    if stripped.len() >= 2
+        && stripped.starts_with('\'')
+        && stripped.ends_with('\'')
+    {
+        &stripped[1..stripped.len() - 1]
+    } else {
+        text
+    }
+}
+
+/// Realm i18n settings from the event's `presentation.language_conf`.
+///
+/// `supportedLocales` is what puts a language in Keycloak's login-page picker,
+/// and nothing else sets it — so an event offering a language the realm does not
+/// list is a ballot whose login page the voter cannot read.
+pub fn language_patch(language_conf: Option<&Value>) -> Map<String, Value> {
+    let mut patch = Map::new();
+    let Some(Value::Object(language_conf)) = language_conf else {
+        return patch;
+    };
+
+    if let Some(codes) = enabled_locales(language_conf) {
+        // Keycloak needs this on for supportedLocales to have any effect.
+        patch.insert("internationalizationEnabled".to_string(), json!(true));
+        patch.insert("supportedLocales".to_string(), json!(codes));
+    }
+
+    if let Some(default) = language_conf
+        .get("default_language_code")
+        .and_then(Value::as_str)
+        .filter(|code| !code.is_empty())
+    {
+        patch.insert(
+            "defaultLocale".to_string(),
+            json!(iso_639_2t_to_bcp47(default)),
+        );
+    }
+    patch
+}
+
+/// The BCP 47 locales a realm localization string should be written for.
+pub fn locales_of(
+    language_conf: Option<&Value>,
+    fallback: &str,
+) -> Vec<String> {
+    if let Some(Value::Object(language_conf)) = language_conf {
+        if let Some(codes) = enabled_locales(language_conf) {
+            return codes;
+        }
+        if let Some(default) = language_conf
+            .get("default_language_code")
+            .and_then(Value::as_str)
+            .filter(|code| !code.is_empty())
+        {
+            return vec![iso_639_2t_to_bcp47(default).to_string()];
+        }
+    }
+    vec![fallback.to_string()]
+}
+
+/// The enabled codes as sorted, deduplicated BCP 47.
+fn enabled_locales(language_conf: &Map<String, Value>) -> Option<Vec<String>> {
+    let Some(Value::Array(enabled)) =
+        language_conf.get("enabled_language_codes")
+    else {
+        return None;
+    };
+    if enabled.is_empty() {
+        return None;
+    }
+
+    let mut codes: Vec<String> = enabled
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|code| !code.is_empty())
+        .map(|code| iso_639_2t_to_bcp47(code).to_string())
+        .collect();
+    if codes.is_empty() {
+        return None;
+    }
+    codes.sort();
+    codes.dedup();
+    Some(codes)
+}
+
+/// The realm `displayName`, taken from the event's own name.
+///
+/// Keycloak shows it above the login form, so leaving it at the platform default
+/// means every client's voters see "Election Event".
+///
+/// `displayNameHtml` is deliberately left alone: Keycloak renders it as raw markup
+/// and prefers it over `displayName` when set, so writing an event name into it
+/// would turn any `&` in a client's name into a rendering bug.
+pub fn title_patch(
+    i18n: Option<&Value>,
+    default_language: Option<&str>,
+) -> Map<String, Value> {
+    let mut patch = Map::new();
+    let Some(Value::Object(i18n)) = i18n else {
+        return patch;
+    };
+    if i18n.is_empty() {
+        return patch;
+    }
+
+    // The event's default language first, then the raw code it was written as,
+    // then English.
+    let converted = default_language.map(iso_639_2t_to_bcp47);
+    let preferred: Vec<&str> = converted
+        .into_iter()
+        .chain(default_language)
+        .chain(std::iter::once("en"))
+        .collect();
+
+    for key in preferred {
+        if let Some(name) = named(i18n.get(key)) {
+            patch.insert("displayName".to_string(), json!(name));
+            return patch;
+        }
+    }
+
+    // No default language matched, so take whichever entry has a name. Sorted so
+    // the choice does not depend on map iteration order.
+    let mut keys: Vec<&String> = i18n.keys().collect();
+    keys.sort();
+    for key in keys {
+        if let Some(name) = named(i18n.get(key)) {
+            patch.insert("displayName".to_string(), json!(name));
+            return patch;
+        }
+    }
+    patch
+}
+
+fn named(entry: Option<&Value>) -> Option<&str> {
+    entry?
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+}
+
+/// `localizationTexts.<locale>.loginCustomCss`, escaped and per language.
+///
+/// Written for every enabled locale: Keycloak looks the message up in the voter's
+/// language, so CSS present only under `en` disappears the moment a voter switches
+/// to Spanish.
+pub fn login_css_patch(css: &str, locales: &[String]) -> Map<String, Value> {
+    let escaped = escape_message_format(unwrap_quoted(css));
+    let mut texts = Map::new();
+    for locale in locales {
+        texts.insert(
+            locale.clone(),
+            json!({LOGIN_CUSTOM_CSS_KEY: escaped.clone()}),
+        );
+    }
+
+    let mut patch = Map::new();
+    patch.insert("localizationTexts".to_string(), Value::Object(texts));
+    patch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn css_braces_and_quotes_are_escaped_the_way_message_format_reads_them() {
+        // Raw CSS in a ${msg(...)} is either a parse error or silently mangled
+        // output: a login page with no styling and nothing in the logs.
+        assert_eq!(
+            escape_message_format("a { b: url('x'); }"),
+            "a '{' b: url(''x''); '}'"
+        );
+    }
+
+    #[test]
+    fn quotes_are_escaped_before_braces_are_wrapped_in_them() {
+        // The other order doubles the quotes this function just added, and the
+        // result renders as a literal '{' instead of a brace.
+        assert_eq!(escape_message_format("{"), "'{'");
+        assert_eq!(escape_message_format("'"), "''");
+        assert_eq!(escape_message_format("'{'"), "'''{'''");
+    }
+
+    #[test]
+    fn text_with_nothing_message_format_cares_about_is_left_alone() {
+        // Most of a stylesheet is not braces, and mangling it would be as bad as
+        // not escaping the parts that are.
+        assert_eq!(escape_message_format("color: red;"), "color: red;");
+        assert_eq!(
+            escape_message_format("background: #fff url(logo.png)"),
+            "background: #fff url(logo.png)"
+        );
+    }
+
+    #[test]
+    fn a_value_already_quoted_for_message_format_is_unwrapped_first() {
+        // A value copied out of a working realm arrives wrapped; one typed as
+        // plain CSS does not. Both have to work.
+        assert_eq!(unwrap_quoted("'a { b: c }'"), "a { b: c }");
+        assert_eq!(unwrap_quoted("a { b: c }"), "a { b: c }");
+        assert_eq!(unwrap_quoted("'"), "'");
+        assert_eq!(unwrap_quoted(""), "");
+    }
+
+    #[test]
+    fn the_enabled_languages_become_the_login_pages_picker() {
+        // Nothing else in the platform sets supportedLocales.
+        let patch = language_patch(Some(&json!({
+            "enabled_language_codes": ["eng", "spa", "cat"],
+            "default_language_code": "spa",
+        })));
+        assert_eq!(patch["internationalizationEnabled"], json!(true));
+        assert_eq!(patch["supportedLocales"], json!(["ca", "en", "es"]));
+        assert_eq!(patch["defaultLocale"], json!("es"));
+    }
+
+    #[test]
+    fn codes_are_converted_by_the_platforms_own_table() {
+        // Not a second transcription of it: the Python copied all 177 entries by
+        // hand, which is exactly the duplication this work removes.
+        let patch = language_patch(Some(&json!({
+            "enabled_language_codes": ["cat", "glg", "spa"],
+        })));
+        assert_eq!(patch["supportedLocales"], json!(["ca", "es", "gl"]));
+    }
+
+    #[test]
+    fn a_code_the_table_does_not_know_passes_through_unchanged() {
+        // Which is the safe answer: an unconverted code is a locale Keycloak may
+        // not recognise, whereas a guessed one is a locale it recognises wrongly.
+        //
+        // Basque ("eus") and Dutch ("nld") are among the codes the platform's
+        // table lacks. Both the Rust and the Python it replaces behave this way,
+        // so this is a gap in `util::locale`, not a regression here.
+        let patch = language_patch(Some(&json!({
+            "enabled_language_codes": ["en", "eus", "nld"],
+        })));
+        assert_eq!(patch["supportedLocales"], json!(["en", "eus", "nld"]));
+    }
+
+    #[test]
+    fn duplicate_codes_collapse() {
+        // "en" and "eng" are the same locale, and a realm listing it twice is a
+        // picker showing it twice.
+        let patch = language_patch(Some(&json!({
+            "enabled_language_codes": ["en", "eng"],
+        })));
+        assert_eq!(patch["supportedLocales"], json!(["en"]));
+    }
+
+    #[test]
+    fn no_language_configuration_means_no_language_patch() {
+        // Leaving the realm alone is the right answer, not writing an empty list
+        // that would empty its picker.
+        assert!(language_patch(None).is_empty());
+        assert!(language_patch(Some(&json!({}))).is_empty());
+        assert!(language_patch(Some(&json!("not an object"))).is_empty());
+        assert!(language_patch(Some(&json!({"enabled_language_codes": []})))
+            .is_empty());
+    }
+
+    #[test]
+    fn a_default_language_alone_still_sets_the_default_locale() {
+        let patch =
+            language_patch(Some(&json!({"default_language_code": "cat"})));
+        assert_eq!(patch["defaultLocale"], json!("ca"));
+        assert!(patch.get("supportedLocales").is_none());
+    }
+
+    #[test]
+    fn the_locales_css_is_written_for_follow_the_enabled_languages() {
+        assert_eq!(
+            locales_of(
+                Some(&json!({"enabled_language_codes": ["eng", "spa"]})),
+                "en"
+            ),
+            ["en", "es"]
+        );
+        assert_eq!(
+            locales_of(Some(&json!({"default_language_code": "spa"})), "en"),
+            ["es"]
+        );
+        assert_eq!(locales_of(None, "en"), ["en"]);
+    }
+
+    #[test]
+    fn the_event_name_becomes_the_realms_display_name() {
+        // Otherwise every client's voters see "Election Event" above the form.
+        let patch = title_patch(
+            Some(&json!({
+                "en": {"name": "Union Election 2027"},
+                "es": {"name": "Elección Sindical 2027"},
+            })),
+            Some("spa"),
+        );
+        assert_eq!(patch["displayName"], json!("Elección Sindical 2027"));
+    }
+
+    #[test]
+    fn the_title_falls_back_to_english_then_to_whatever_has_a_name() {
+        assert_eq!(
+            title_patch(Some(&json!({"en": {"name": "English"}})), Some("spa"))
+                ["displayName"],
+            json!("English")
+        );
+        assert_eq!(
+            title_patch(
+                Some(&json!({"fr": {"name": "Français"}})),
+                Some("spa")
+            )["displayName"],
+            json!("Français")
+        );
+    }
+
+    #[test]
+    fn a_default_language_written_as_bcp47_matches_too() {
+        // An author who writes "es" rather than "spa" means the same thing.
+        assert_eq!(
+            title_patch(
+                Some(
+                    &json!({"es": {"name": "Español"}, "en": {"name": "English"}})
+                ),
+                Some("es")
+            )["displayName"],
+            json!("Español")
+        );
+    }
+
+    #[test]
+    fn a_nameless_i18n_block_leaves_the_display_name_alone() {
+        assert!(title_patch(Some(&json!({"en": {}})), Some("eng")).is_empty());
+        assert!(
+            title_patch(Some(&json!({"en": {"name": ""}})), None).is_empty()
+        );
+        assert!(title_patch(None, None).is_empty());
+        assert!(title_patch(Some(&json!({})), None).is_empty());
+    }
+
+    #[test]
+    fn display_name_html_is_never_written() {
+        // Keycloak renders it as raw markup and prefers it when set, so an "&" in
+        // a client's name would become a rendering bug.
+        let patch = title_patch(
+            Some(&json!({"en": {"name": "Smith & Sons Local"}})),
+            None,
+        );
+        assert_eq!(patch["displayName"], json!("Smith & Sons Local"));
+        assert!(patch.get("displayNameHtml").is_none());
+    }
+
+    #[test]
+    fn login_css_is_written_for_every_enabled_language() {
+        // Keycloak looks the message up in the voter's language, so CSS under `en`
+        // alone vanishes when a voter switches to Spanish.
+        let patch = login_css_patch(
+            ".logo { display: none; }",
+            &["en".to_string(), "es".to_string()],
+        );
+        let texts = &patch["localizationTexts"];
+        assert_eq!(
+            texts["en"][LOGIN_CUSTOM_CSS_KEY],
+            json!(".logo '{' display: none; '}'")
+        );
+        assert_eq!(
+            texts["es"][LOGIN_CUSTOM_CSS_KEY],
+            texts["en"][LOGIN_CUSTOM_CSS_KEY]
+        );
+    }
+
+    #[test]
+    fn login_css_copied_out_of_a_realm_is_not_escaped_twice() {
+        // It arrives already wrapped in quotes; escaping that as content would
+        // double every quote in it.
+        let patch =
+            login_css_patch("'.logo { display: none; }'", &["en".to_string()]);
+        assert_eq!(
+            patch["localizationTexts"]["en"][LOGIN_CUSTOM_CSS_KEY],
+            json!(".logo '{' display: none; '}'")
+        );
+    }
+}

--- a/packages/sequent-core/src/election_config/build.rs
+++ b/packages/sequent-core/src/election_config/build.rs
@@ -15,15 +15,14 @@
 //! problem carries the sheet and row it came from, because a bundle path is no
 //! use to whoever has to edit the file.
 //!
-//! The CSV members and the files that travel beside a bundle are in
-//! `build_tables.rs`, a child module, so that this file stays readable; the two
-//! are one unit of code split across two files.
-//!
-//! The auth presets and the Keycloak realm are the next level of the same port;
-//! `keycloak_event_realm` is left null until then.
+//! Split across three files so each stays readable, all one unit of code: the CSV
+//! members and the files that travel beside a bundle are in `build_tables.rs`, and
+//! everything to do with the Keycloak realm is in `build_realm.rs`. Both are child
+//! modules, so both can reach the resolved ids without any of it being public.
 
 use crate::election_config::ids::IdFactory;
 use crate::election_config::paths::{deep_merge, set_path, split_path};
+use crate::election_config::presets::{self, AuthPreset, RealmPatch};
 use crate::election_config::problem::{Code, Problem, Report};
 use crate::election_config::render::TemplateSet;
 use crate::election_config::sheet::{
@@ -34,9 +33,13 @@ use crate::election_config::sheet::{
 };
 use serde_json::{json, Map, Value};
 
+#[path = "build_realm.rs"]
+mod realm;
+
 #[path = "build_tables.rs"]
 mod tables;
 
+pub use realm::PARAM_LOGIN_CUSTOM_CSS;
 pub use tables::{
     CommunicationTemplate, JsonTable, PlainTable, EVENT_PROCESSORS,
     VOTER_LEADING_COLUMNS,
@@ -92,7 +95,8 @@ pub const PARAMETER_PREFIXES: &[&str] = &[
 ];
 
 /// Parameters the builder acts on directly rather than carrying as metadata.
-pub const HANDLED_PARAMETERS: &[&str] = &["tenant_id", "login_custom_css"];
+pub const HANDLED_PARAMETERS: &[&str] =
+    &["tenant_id", realm::PARAM_LOGIN_CUSTOM_CSS];
 
 /// Fields of a base entity that describe *that* event rather than the platform's
 /// defaults, and so must not leak into a new one.
@@ -180,6 +184,13 @@ pub struct BuildOptions {
 
     /// Timestamp for every entity. [`DEFAULT_CREATED_AT`] when absent.
     pub created_at: Option<String>,
+
+    /// Which authentication preset to apply, overriding the document's
+    /// `auth_type`.
+    ///
+    /// [`presets::NONE`] leaves the realm alone whatever the document declares —
+    /// worth having while a client has not yet supplied what a preset needs.
+    pub auth_preset: Option<String>,
 }
 
 /// A built bundle: the JSON document and what was worth saying about it.
@@ -217,6 +228,20 @@ pub struct Bundle {
     /// rather than imported — the event zip has no member for them.
     pub templates: Vec<CommunicationTemplate>,
 
+    /// Everything the document asked of the event's Keycloak realm.
+    ///
+    /// Kept whether or not it could be applied here, so that an `auth_type` or a
+    /// `keycloak_event_realm.*` parameter is never lost just because no base
+    /// export was given.
+    pub realm_patch: RealmPatch,
+
+    /// `keycloak_admin_realm.*` parameters. Tenant-scoped, so not part of the
+    /// event import.
+    pub admin_realm_patch: Map<String, Value>,
+
+    /// The preset that was applied, if any.
+    pub auth_preset: Option<&'static str>,
+
     /// Warnings. Not errors: the bundle imports, but something about it looks
     /// unintended.
     pub warnings: Report,
@@ -244,6 +269,9 @@ struct Builder<'a> {
 
     /// `(type, key) -> value` from the Parameters sheet, in sheet order.
     parameters: Vec<(String, String, Value)>,
+
+    auth_preset: Option<&'static AuthPreset>,
+    realm_patch: RealmPatch,
 
     event_row: Row,
     event_external_id: String,
@@ -301,6 +329,8 @@ impl<'a> Builder<'a> {
                 .unwrap_or_else(|| DEFAULT_CREATED_AT.to_string()),
             report,
             parameters: Vec::new(),
+            auth_preset: None,
+            realm_patch: RealmPatch::default(),
             event_row,
             event_external_id: event_external_id.clone(),
             event_id,
@@ -319,16 +349,27 @@ impl<'a> Builder<'a> {
         builder.parameters = builder.read_parameters();
         builder.tenant_id =
             builder.resolve_tenant_id(options.tenant_id.as_deref());
+        builder.auth_preset =
+            builder.resolve_auth_preset(options.auth_preset.as_deref());
         Ok(builder)
     }
 
     fn build(mut self) -> Result<Bundle, Report> {
+        // Built before the realm, because the realm applies it, and before the
+        // entities so that a preset's requirements are reported first.
+        self.realm_patch = self.build_realm_patch();
+        self.warn_permission_labels();
+
         let elections = self.build_elections();
         let contests = self.build_contests();
         let candidates = self.build_candidates();
         let areas = self.build_areas();
         let area_contests = self.build_area_contests();
         let event = self.build_election_event();
+        // After the event, because a stale base event id is swapped out of the
+        // realm's URLs and that id comes from the base export.
+        let realm = self.build_realm();
+        let admin_realm_patch = self.admin_realm_patch();
 
         let version = self
             .base_export
@@ -339,8 +380,7 @@ impl<'a> Builder<'a> {
 
         let export = json!({
             "tenant_id": self.tenant_id,
-            // Filled in by the realm level of this port.
-            "keycloak_event_realm": Value::Null,
+            "keycloak_event_realm": realm,
             "election_event": event,
             "elections": elections,
             "contests": contests,
@@ -385,6 +425,9 @@ impl<'a> Builder<'a> {
             admin_users,
             role_permissions,
             templates,
+            realm_patch: self.realm_patch,
+            admin_realm_patch,
+            auth_preset: self.auth_preset.map(|preset| preset.name),
             warnings: self.report,
         })
     }
@@ -482,23 +525,36 @@ impl<'a> Builder<'a> {
     /// something to them, and silently ignoring it is how a setting goes missing
     /// on election day.
     fn uninterpreted_parameters(&self) -> Vec<(String, Value)> {
-        self.parameters
+        // A key a preset takes is not uninterpreted, whether or not a preset was
+        // selected: reporting it as ignored while a preset would have acted on it
+        // contradicts itself.
+        let consumed = presets::all_preset_parameters();
+
+        let mut carried: Vec<(String, Value)> = self
+            .parameters
             .iter()
             .filter(|(_, key, _)| {
                 !HANDLED_PARAMETERS.contains(&key.as_str())
+                    && !consumed.contains(&key.as_str())
                     && !PARAMETER_PREFIXES
                         .iter()
                         .any(|prefix| key.starts_with(prefix))
             })
             .map(|(kind, key, value)| {
-                let name = if kind.is_empty() {
-                    key.clone()
-                } else {
-                    format!("{kind}.{key}")
-                };
-                (name, value.clone())
+                let kind = if kind.is_empty() { "event" } else { kind };
+                // The prefix is what the SEIU1000 bundle already carries; keeping
+                // it means a regenerated event does not move its annotations.
+                (
+                    format!("janitor.param.{kind}.{key}"),
+                    match value {
+                        Value::String(_) => value.clone(),
+                        other => Value::String(other.to_string()),
+                    },
+                )
             })
-            .collect()
+            .collect();
+        carried.sort_by(|left, right| left.0.cmp(&right.0));
+        carried
     }
 
     fn resolve_tenant_id(&self, explicit: Option<&str>) -> String {
@@ -622,12 +678,18 @@ impl<'a> Builder<'a> {
 
         let event_id = self.event_id.clone();
         let tenant_id = self.tenant_id.clone();
+        let base = self.base("election_event", SCRUB_EVENT);
         let mut event = self.under_base(
             event,
             "election_event",
             SCRUB_EVENT,
             &[("id", &event_id), ("tenant_id", &tenant_id)],
         );
+        if let Some(base) = base {
+            // Say out loud what the base contributed to the voter's screen.
+            let merged = event.clone();
+            self.warn_inherited_branding(&base, &merged);
+        }
 
         event.insert("external_id".to_string(), json!(self.event_external_id));
 

--- a/packages/sequent-core/src/election_config/build_realm.rs
+++ b/packages/sequent-core/src/election_config/build_realm.rs
@@ -1,0 +1,911 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The Keycloak realm: what a source document may ask of it, and how.
+//!
+//! A realm is ~165 kB of interdependent Keycloak configuration — authentication
+//! flows, clients, a user profile carried as a stringified JSON blob — none of
+//! which can be authored from a spreadsheet, and whose client URLs belong to the
+//! environment it came from. So a realm someone exported from a working event is
+//! patched, or none is emitted and the platform loads its own provisioned default.
+//!
+//! Emitting an invented realm would be worse than emitting none: the importer
+//! takes `keycloak_event_realm` **wholesale**, so a present realm *replaces* the
+//! environment's default rather than merging into it. When there is no base export
+//! the patch is kept as its own artifact instead, so nothing the document asked
+//! for is lost.
+
+use super::{value_as_text, Builder};
+use crate::election_config::branding;
+use crate::election_config::paths::{deep_merge, set_path, split_path};
+use crate::election_config::presets::{
+    self, AuthPreset, PresetInput, RealmPatch, PARAM_AUTH_TYPE,
+};
+use crate::election_config::problem::Code;
+use crate::election_config::sheet::{
+    Origin, SHEET_ADMIN_USERS, SHEET_ELECTIONS, SHEET_REPORTS,
+};
+use serde_json::{Map, Value};
+
+/// The parameter carrying the login page's stylesheet.
+pub const PARAM_LOGIN_CUSTOM_CSS: &str = "login_custom_css";
+
+impl Builder<'_> {
+    /// The preset named by the caller, else by the document's `auth_type`.
+    ///
+    /// `None` leaves the realm entirely alone — no preset, no patch, and
+    /// `keycloak_event_realm` stays whatever a base export gave, or null.
+    pub(super) fn resolve_auth_preset(
+        &mut self,
+        explicit: Option<&str>,
+    ) -> Option<&'static AuthPreset> {
+        if explicit
+            .map(|name| name.trim().eq_ignore_ascii_case(presets::NONE))
+            .unwrap_or(false)
+        {
+            // Explicitly ignore whatever the document declares.
+            return None;
+        }
+
+        let declared = self.parameter(PARAM_AUTH_TYPE).map(value_as_text);
+        let name = match explicit {
+            Some(explicit) if !explicit.trim().is_empty() => {
+                explicit.trim().to_string()
+            }
+            _ => match declared {
+                Some(declared) if !declared.trim().is_empty() => declared,
+                _ => return None,
+            },
+        };
+
+        let Some(preset) = presets::get(&name) else {
+            // Whichever said it wrong is where the author has to look.
+            let origin = if explicit.is_some() {
+                Origin {
+                    sheet: "auth preset option".to_string(),
+                    row: 0,
+                    column: None,
+                }
+            } else {
+                Origin {
+                    sheet: "Parameters".to_string(),
+                    row: 0,
+                    column: Some("value".to_string()),
+                }
+            };
+            let message = format!(
+                "'{name}' is not an authentication preset; expected one of {}",
+                presets::names().join(", ")
+            );
+            self.problem(origin, Code::InvalidValue, message);
+            return None;
+        };
+
+        let missing: Vec<&str> = preset
+            .required_parameters
+            .iter()
+            .filter(|key| {
+                self.parameter(key)
+                    .map(value_as_text)
+                    .filter(|value| !value.trim().is_empty())
+                    .is_none()
+            })
+            .copied()
+            .collect();
+
+        if !missing.is_empty() {
+            let wanted: Vec<String> = missing
+                .iter()
+                .map(|key| format!("a '{key}' parameter"))
+                .collect();
+            let message = format!(
+                "the '{}' preset needs {}. Add it to the Parameters sheet, or \
+                 select the 'none' preset to build without configuring \
+                 authentication.",
+                preset.name,
+                wanted.join(", ")
+            );
+            self.problem(
+                Origin {
+                    sheet: "Parameters".to_string(),
+                    row: 0,
+                    column: None,
+                },
+                Code::MissingField,
+                message,
+            );
+            return None;
+        }
+        Some(preset)
+    }
+
+    /// Everything the document asks of the realm, as one patch.
+    ///
+    /// Kept as its own artifact whether or not a base export was given, so a
+    /// `keycloak_event_realm.*` parameter or an `auth_type` is never silently
+    /// dropped just because there was no realm to apply it to.
+    pub(super) fn build_realm_patch(&mut self) -> RealmPatch {
+        let mut result = RealmPatch::default();
+
+        if let Some(preset) = self.auth_preset {
+            let values: Vec<(String, Value)> = preset
+                .consumes()
+                .iter()
+                .filter_map(|key| {
+                    self.parameter(key)
+                        .map(|value| ((*key).to_string(), value.clone()))
+                })
+                .collect();
+            result = preset.build(&PresetInput::new(values));
+        }
+
+        result.patch =
+            merge_maps(result.patch, self.event_derived_realm_patch());
+
+        // Explicit parameters last, so they can override anything derived.
+        let mut problems = Vec::new();
+        for (path, value) in self.parameter_patches("keycloak_event_realm.") {
+            if let Err(problem) =
+                set_path(&mut result.patch, &split_path(&path), value)
+            {
+                problems.push(problem);
+            }
+        }
+        for problem in problems {
+            self.report.push(problem);
+        }
+
+        result
+    }
+
+    /// Realm settings the event already states, which nothing else carries over.
+    ///
+    /// The platform syncs the default locale only under a force-default detection
+    /// policy, never syncs `supportedLocales`, and has no path at all from an event
+    /// name to a realm display name. Stating them twice in a document would be a
+    /// way to get them out of step, so they are derived from what the event says.
+    fn event_derived_realm_patch(&mut self) -> Map<String, Value> {
+        let presentation = self
+            .event_row
+            .overrides(&[])
+            .ok()
+            .and_then(|overrides| overrides.get("presentation").cloned())
+            .unwrap_or(Value::Null);
+
+        let language_conf = presentation.get("language_conf");
+        let default_language = language_conf
+            .and_then(|conf| conf.get("default_language_code"))
+            .and_then(Value::as_str);
+
+        let mut patch = branding::language_patch(language_conf);
+        for (key, value) in
+            branding::title_patch(presentation.get("i18n"), default_language)
+        {
+            patch.insert(key, value);
+        }
+
+        if let Some(css) = self
+            .parameter(PARAM_LOGIN_CUSTOM_CSS)
+            .map(value_as_text)
+            .filter(|css| !css.trim().is_empty())
+        {
+            let locales = branding::locales_of(language_conf, "en");
+            patch =
+                merge_maps(patch, branding::login_css_patch(&css, &locales));
+        }
+        patch
+    }
+
+    /// `keycloak_admin_realm.*` parameters, as a nested object.
+    ///
+    /// Its own artifact: the admin realm is tenant-scoped, so it is not part of an
+    /// election event import.
+    pub(super) fn admin_realm_patch(&mut self) -> Map<String, Value> {
+        let patches = self.parameter_patches("keycloak_admin_realm.");
+        if patches.is_empty() {
+            return Map::new();
+        }
+        match crate::election_config::paths::expand(&patches) {
+            Ok(expanded) => expanded,
+            Err(problem) => {
+                self.report.push(problem);
+                Map::new()
+            }
+        }
+    }
+
+    /// Patch the base export's realm, or emit none.
+    pub(super) fn build_realm(&mut self) -> Value {
+        let Some(Value::Object(realm)) =
+            self.base_export.get("keycloak_event_realm").cloned()
+        else {
+            if !self.realm_patch.patch.is_empty() {
+                let mut keys: Vec<&str> =
+                    self.realm_patch.patch.keys().map(String::as_str).collect();
+                keys.sort_unstable();
+                let message = format!(
+                    "no base export, so nothing here configures the login page: \
+                     {} are kept as a realm patch instead of being applied. Until \
+                     that patch reaches the realm, voters see the platform's \
+                     default login page.",
+                    keys.join(", ")
+                );
+                self.warn("keycloak_event_realm", message);
+            }
+            return Value::Null;
+        };
+
+        let mut realm = realm;
+
+        // The realm name is structural: the voting portal and the smart-link URLs
+        // derive it from tenant + event, so it is not a free choice.
+        realm.insert(
+            "realm".to_string(),
+            Value::String(format!(
+                "tenant-{}-event-{}",
+                self.tenant_id, self.event_id
+            )),
+        );
+        realm.insert("id".to_string(), Value::String(self.event_id.clone()));
+
+        let realm = self.apply_realm_patch(realm);
+
+        // Hosts in rootUrl/redirectUris belong to the environment and stay, but a
+        // base export also embeds its OWN event id in those URLs. Import remaps
+        // every UUID it finds, so a stale id would be remapped to something
+        // unrelated; swapping it first makes the remap land right.
+        let base_event_id = self
+            .base_export
+            .get("election_event")
+            .and_then(|event| event.get("id"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
+        match base_event_id {
+            Some(base_event_id) if base_event_id != self.event_id => {
+                let encoded = Value::Object(realm).to_string();
+                let swapped = encoded.replace(&base_event_id, &self.event_id);
+                serde_json::from_str(&swapped)
+                    .unwrap_or_else(|_| Value::String(swapped))
+            }
+            _ => Value::Object(realm),
+        }
+    }
+
+    /// Apply the patch to a real realm, checking what the preset assumes.
+    ///
+    /// Alias-keyed collections are merged by alias rather than replaced: a realm's
+    /// `identityProviders` and `authenticatorConfig` are referenced by alias from
+    /// elsewhere, so replacing either wholesale would strip providers the
+    /// environment configured on purpose.
+    fn apply_realm_patch(
+        &mut self,
+        realm: Map<String, Value>,
+    ) -> Map<String, Value> {
+        let mut realm = realm;
+        let mut patch = self.realm_patch.patch.clone();
+
+        if self.auth_preset.is_some() {
+            self.check_realm_requirements(&realm);
+        }
+
+        for key in ["identityProviders", "authenticatorConfig"] {
+            if let Some(Value::Array(additions)) = patch.remove(key) {
+                if additions.is_empty() {
+                    continue;
+                }
+                let existing = match realm.get(key) {
+                    Some(Value::Array(existing)) => existing.clone(),
+                    _ => Vec::new(),
+                };
+                realm.insert(
+                    key.to_string(),
+                    Value::Array(merge_by_alias(existing, additions)),
+                );
+            }
+        }
+
+        let mut realm = merge_maps(realm, patch);
+
+        if let Some((authenticator, config_alias)) =
+            self.realm_patch.bind_authenticator_config.clone()
+        {
+            bind_authenticator_config(
+                &mut realm,
+                &authenticator,
+                &config_alias,
+            );
+        }
+        if let Some(profile) = self.realm_patch.user_profile.clone() {
+            self.patch_user_profile(&mut realm, &profile);
+        }
+        realm
+    }
+
+    /// Report anything the preset needs that the target realm lacks.
+    fn check_realm_requirements(&mut self, realm: &Map<String, Value>) {
+        let Some(preset) = self.auth_preset else {
+            return;
+        };
+
+        let flows = aliases_of(realm.get("authenticationFlows"), "alias");
+        let configs = aliases_of(realm.get("authenticatorConfig"), "alias");
+
+        let authenticators: Vec<String> = realm
+            .get("authenticationFlows")
+            .and_then(Value::as_array)
+            .map(|flows| {
+                flows
+                    .iter()
+                    .filter_map(|flow| {
+                        flow.get("authenticationExecutions")?.as_array()
+                    })
+                    .flatten()
+                    .filter_map(|execution| {
+                        execution.get("authenticator")?.as_str()
+                    })
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut warnings = Vec::new();
+        for requirement in preset.requires {
+            let present = match requirement.kind {
+                "flow" => &flows,
+                "authenticator_config" => &configs,
+                _ => &authenticators,
+            };
+            if !present.iter().any(|name| name == requirement.name) {
+                warnings.push(format!(
+                    "the base export's realm has no {} '{}', which the '{}' \
+                     preset needs: {}. The patch is still written out on its own.",
+                    requirement.kind,
+                    requirement.name,
+                    preset.name,
+                    requirement.why
+                ));
+            }
+        }
+        for warning in warnings {
+            self.warn("keycloak_event_realm", warning);
+        }
+    }
+
+    /// Patch the user profile, which travels as a stringified JSON blob.
+    ///
+    /// It lives inside a Keycloak component's config as a single JSON string, so it
+    /// has to be parsed, patched and re-serialised rather than merged.
+    fn patch_user_profile(
+        &mut self,
+        realm: &mut Map<String, Value>,
+        profile_patch: &Map<String, Value>,
+    ) {
+        let preset_name =
+            self.auth_preset.map_or("selected", |preset| preset.name);
+
+        let component = realm
+            .get_mut("components")
+            .and_then(|components| {
+                components
+                    .get_mut("org.keycloak.userprofile.UserProfileProvider")
+            })
+            .and_then(Value::as_array_mut)
+            .and_then(|components| components.first_mut());
+
+        let Some(component) = component else {
+            let message = format!(
+                "the base export's realm has no user profile component, so the \
+                 '{preset_name}' preset could not set which login fields are \
+                 typeable"
+            );
+            self.warn("keycloak_event_realm", message);
+            return;
+        };
+
+        // The config value is a one-element list of JSON text.
+        let raw = component
+            .get("config")
+            .and_then(|config| config.get("kc.user.profile.config"))
+            .map(|value| match value {
+                Value::Array(items) => items
+                    .first()
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                Value::String(text) => text.clone(),
+                _ => String::new(),
+            })
+            .unwrap_or_default();
+
+        if raw.is_empty() {
+            self.warn(
+                "keycloak_event_realm",
+                "the base export's realm user profile component is empty",
+            );
+            return;
+        }
+
+        let mut profile: Value = match serde_json::from_str(&raw) {
+            Ok(profile) => profile,
+            Err(error) => {
+                let message = format!(
+                    "the realm's user profile is not readable JSON: {error}"
+                );
+                self.problem(
+                    Origin {
+                        sheet: "base export".to_string(),
+                        row: 0,
+                        column: None,
+                    },
+                    Code::InvalidValue,
+                    message,
+                );
+                return;
+            }
+        };
+
+        let mut missing = Vec::new();
+        {
+            let attributes =
+                profile.get_mut("attributes").and_then(Value::as_array_mut);
+            let Some(attributes) = attributes else {
+                self.warn(
+                    "keycloak_event_realm",
+                    "the base export's realm user profile lists no attributes",
+                );
+                return;
+            };
+
+            for (name, changes) in profile_patch {
+                let attribute = attributes.iter_mut().find(|attribute| {
+                    attribute.get("name").and_then(Value::as_str) == Some(name)
+                });
+                match attribute {
+                    Some(attribute) => {
+                        if let (Some(target), Some(changes)) =
+                            (attribute.as_object_mut(), changes.as_object())
+                        {
+                            for (key, value) in changes {
+                                target.insert(key.clone(), value.clone());
+                            }
+                        }
+                    }
+                    None => missing.push(name.clone()),
+                }
+            }
+        }
+
+        for name in missing {
+            let message = format!(
+                "the realm's user profile has no '{name}' attribute, so the \
+                 '{preset_name}' preset could not configure it"
+            );
+            self.warn("keycloak_event_realm", message);
+        }
+
+        let encoded = profile.to_string();
+        let config = component
+            .as_object_mut()
+            .expect("a realm component is an object")
+            .entry("config")
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Some(config) = config.as_object_mut() {
+            config.insert(
+                "kc.user.profile.config".to_string(),
+                Value::Array(vec![Value::String(encoded)]),
+            );
+        }
+    }
+
+    /// Check every permission label against the administrators who hold one.
+    ///
+    /// A permission label scopes an entity to administrators carrying that label.
+    /// Hasura filters `election` and `report` on `permission_label IS NULL OR
+    /// permission_label IN X-Hasura-Permission-Labels`, where the claim comes from
+    /// the `permission_labels` attribute on the Keycloak administrator.
+    ///
+    /// The failure this guards against is quiet and expensive: an election whose
+    /// label nobody holds imports cleanly, reports no error, and then does not
+    /// appear in the Elections list at all. It happened on the first real import,
+    /// where a document labelled an election `dlc-officers-dburs` while its own
+    /// administrators carried `dlc-officers`. Nothing anywhere said so.
+    ///
+    /// Warnings rather than errors, because the document is not the whole picture:
+    /// administrators may already exist in the target tenant carrying labels this
+    /// file knows nothing about.
+    pub(super) fn warn_permission_labels(&mut self) {
+        // Insertion-ordered so the message does not depend on a hash.
+        let mut used: Vec<(String, Vec<String>)> = Vec::new();
+        let note = |used: &mut Vec<(String, Vec<String>)>,
+                        label: String,
+                        entity: String| {
+            match used.iter_mut().find(|(seen, _)| seen == &label) {
+                Some((_, entities)) => entities.push(entity),
+                None => used.push((label, vec![entity])),
+            }
+        };
+
+        for row in self.workbook.rows(SHEET_ELECTIONS) {
+            if let Some(label) = row.get("permission_label").map(value_as_text)
+            {
+                let label = label.trim().to_string();
+                if label.is_empty() {
+                    continue;
+                }
+                let entity = format!(
+                    "election '{}'",
+                    row.text("external_id")
+                        .map(str::to_string)
+                        .unwrap_or_else(|| row.number.to_string())
+                );
+                note(&mut used, label, entity);
+            }
+        }
+
+        for row in self.workbook.rows(SHEET_REPORTS) {
+            for label in labels_of(row.get("permission_label")) {
+                note(&mut used, label, format!("report on row {}", row.number));
+            }
+        }
+
+        if used.is_empty() {
+            return;
+        }
+
+        let mut granted: Vec<String> = Vec::new();
+        for row in self.workbook.rows(SHEET_ADMIN_USERS) {
+            for label in labels_of(row.get("permission_labels")) {
+                if !granted.contains(&label) {
+                    granted.push(label);
+                }
+            }
+        }
+
+        let mut unmatched: Vec<&(String, Vec<String>)> = used
+            .iter()
+            .filter(|(label, _)| !granted.contains(label))
+            .collect();
+        unmatched.sort_by(|left, right| left.0.cmp(&right.0));
+
+        let mut warnings = Vec::new();
+        for (label, entities) in unmatched {
+            let listed: Vec<&str> =
+                entities.iter().take(4).map(String::as_str).collect();
+            let more = if entities.len() > 4 {
+                format!(" and {} more", entities.len() - 4)
+            } else {
+                String::new()
+            };
+            let nobody = if granted.is_empty() {
+                ", and this document grants no permission labels to anyone"
+            } else {
+                ", but no administrator in the Admin Users sheet carries it"
+            };
+            warnings.push(format!(
+                "permission label '{label}' is used by {}{more}{nobody}. \
+                 Anything carrying a label is hidden from every administrator \
+                 without it — the event imports cleanly and then lists nothing.",
+                listed.join(", ")
+            ));
+        }
+
+        let mut all: Vec<&str> =
+            used.iter().map(|(label, _)| label.as_str()).collect();
+        all.sort_unstable();
+        warnings.push(format!(
+            "permission labels in use: {}. Whoever imports this event needs one \
+             of them on their own 'permission_labels' attribute, or the Admin \
+             Portal will show them an empty list.",
+            all.join(", ")
+        ));
+
+        for warning in warnings {
+            self.warn("permission_label", warning);
+        }
+    }
+
+    /// Say out loud what a base export contributed to the voter's screen.
+    ///
+    /// Entity fields the template does not set are inherited from the base, and
+    /// `presentation.i18n` merges key by key. That is useful when the base is a
+    /// reference event and wrong when it is another client's: their login title and
+    /// instruction copy would come along silently. A base export should be a
+    /// generic reference event, and if it is not, this is where you find out.
+    pub(super) fn warn_inherited_branding(
+        &mut self,
+        base: &Map<String, Value>,
+        event: &Map<String, Value>,
+    ) {
+        let base_presentation = base.get("presentation");
+        let event_presentation = event.get("presentation");
+
+        let mut inherited: Vec<&String> = Vec::new();
+        if let Some(Value::Object(base_presentation)) = base_presentation {
+            for (key, value) in base_presentation {
+                if ["i18n", "css", "logo_url"].contains(&key.as_str()) {
+                    continue;
+                }
+                if value.is_null()
+                    || value == &Value::String(String::new())
+                    || value == &Value::Object(Map::new())
+                    || value == &Value::Array(Vec::new())
+                {
+                    continue;
+                }
+                if event_presentation.and_then(|event| event.get(key))
+                    == Some(value)
+                {
+                    inherited.push(key);
+                }
+            }
+        }
+        inherited.sort();
+
+        let base_copy: Vec<&String> = base_presentation
+            .and_then(|presentation| presentation.get("i18n"))
+            .and_then(|i18n| i18n.get("en"))
+            .and_then(Value::as_object)
+            .map(|english| english.keys().collect())
+            .unwrap_or_default();
+
+        let own_copy: Vec<String> = self
+            .event_row
+            .overrides(&[])
+            .ok()
+            .and_then(|overrides| {
+                overrides
+                    .get("presentation")?
+                    .get("i18n")?
+                    .get("en")?
+                    .as_object()
+                    .map(|english| english.keys().cloned().collect())
+            })
+            .unwrap_or_default();
+
+        let mut inherited_copy: Vec<&String> = base_copy
+            .into_iter()
+            .filter(|key| !own_copy.contains(key))
+            .collect();
+        inherited_copy.sort();
+
+        let mut warnings = Vec::new();
+        if !inherited_copy.is_empty() {
+            let listed: Vec<String> = inherited_copy
+                .iter()
+                .take(6)
+                .map(|key| format!("presentation.i18n.en.{key}"))
+                .collect();
+            let more = if inherited_copy.len() > 6 {
+                format!(" and {} more", inherited_copy.len() - 6)
+            } else {
+                String::new()
+            };
+            warnings.push(format!(
+                "the base export's voter-facing copy is inherited: {}{more}. Use \
+                 a reference event as the base, not another client's, or set these \
+                 in the ElectionEvent sheet.",
+                listed.join(", ")
+            ));
+        }
+        if !inherited.is_empty() {
+            let listed: Vec<&str> =
+                inherited.iter().take(8).map(|key| key.as_str()).collect();
+            let more = if inherited.len() > 8 {
+                format!(" and {} more", inherited.len() - 8)
+            } else {
+                String::new()
+            };
+            warnings.push(format!(
+                "presentation settings inherited from the base export: {}{more}",
+                listed.join(", ")
+            ));
+        }
+
+        for warning in warnings {
+            self.warn("election_event.presentation", warning);
+        }
+    }
+}
+
+/// Merge alias-keyed realm collections, replacing by alias and appending the rest.
+fn merge_by_alias(existing: Vec<Value>, additions: Vec<Value>) -> Vec<Value> {
+    let mut merged = existing;
+    for addition in additions {
+        let alias = addition
+            .get("alias")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let at = alias.as_ref().and_then(|alias| {
+            merged.iter().position(|item| {
+                item.get("alias").and_then(Value::as_str) == Some(alias)
+            })
+        });
+        match at {
+            Some(index) => {
+                let existing = merged[index].clone();
+                merged[index] = deep_merge(existing, addition);
+            }
+            None => merged.push(addition),
+        }
+    }
+    merged
+}
+
+/// Point every execution of an authenticator at a config alias.
+fn bind_authenticator_config(
+    realm: &mut Map<String, Value>,
+    authenticator: &str,
+    config_alias: &str,
+) {
+    let Some(flows) = realm
+        .get_mut("authenticationFlows")
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+
+    for flow in flows {
+        let Some(executions) = flow
+            .get_mut("authenticationExecutions")
+            .and_then(Value::as_array_mut)
+        else {
+            continue;
+        };
+        for execution in executions {
+            if execution.get("authenticator").and_then(Value::as_str)
+                == Some(authenticator)
+            {
+                if let Some(execution) = execution.as_object_mut() {
+                    execution.insert(
+                        "authenticatorConfig".to_string(),
+                        Value::String(config_alias.to_string()),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The values of `key` across a list of objects.
+fn aliases_of(value: Option<&Value>, key: &str) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get(key)?.as_str())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A cell that may hold one label or a list of them.
+fn labels_of(value: Option<&Value>) -> Vec<String> {
+    match value {
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(value_as_text)
+            .map(|label| label.trim().to_string())
+            .filter(|label| !label.is_empty())
+            .collect(),
+        Some(Value::Null) | None => Vec::new(),
+        Some(other) => {
+            let label = value_as_text(other).trim().to_string();
+            if label.is_empty() {
+                Vec::new()
+            } else {
+                vec![label]
+            }
+        }
+    }
+}
+
+/// Deep-merge one object over another.
+fn merge_maps(
+    base: Map<String, Value>,
+    over: Map<String, Value>,
+) -> Map<String, Value> {
+    match deep_merge(Value::Object(base), Value::Object(over)) {
+        Value::Object(merged) => merged,
+        _ => unreachable!("merging two objects yields an object"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn a_provider_with_the_same_alias_is_merged_not_appended() {
+        // identityProviders is referenced by alias from elsewhere in the realm, so
+        // two entries under one alias is a realm nothing can resolve.
+        let merged = merge_by_alias(
+            vec![json!({"alias": "a", "enabled": false, "keep": 1})],
+            vec![json!({"alias": "a", "enabled": true})],
+        );
+        assert_eq!(merged.len(), 1);
+        assert_eq!(
+            merged[0],
+            json!({"alias": "a", "enabled": true, "keep": 1})
+        );
+    }
+
+    #[test]
+    fn a_provider_the_realm_does_not_have_is_appended() {
+        // Replacing the list wholesale would strip providers the environment
+        // configured on purpose.
+        let merged = merge_by_alias(
+            vec![json!({"alias": "environment-idp"})],
+            vec![json!({"alias": "client-saml-idp"})],
+        );
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0]["alias"], json!("environment-idp"));
+        assert_eq!(merged[1]["alias"], json!("client-saml-idp"));
+    }
+
+    #[test]
+    fn an_addition_with_no_alias_is_appended_rather_than_dropped() {
+        let merged =
+            merge_by_alias(vec![json!({"alias": "a"})], vec![json!({"x": 1})]);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn every_execution_of_the_authenticator_gets_the_config() {
+        // A realm may run the same authenticator in more than one flow, and a step
+        // left unbound is a step with no configuration.
+        let mut realm = match json!({
+            "authenticationFlows": [
+                {"authenticationExecutions": [
+                    {"authenticator": "message-otp-authenticator"},
+                    {"authenticator": "something-else"},
+                ]},
+                {"authenticationExecutions": [
+                    {"authenticator": "message-otp-authenticator"},
+                ]},
+            ]
+        }) {
+            Value::Object(realm) => realm,
+            _ => unreachable!(),
+        };
+
+        bind_authenticator_config(
+            &mut realm,
+            "message-otp-authenticator",
+            "janitor-otp-by-availability",
+        );
+
+        let flows = realm["authenticationFlows"].as_array().unwrap();
+        assert_eq!(
+            flows[0]["authenticationExecutions"][0]["authenticatorConfig"],
+            json!("janitor-otp-by-availability")
+        );
+        assert!(flows[0]["authenticationExecutions"][1]
+            .get("authenticatorConfig")
+            .is_none());
+        assert_eq!(
+            flows[1]["authenticationExecutions"][0]["authenticatorConfig"],
+            json!("janitor-otp-by-availability")
+        );
+    }
+
+    #[test]
+    fn binding_a_realm_with_no_flows_does_nothing_rather_than_panicking() {
+        let mut realm = Map::new();
+        bind_authenticator_config(&mut realm, "a", "b");
+        assert!(realm.is_empty());
+    }
+
+    #[test]
+    fn a_label_cell_reads_as_one_label_or_a_list() {
+        assert_eq!(labels_of(Some(&json!("one"))), ["one"]);
+        assert_eq!(labels_of(Some(&json!(["a", "b"]))), ["a", "b"]);
+        assert_eq!(labels_of(Some(&json!(["a", "  ", "b"]))), ["a", "b"]);
+        assert!(labels_of(Some(&json!(" "))).is_empty());
+        assert!(labels_of(None).is_empty());
+    }
+}

--- a/packages/sequent-core/src/election_config/build_tables.rs
+++ b/packages/sequent-core/src/election_config/build_tables.rs
@@ -373,6 +373,13 @@ impl Builder<'_> {
             return;
         }
 
+        // Under an identity provider that authenticates the voter itself there is
+        // no code to send, so the whole question is noise. With no preset named,
+        // checking is the safer default.
+        if self.auth_preset.is_some_and(|preset| !preset.uses_otp) {
+            return;
+        }
+
         // There is always at least one contact column: `email` is derived, so it
         // is present whether or not the source has it. The Python this was ported
         // from also carried a "no contact column at all" warning, which for the

--- a/packages/sequent-core/src/election_config/build_tests.rs
+++ b/packages/sequent-core/src/election_config/build_tests.rs
@@ -617,8 +617,11 @@ fn a_parameter_nothing_interprets_is_recorded_and_said_out_loud() {
             vec![text("client"), text("helpdesk_phone"), text("555-0100")],
         ],
     ));
+    // Namespaced the way the SEIU1000 bundle already carries them, so a
+    // regenerated event does not move its annotations.
     assert_eq!(
-        bundle.export["election_event"]["annotations"]["client.helpdesk_phone"],
+        bundle.export["election_event"]["annotations"]
+            ["janitor.param.client.helpdesk_phone"],
         json!("555-0100")
     );
     assert!(bundle
@@ -642,9 +645,8 @@ fn a_parameter_with_no_value_is_ignored_with_a_warning() {
         .contains("has no value and is ignored")));
     assert!(bundle.export["election_event"]
         .get("annotations")
-        .and_then(
-            |annotations| annotations.get("settings.saml_idp_metadata_url")
-        )
+        .and_then(|annotations| annotations
+            .get("janitor.param.settings.saml_idp_metadata_url"))
         .is_none());
 }
 
@@ -1642,4 +1644,713 @@ fn the_csv_members_render_through_the_shared_writers() {
         .collect();
     let schedule = json_csv(&schedule_columns, &bundle.scheduled_events.rows);
     assert!(schedule.starts_with("id,tenant_id,election_event_id"));
+}
+
+// -- the realm ------------------------------------------------------------
+
+/// A realm with the pieces the presets expect, small enough to read.
+fn base_realm() -> Value {
+    json!({
+        "realm": "some-other-realm",
+        "id": "99999999-9999-4999-8999-999999999999",
+        "identityProviders": [{"alias": "environment-idp", "enabled": true}],
+        "authenticationFlows": [{
+            "alias": "browser",
+            "authenticationExecutions": [
+                {"authenticator": "message-otp-authenticator"},
+            ],
+        }, {
+            "alias": "saml-first-broker-flow",
+            "authenticationExecutions": [],
+        }],
+        "authenticatorConfig": [{"alias": "deferred", "config": {}}],
+        "components": {
+            "org.keycloak.userprofile.UserProfileProvider": [{
+                "config": {"kc.user.profile.config": [
+                    r#"{"attributes":[{"name":"username"},{"name":"dateOfBirth"}]}"#
+                ]},
+            }],
+        },
+        "clients": [{
+            "clientId": "voting-portal",
+            "rootUrl": "https://vote.example.org/99999999-9999-4999-8999-999999999999",
+        }],
+    })
+}
+
+fn with_options(workbook: &Workbook, options: BuildOptions) -> Bundle {
+    let templates = TemplateSet::builtin().unwrap();
+    match build(workbook, &templates, &options) {
+        Ok(bundle) => bundle,
+        Err(report) => panic!("expected a clean build, got:\n{report}"),
+    }
+}
+
+#[test]
+fn no_base_export_means_no_realm_at_all() {
+    // The importer takes keycloak_event_realm wholesale, so a realm invented here
+    // would replace the environment's provisioned default rather than merge into
+    // it. Emitting none is the safe answer.
+    let bundle = built(&sound());
+    assert_eq!(bundle.export["keycloak_event_realm"], Value::Null);
+}
+
+#[test]
+fn what_the_document_asked_of_the_realm_is_kept_even_with_no_realm_to_apply_it_to(
+) {
+    // Otherwise an auth_type or a login stylesheet is silently lost.
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("otp_email_or_sms"),
+            ],
+        ],
+    ));
+    assert_eq!(bundle.auth_preset, Some("otp_email_or_sms"));
+    assert!(!bundle.realm_patch.patch.is_empty());
+    assert!(bundle.realm_patch.bind_authenticator_config.is_some());
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains(
+            "no base export, so nothing here configures the login page"
+        )));
+}
+
+#[test]
+fn the_realms_name_is_derived_from_the_tenant_and_the_event() {
+    // Structural: the voting portal and the smart-link URLs derive it the same
+    // way, so it is not a free choice.
+    let bundle = with_options(
+        &sound(),
+        BuildOptions {
+            base_export: Some(json!({"keycloak_event_realm": base_realm()})),
+            ..BuildOptions::default()
+        },
+    );
+    let realm = &bundle.export["keycloak_event_realm"];
+    assert_eq!(
+        realm["realm"],
+        json!(format!(
+            "tenant-{}-event-{}",
+            bundle.tenant_id, bundle.event_id
+        ))
+    );
+    assert_eq!(realm["id"], json!(bundle.event_id));
+}
+
+#[test]
+fn a_stale_event_id_in_the_realms_urls_is_swapped_for_this_events() {
+    // Hosts belong to the environment and stay, but the base export embeds its own
+    // event id in those URLs, and import remaps every UUID it finds — so a stale
+    // one would be remapped to something unrelated.
+    let bundle = with_options(
+        &sound(),
+        BuildOptions {
+            base_export: Some(json!({
+                "keycloak_event_realm": base_realm(),
+                "election_event": {"id": "99999999-9999-4999-8999-999999999999"},
+            })),
+            ..BuildOptions::default()
+        },
+    );
+    let root = bundle.export["keycloak_event_realm"]["clients"][0]["rootUrl"]
+        .as_str()
+        .unwrap();
+    assert!(root.starts_with("https://vote.example.org/"), "{root}");
+    assert!(root.ends_with(&bundle.event_id), "{root}");
+    assert!(!root.contains("99999999-9999-4999-8999-999999999999"));
+}
+
+#[test]
+fn a_preset_adds_its_provider_without_removing_the_environments() {
+    // identityProviders is referenced by alias from elsewhere in the realm;
+    // replacing the list would strip what the environment configured on purpose.
+    let workbook = with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("saml_sso_idp_initiated"),
+            ],
+            vec![
+                text("settings"),
+                text("saml_idp_metadata_url"),
+                text("https://idp.example.org/metadata"),
+            ],
+        ],
+    );
+    let bundle = with_options(
+        &workbook,
+        BuildOptions {
+            base_export: Some(json!({"keycloak_event_realm": base_realm()})),
+            ..BuildOptions::default()
+        },
+    );
+
+    let providers = bundle.export["keycloak_event_realm"]["identityProviders"]
+        .as_array()
+        .unwrap();
+    let aliases: Vec<&str> = providers
+        .iter()
+        .map(|provider| provider["alias"].as_str().unwrap())
+        .collect();
+    assert_eq!(aliases, ["environment-idp", "client-saml-idp"]);
+}
+
+#[test]
+fn the_otp_preset_binds_its_config_to_the_authenticator_in_the_realm() {
+    // Registering the config without binding it leaves the step unconfigured, and
+    // nothing about the realm would say so.
+    let workbook = with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("otp_email_or_sms"),
+            ],
+        ],
+    );
+    let bundle = with_options(
+        &workbook,
+        BuildOptions {
+            base_export: Some(json!({"keycloak_event_realm": base_realm()})),
+            ..BuildOptions::default()
+        },
+    );
+
+    let realm = &bundle.export["keycloak_event_realm"];
+    assert_eq!(
+        realm["authenticationFlows"][0]["authenticationExecutions"][0]
+            ["authenticatorConfig"],
+        json!("janitor-otp-by-availability")
+    );
+    // And the config it points at is present alongside the realm's own.
+    let aliases: Vec<&str> = realm["authenticatorConfig"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|config| config["alias"].as_str().unwrap())
+        .collect();
+    assert!(aliases.contains(&"deferred"));
+    assert!(aliases.contains(&"janitor-otp-by-availability"));
+}
+
+#[test]
+fn the_link_preset_patches_the_user_profile_inside_its_stringified_blob() {
+    // It lives inside a Keycloak component as a single JSON string, so it has to
+    // be parsed, patched and re-serialised rather than merged.
+    let workbook = with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("voter_link_plus_dob"),
+            ],
+        ],
+    );
+    let bundle = with_options(
+        &workbook,
+        BuildOptions {
+            base_export: Some(json!({"keycloak_event_realm": base_realm()})),
+            ..BuildOptions::default()
+        },
+    );
+
+    let raw = bundle.export["keycloak_event_realm"]["components"]
+        ["org.keycloak.userprofile.UserProfileProvider"][0]["config"]
+        ["kc.user.profile.config"][0]
+        .as_str()
+        .unwrap();
+    let profile: Value = serde_json::from_str(raw).unwrap();
+    let attributes = profile["attributes"].as_array().unwrap();
+
+    let date_of_birth = attributes
+        .iter()
+        .find(|attribute| attribute["name"] == json!("dateOfBirth"))
+        .unwrap();
+    assert_eq!(
+        date_of_birth["annotations"]["loginHintPrefillPolicy"],
+        json!("IGNORE")
+    );
+    let username = attributes
+        .iter()
+        .find(|attribute| attribute["name"] == json!("username"))
+        .unwrap();
+    assert_eq!(
+        username["annotations"]["loginHintPrefillPolicy"],
+        json!("READ_ONLY")
+    );
+}
+
+#[test]
+fn a_preset_whose_flow_the_realm_lacks_is_warned_about_rather_than_applied_blindly(
+) {
+    let workbook = with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("digital_certificates"),
+            ],
+        ],
+    );
+    let bundle = with_options(
+        &workbook,
+        BuildOptions {
+            base_export: Some(json!({"keycloak_event_realm": base_realm()})),
+            ..BuildOptions::default()
+        },
+    );
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("has no flow 'certificate-first-login-flow'")));
+}
+
+#[test]
+fn a_preset_missing_a_required_parameter_refuses_the_build() {
+    // The SEIU document's own case: it declares SAML and leaves the IdP metadata
+    // URL blank pending the client's identity provider.
+    let report = refused(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("saml_sso_idp_initiated"),
+            ],
+        ],
+    ));
+    assert!(has_error_saying(
+        &report,
+        "needs a 'saml_idp_metadata_url' parameter"
+    ));
+}
+
+#[test]
+fn selecting_the_none_preset_ignores_what_the_document_declares() {
+    // Which is how a document declaring SAML still builds while the client has not
+    // supplied their metadata URL.
+    let workbook = with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("saml_sso_idp_initiated"),
+            ],
+        ],
+    );
+    let bundle = with_options(
+        &workbook,
+        BuildOptions {
+            auth_preset: Some("none".to_string()),
+            ..BuildOptions::default()
+        },
+    );
+    assert_eq!(bundle.auth_preset, None);
+    assert!(bundle.realm_patch.bind_authenticator_config.is_none());
+}
+
+#[test]
+fn a_preset_nobody_wrote_is_refused_with_the_list() {
+    let report = refused(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![text("settings"), text("auth_type"), text("magic_link")],
+        ],
+    ));
+    assert!(has_error_saying(&report, "is not an authentication preset"));
+    assert!(has_error_saying(&report, "otp_email_or_sms"));
+}
+
+#[test]
+fn a_preset_that_authenticates_the_voter_elsewhere_stops_asking_for_contacts() {
+    // Under SAML the client's IdP authenticates the voter, so "no voter can be
+    // sent a code" is noise rather than a finding.
+    let mut sheets: Vec<Sheet> = sound().sheets().to_vec();
+    sheets.push(
+        Sheet::from_grid(
+            "Voters",
+            &[
+                vec![text("username"), text("area.external_id")],
+                vec![text("m-1001"), text("area-north")],
+            ],
+        )
+        .unwrap(),
+    );
+    sheets.push(
+        Sheet::from_grid(
+            "Parameters",
+            &[
+                vec![text("type"), text("key"), text("value")],
+                vec![
+                    text("settings"),
+                    text("auth_type"),
+                    text("saml_sso_idp_initiated"),
+                ],
+                vec![
+                    text("settings"),
+                    text("saml_idp_metadata_url"),
+                    text("https://idp.example.org/metadata"),
+                ],
+            ],
+        )
+        .unwrap(),
+    );
+    let bundle = built(&Workbook::new(sheets).unwrap());
+    assert!(
+        !bundle
+            .warnings
+            .warnings()
+            .any(|problem| problem.message.contains("one-time code")),
+        "{}",
+        bundle.warnings
+    );
+}
+
+#[test]
+fn the_event_languages_become_the_login_pages() {
+    // The platform never syncs supportedLocales, so this is the only thing that
+    // puts a language in Keycloak's picker.
+    let bundle = built(&with_sheet(
+        "ElectionEvent",
+        vec![
+            vec![
+                text("external_id"),
+                text("presentation.i18n.en.name"),
+                text("presentation.language_conf.enabled_language_codes"),
+                text("presentation.language_conf.default_language_code"),
+            ],
+            vec![
+                text("union-2027"),
+                text("Union Election 2027"),
+                text(r#"["eng", "spa"]"#),
+                text("spa"),
+            ],
+        ],
+    ));
+    assert_eq!(
+        bundle.realm_patch.patch["supportedLocales"],
+        json!(["en", "es"])
+    );
+    assert_eq!(bundle.realm_patch.patch["defaultLocale"], json!("es"));
+    assert_eq!(
+        bundle.realm_patch.patch["internationalizationEnabled"],
+        json!(true)
+    );
+}
+
+#[test]
+fn the_event_title_becomes_the_realms_display_name() {
+    // Otherwise every client's voters see "Election Event" above the login form.
+    let bundle = built(&sound());
+    assert_eq!(
+        bundle.realm_patch.patch["displayName"],
+        json!("Union Election 2027")
+    );
+}
+
+#[test]
+fn login_css_reaches_every_enabled_language_escaped_for_message_format() {
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("login_custom_css"),
+                text(".logo { display: none; }"),
+            ],
+        ],
+    ));
+    let texts = &bundle.realm_patch.patch["localizationTexts"];
+    assert_eq!(
+        texts["en"]["loginCustomCss"],
+        json!(".logo '{' display: none; '}'")
+    );
+}
+
+#[test]
+fn an_explicit_realm_parameter_wins_over_anything_derived() {
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("keycloak_event_realm.displayName"),
+                text("Chosen By Hand"),
+            ],
+        ],
+    ));
+    assert_eq!(
+        bundle.realm_patch.patch["displayName"],
+        json!("Chosen By Hand")
+    );
+}
+
+#[test]
+fn admin_realm_parameters_travel_separately_because_they_are_tenant_scoped() {
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("keycloak_admin_realm.smtpServer.host"),
+                text("smtp.example.org"),
+            ],
+        ],
+    ));
+    assert_eq!(
+        bundle.admin_realm_patch["smtpServer"]["host"],
+        json!("smtp.example.org")
+    );
+    // And not into the event's realm patch.
+    assert!(bundle.realm_patch.patch.get("smtpServer").is_none());
+}
+
+#[test]
+fn a_parameter_a_preset_consumes_is_not_also_reported_as_uninterpreted() {
+    // Reporting it as ignored while a preset acts on it contradicts itself.
+    let bundle = built(&with_sheet(
+        "Parameters",
+        vec![
+            vec![text("type"), text("key"), text("value")],
+            vec![
+                text("settings"),
+                text("auth_type"),
+                text("otp_email_or_sms"),
+            ],
+            vec![text("settings"), text("otp_length"), Cell::Int(8)],
+        ],
+    ));
+    // Nothing was carried, so annotations stays whatever the template said —
+    // null, not an object with the preset's own parameters in it.
+    let annotations = &bundle.export["election_event"]["annotations"];
+    let carried: Vec<&String> = annotations
+        .as_object()
+        .map(|annotations| annotations.keys().collect())
+        .unwrap_or_default();
+    assert!(
+        carried.is_empty(),
+        "a preset's own parameters were carried as uninterpreted: {carried:?}"
+    );
+}
+
+// -- permission labels ----------------------------------------------------
+
+#[test]
+fn a_permission_label_no_administrator_holds_is_warned_about() {
+    // The failure this guards against is quiet and expensive: the event imports
+    // cleanly and the Elections list is empty. It happened on the first real
+    // import, where a document labelled an election 'dlc-officers-dburs' while its
+    // own administrators carried 'dlc-officers'.
+    let mut sheets: Vec<Sheet> = sound()
+        .sheets()
+        .iter()
+        .filter(|sheet| sheet.name != "Elections")
+        .cloned()
+        .collect();
+    sheets.push(
+        Sheet::from_grid(
+            "Elections",
+            &[
+                vec![text("external_id"), text("permission_label")],
+                vec![text("statewide"), text("dlc-officers-dburs")],
+            ],
+        )
+        .unwrap(),
+    );
+    sheets.push(
+        Sheet::from_grid(
+            "Admin Users",
+            &[
+                vec![text("username"), text("permission_labels")],
+                vec![text("admin1"), text("dlc-officers")],
+            ],
+        )
+        .unwrap(),
+    );
+
+    let bundle = built(&Workbook::new(sheets).unwrap());
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("no administrator in the Admin Users sheet carries it")));
+    assert!(bundle
+        .warnings
+        .warnings()
+        .any(|problem| problem.message.contains("permission labels in use")));
+}
+
+#[test]
+fn a_label_an_administrator_does_hold_is_only_noted_not_flagged() {
+    let mut sheets: Vec<Sheet> = sound()
+        .sheets()
+        .iter()
+        .filter(|sheet| sheet.name != "Elections")
+        .cloned()
+        .collect();
+    sheets.push(
+        Sheet::from_grid(
+            "Elections",
+            &[
+                vec![text("external_id"), text("permission_label")],
+                vec![text("statewide"), text("statewide-officers")],
+            ],
+        )
+        .unwrap(),
+    );
+    sheets.push(
+        Sheet::from_grid(
+            "Admin Users",
+            &[
+                vec![text("username"), text("permission_labels")],
+                vec![text("admin1"), text("statewide-officers")],
+            ],
+        )
+        .unwrap(),
+    );
+
+    let bundle = built(&Workbook::new(sheets).unwrap());
+    assert!(!bundle
+        .warnings
+        .warnings()
+        .any(|problem| problem.message.contains("carries it")));
+    // Whoever imports still needs the label on their own attribute.
+    assert!(bundle
+        .warnings
+        .warnings()
+        .any(|problem| problem.message.contains("permission labels in use")));
+}
+
+#[test]
+fn a_document_that_grants_no_labels_at_all_says_so_differently() {
+    let mut sheets: Vec<Sheet> = sound()
+        .sheets()
+        .iter()
+        .filter(|sheet| sheet.name != "Elections")
+        .cloned()
+        .collect();
+    sheets.push(
+        Sheet::from_grid(
+            "Elections",
+            &[
+                vec![text("external_id"), text("permission_label")],
+                vec![text("statewide"), text("statewide-officers")],
+            ],
+        )
+        .unwrap(),
+    );
+    let bundle = built(&Workbook::new(sheets).unwrap());
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("grants no permission labels to anyone")));
+}
+
+#[test]
+fn a_document_with_no_labels_says_nothing_about_them() {
+    let bundle = built(&sound());
+    assert!(!bundle
+        .warnings
+        .warnings()
+        .any(|problem| problem.message.contains("permission label")));
+}
+
+// -- inherited branding ---------------------------------------------------
+
+#[test]
+fn voter_facing_copy_inherited_from_a_base_export_is_named() {
+    // Useful when the base is a reference event and wrong when it is another
+    // client's: their login title and instruction copy would come along silently.
+    let bundle = with_options(
+        &sound(),
+        BuildOptions {
+            base_export: Some(json!({
+                "election_event": {
+                    "presentation": {
+                        "i18n": {"en": {
+                            "login_instructions": "Ring the other client's helpdesk",
+                        }},
+                        "theme": "other-client",
+                    },
+                },
+            })),
+            ..BuildOptions::default()
+        },
+    );
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("presentation.i18n.en.login_instructions")));
+    assert!(bundle.warnings.warnings().any(|problem| problem
+        .message
+        .contains("presentation settings inherited from the base export")));
+}
+
+#[test]
+fn copy_the_document_sets_itself_is_not_reported_as_inherited() {
+    let mut sheets: Vec<Sheet> = sound()
+        .sheets()
+        .iter()
+        .filter(|sheet| sheet.name != "ElectionEvent")
+        .cloned()
+        .collect();
+    sheets.push(
+        Sheet::from_grid(
+            "ElectionEvent",
+            &[
+                vec![
+                    text("external_id"),
+                    text("presentation.i18n.en.name"),
+                    text("presentation.i18n.en.login_instructions"),
+                ],
+                vec![
+                    text("union-2027"),
+                    text("Union Election 2027"),
+                    text("Ring our helpdesk"),
+                ],
+            ],
+        )
+        .unwrap(),
+    );
+
+    let bundle = with_options(
+        &Workbook::new(sheets).unwrap(),
+        BuildOptions {
+            base_export: Some(json!({
+                "election_event": {"presentation": {"i18n": {"en": {
+                    "login_instructions": "Ring the other client's helpdesk",
+                }}}},
+            })),
+            ..BuildOptions::default()
+        },
+    );
+    assert!(
+        !bundle
+            .warnings
+            .warnings()
+            .any(|problem| problem.message.contains("login_instructions")),
+        "{}",
+        bundle.warnings
+    );
+    assert_eq!(
+        bundle.export["election_event"]["presentation"]["i18n"]["en"]
+            ["login_instructions"],
+        json!("Ring our helpdesk")
+    );
 }

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -28,9 +28,11 @@
 #[cfg(feature = "election_config_templates")]
 pub mod build;
 
+pub mod branding;
 pub mod emit;
 pub mod ids;
 pub mod paths;
+pub mod presets;
 pub mod problem;
 
 /// Rendering the base entity templates, behind its own feature so a front end
@@ -58,6 +60,8 @@ pub use build::{
 pub use emit::{json_csv, plain_csv, JsonField};
 pub use ids::IdFactory;
 pub use paths::{coerce_cell, deep_merge, expand, Cell};
+#[cfg(feature = "election_config_templates")]
+pub use presets::{AuthPreset, RealmPatch};
 pub use problem::{Code, Problem, Report as ValidationReport, Severity};
 #[cfg(feature = "election_config_templates")]
 pub use render::TemplateSet;

--- a/packages/sequent-core/src/election_config/presets.rs
+++ b/packages/sequent-core/src/election_config/presets.rs
@@ -1,0 +1,742 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Authentication presets: how voters prove who they are.
+//!
+//! A source document declares this as one `auth_type` parameter. A preset turns
+//! that one cell into the realm configuration it implies — an identity provider,
+//! an authenticator config, the user-profile permissions that make a field
+//! typeable on the login form.
+//!
+//! Presets are **patches, not realms.** Two reasons, and the second is the
+//! important one:
+//!
+//! * A realm is ~165 kB of interdependent Keycloak configuration whose client
+//!   `redirectUris` and endpoint URLs belong to the environment it was exported
+//!   from. Every realm available to copy from is saturated with them.
+//! * `keycloak_event_realm` is taken wholesale by the importer: if it is present
+//!   it *replaces* the environment's own provisioned default rather than merging
+//!   with it. Emitting an invented realm would silently override configuration
+//!   that was deployed on purpose.
+//!
+//! So a preset is applied to a realm supplied as a base export, and is always
+//! also written out on its own so that nothing the document asked for is silently
+//! dropped.
+//!
+//! Every value here is transcribed from a realm that works, not invented. The
+//! SAML provider relies on `enabledFromMetadata`, which is what lets it carry
+//! only a metadata URL: Keycloak fetches the SSO endpoints and the signing
+//! certificate from the IdP's metadata, so no certificate is embedded here and
+//! none goes stale.
+
+use serde_json::{json, Map, Value};
+
+/// Parameter keys a preset may consume.
+///
+/// Anything a preset takes is kept out of the "carried but not interpreted"
+/// bucket, so the two never contradict each other.
+pub const PARAM_AUTH_TYPE: &str = "auth_type";
+pub const PARAM_SAML_METADATA_URL: &str = "saml_idp_metadata_url";
+pub const PARAM_SAML_IDP_ALIAS: &str = "saml_idp_alias";
+pub const PARAM_SAML_PRINCIPAL_ATTRIBUTE: &str = "saml_principal_attribute";
+pub const PARAM_OTP_SENDER_ID: &str = "otp_sender_id";
+pub const PARAM_OTP_LENGTH: &str = "otp_length";
+pub const PARAM_OTP_TTL_SECONDS: &str = "otp_ttl_seconds";
+
+/// The flow an imported SAML identity provider hands first-time logins to.
+///
+/// Present in the platform's event realm; a preset naming a flow the target realm
+/// does not have is reported rather than applied blindly.
+pub const SAML_FIRST_BROKER_FLOW: &str = "saml-first-broker-flow";
+pub const CERTIFICATE_FIRST_LOGIN_FLOW: &str = "certificate-first-login-flow";
+
+/// `crate::types::keycloak::CERTIFICATES_IDP_ALIAS`.
+///
+/// Import special-cases this alias: it generates a client secret for the matching
+/// client and rewrites the provider's URLs, so the alias is not a free choice.
+pub const CERTIFICATES_IDP_ALIAS: &str = "digital-certificates";
+
+/// The Keycloak authenticator each preset needs the target realm to contain.
+pub const OTP_AUTHENTICATOR: &str = "message-otp-authenticator";
+pub const DEFERRED_AUTHENTICATOR_CONFIG: &str = "deferred";
+
+/// The OTP config a preset registers under.
+pub const OTP_CONFIG_ALIAS: &str = "janitor-otp-by-availability";
+
+/// Names the preset that leaves the realm alone, whatever the document declares.
+///
+/// Useful while a client has not supplied what a preset needs — the SEIU document,
+/// for instance, declares SAML but leaves the IdP metadata URL blank pending their
+/// identity provider.
+pub const NONE: &str = "none";
+
+/// Something a preset needs the target realm to already have.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Requirement {
+    /// `flow`, `authenticator` or `authenticator_config`.
+    pub kind: &'static str,
+    pub name: &'static str,
+    pub why: &'static str,
+}
+
+/// What a preset asks of a realm: a merge, plus two things a merge cannot do.
+///
+/// The two directives are separate fields rather than magic keys inside the patch
+/// — which is how the Python carried them — so that writing the patch out never
+/// has to strip them, and so a caller cannot forget to.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RealmPatch {
+    /// Merged into the realm, deeply.
+    pub patch: Map<String, Value>,
+
+    /// Point every execution of an authenticator at a config alias.
+    pub bind_authenticator_config: Option<(String, String)>,
+
+    /// Changes to named user-profile attributes.
+    ///
+    /// The user profile travels as a stringified JSON blob inside a Keycloak
+    /// component, so it has to be parsed, patched and re-serialised rather than
+    /// merged.
+    pub user_profile: Option<Map<String, Value>>,
+}
+
+/// The parameters a preset reads, as resolved from the source document.
+#[derive(Debug, Clone, Default)]
+pub struct PresetInput {
+    values: Vec<(String, Value)>,
+}
+
+impl PresetInput {
+    pub fn new(values: Vec<(String, Value)>) -> Self {
+        PresetInput { values }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.values
+            .iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value)
+    }
+
+    /// A parameter as text, or `fallback` when absent or empty.
+    fn text(&self, key: &str, fallback: &str) -> String {
+        match self.get(key) {
+            Some(Value::String(text)) if !text.trim().is_empty() => {
+                text.trim().to_string()
+            }
+            Some(Value::Null) | None => fallback.to_string(),
+            Some(Value::String(_)) => fallback.to_string(),
+            Some(other) => other.to_string(),
+        }
+    }
+}
+
+/// One way of authenticating voters.
+#[derive(Debug, Clone, Copy)]
+pub struct AuthPreset {
+    pub name: &'static str,
+    pub summary: &'static str,
+
+    /// Whether a voter needs an email address or mobile number to log in.
+    ///
+    /// This is the difference between "56 of 56 voters cannot be sent a one-time
+    /// code" being a real problem and being noise: under SAML the client's
+    /// identity provider authenticates the voter, and asking for contact details
+    /// is not this tool's business.
+    pub uses_otp: bool,
+
+    pub requires: &'static [Requirement],
+    pub required_parameters: &'static [&'static str],
+    pub optional_parameters: &'static [&'static str],
+
+    build: fn(&PresetInput) -> RealmPatch,
+}
+
+impl AuthPreset {
+    /// Turn the resolved parameters into what the realm needs.
+    pub fn build(&self, input: &PresetInput) -> RealmPatch {
+        (self.build)(input)
+    }
+
+    /// Every parameter key this preset reads.
+    pub fn consumes(&self) -> Vec<&'static str> {
+        let mut keys = vec![PARAM_AUTH_TYPE];
+        keys.extend(self.required_parameters);
+        keys.extend(self.optional_parameters);
+        keys
+    }
+}
+
+// -- saml_sso_idp_initiated ------------------------------------------------
+
+/// A SAML identity provider driven entirely by the IdP's metadata.
+///
+/// `enabledFromMetadata` is the whole reason this preset is portable: Keycloak
+/// reads `singleSignOnServiceUrl`, `singleLogoutServiceUrl`, the entity id and the
+/// signing certificate out of the document at `metadataDescriptorUrl`. So nothing
+/// environment-specific and nothing that expires is written here.
+///
+/// For IdP-initiated SSO the client's IdP posts an unsolicited assertion to
+/// Keycloak's broker endpoint, which is derived from the alias — which is why the
+/// alias is worth being able to set.
+fn saml_patch(input: &PresetInput) -> RealmPatch {
+    let alias = input.text(PARAM_SAML_IDP_ALIAS, "client-saml-idp");
+    let metadata_url = input.text(PARAM_SAML_METADATA_URL, "");
+    let principal_attribute =
+        input.text(PARAM_SAML_PRINCIPAL_ATTRIBUTE, "username");
+
+    let patch = json!({
+        "identityProviders": [{
+            "alias": alias,
+            "displayName": "Sign in with your organisation",
+            "providerId": "saml",
+            "enabled": true,
+            "trustEmail": false,
+            "storeToken": false,
+            "addReadTokenRoleOnCreate": false,
+            // SP-initiated redirect stays off: the voter arrives from the IdP.
+            "authenticateByDefault": false,
+            "linkOnly": false,
+            "updateProfileFirstLoginMode": "off",
+            "firstBrokerLoginFlowAlias": SAML_FIRST_BROKER_FLOW,
+            "config": {
+                "metadataDescriptorUrl": metadata_url,
+                // Endpoints and signing certificate come from the metadata.
+                "enabledFromMetadata": "true",
+                "validateSignature": "true",
+                "wantAssertionsSigned": "true",
+                "wantAssertionsEncrypted": "false",
+                "wantAuthnRequestsSigned": "false",
+                "signSpMetadata": "false",
+                "forceAuthn": "false",
+                "postBindingResponse": "true",
+                "postBindingAuthnRequest": "true",
+                "postBindingLogout": "true",
+                "backchannelSupported": "false",
+                // Match the assertion to an existing census voter rather than
+                // creating one: the census is the roll of who may vote.
+                "principalType": "ATTRIBUTE",
+                "principalAttribute": principal_attribute,
+                "nameIDPolicyFormat":
+                    "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+                "syncMode": "IMPORT",
+                "allowCreate": "false",
+                "hideOnLoginPage": "false",
+                "authnContextComparisonType": "exact",
+                "allowedClockSkew": "30",
+            },
+        }],
+        // The IdP is the authority on who the voter is, so the realm must not
+        // offer a local password or a self-service registration path.
+        "registrationAllowed": false,
+        "resetPasswordAllowed": false,
+        "loginWithEmailAllowed": false,
+        "rememberMe": false,
+    });
+
+    RealmPatch {
+        patch: object(patch),
+        ..RealmPatch::default()
+    }
+}
+
+// -- otp_email_or_sms ------------------------------------------------------
+
+/// One OTP step that follows whatever the voter actually has.
+///
+/// `messageCourierAttribute: BOTH` is availability-driven rather than a demand for
+/// both channels: `Utils.sendCode` guards each channel on a non-empty address, so
+/// an email-only voter gets email, a mobile-only voter gets SMS, and a voter with
+/// both gets both.
+fn otp_config(input: &PresetInput) -> Value {
+    json!({
+        "alias": OTP_CONFIG_ALIAS,
+        "config": {
+            "messageCourierAttribute": "BOTH",
+            "telUserAttribute": "sequent.read-only.mobile-number",
+            "deferredUserAttribute": "false",
+            "one-time-link": "false",
+            "length": input.text(PARAM_OTP_LENGTH, "6"),
+            "ttl": input.text(PARAM_OTP_TTL_SECONDS, "900"),
+            "resendCoudActivationTimer": "60",
+            "max-receiver-reuse": "1",
+            "senderId": input.text(PARAM_OTP_SENDER_ID, "Sequent"),
+            "test-mode": "false",
+        },
+    })
+}
+
+fn otp_patch(input: &PresetInput) -> RealmPatch {
+    let patch = json!({
+        "authenticatorConfig": [otp_config(input)],
+        "registrationAllowed": true,
+        "registrationEmailAsUsername": false,
+        "loginWithEmailAllowed": false,
+        // There is no password in this flow, so a "forgot password" link is a
+        // dead end.
+        "resetPasswordAllowed": false,
+        "bruteForceProtected": true,
+    });
+
+    RealmPatch {
+        patch: object(patch),
+        bind_authenticator_config: Some((
+            OTP_AUTHENTICATOR.to_string(),
+            OTP_CONFIG_ALIAS.to_string(),
+        )),
+        user_profile: None,
+    }
+}
+
+// -- voter_link_plus_dob ---------------------------------------------------
+
+/// Member id prefilled from the link, date of birth typed, then OTP.
+///
+/// The date of birth is deliberately **not** prefillable. If it were, the link
+/// alone would authenticate the voter, and links get forwarded.
+fn voter_link_dob_patch(input: &PresetInput) -> RealmPatch {
+    let mut result = otp_patch(input);
+
+    let deferred = json!({
+        "alias": DEFERRED_AUTHENTICATOR_CONFIG,
+        "config": {
+            "form-mode": "LOGIN",
+            "password-required": "false",
+            "search-attributes": "username,dateOfBirth",
+            "hidden-profile-attributes": "locale,firstName,lastName,ssn4",
+            "prefill-parameters-policy": "ACCEPT",
+            "user-status": "sequent.read-only.id-card-number-validated",
+            "password-expiration-user-attribute":
+                "sequent.read-only.expirationDate",
+        },
+    });
+
+    if let Some(Value::Array(configs)) =
+        result.patch.get_mut("authenticatorConfig")
+    {
+        configs.push(deferred);
+    }
+
+    result.user_profile = Some(object(json!({
+        "username": {
+            "permissions": {"view": ["admin", "user"], "edit": ["admin", "user"]},
+            "annotations": {"loginHintPrefillPolicy": "READ_ONLY"},
+        },
+        "dateOfBirth": {
+            "permissions": {"view": ["admin", "user"], "edit": ["admin", "user"]},
+            "required": {"roles": ["user"]},
+            // IGNORE on purpose: a prefillable date of birth means the link alone
+            // authenticates the voter.
+            "annotations": {
+                "inputType": "html5-date",
+                "loginHintPrefillPolicy": "IGNORE",
+            },
+        },
+    })));
+    result
+}
+
+// -- digital_certificates --------------------------------------------------
+
+/// Enable the digital-certificates provider the platform already knows.
+///
+/// Only the alias and the enabled flag are set. Import rewrites this provider's
+/// URLs and generates its client secret itself — `import_election_event.rs`
+/// special-cases exactly this alias — so writing endpoints here would be
+/// overwritten at best and wrong at worst.
+fn certificates_patch(_: &PresetInput) -> RealmPatch {
+    let patch = json!({
+        "identityProviders": [{
+            "alias": CERTIFICATES_IDP_ALIAS,
+            "providerId": "keycloak-oidc",
+            "displayName": "Digital Certificates",
+            "enabled": true,
+            "trustEmail": false,
+            "storeToken": false,
+            "addReadTokenRoleOnCreate": false,
+            "authenticateByDefault": false,
+            "linkOnly": false,
+            "updateProfileFirstLoginMode": "off",
+            "firstBrokerLoginFlowAlias": CERTIFICATE_FIRST_LOGIN_FLOW,
+        }],
+        "registrationAllowed": false,
+        "resetPasswordAllowed": false,
+    });
+
+    RealmPatch {
+        patch: object(patch),
+        ..RealmPatch::default()
+    }
+}
+
+/// Every preset, in the order a caller should see them listed.
+pub const PRESETS: &[AuthPreset] = &[
+    AuthPreset {
+        name: "digital_certificates",
+        summary: "The voter presents a digital certificate, brokered through the \
+                  platform's digital-certificates provider.",
+        uses_otp: false,
+        build: certificates_patch,
+        required_parameters: &[],
+        optional_parameters: &[],
+        requires: &[Requirement {
+            kind: "flow",
+            name: CERTIFICATE_FIRST_LOGIN_FLOW,
+            why: "a first-time certificate login is handed to this flow",
+        }],
+    },
+    AuthPreset {
+        name: "otp_email_or_sms",
+        summary: "The voter types their member id, then a one-time code sent to \
+                  whichever of email and mobile the census holds for them.",
+        uses_otp: true,
+        build: otp_patch,
+        required_parameters: &[],
+        optional_parameters: &[
+            PARAM_OTP_SENDER_ID,
+            PARAM_OTP_LENGTH,
+            PARAM_OTP_TTL_SECONDS,
+        ],
+        requires: &[Requirement {
+            kind: "authenticator",
+            name: OTP_AUTHENTICATOR,
+            why: "the one-time code step is bound to this authenticator's config",
+        }],
+    },
+    AuthPreset {
+        name: "saml_sso_idp_initiated",
+        summary: "The client's SAML identity provider authenticates the voter and \
+                  posts an assertion to Keycloak. Voters need no email address or \
+                  mobile number.",
+        uses_otp: false,
+        build: saml_patch,
+        required_parameters: &[PARAM_SAML_METADATA_URL],
+        optional_parameters: &[
+            PARAM_SAML_IDP_ALIAS,
+            PARAM_SAML_PRINCIPAL_ATTRIBUTE,
+        ],
+        requires: &[Requirement {
+            kind: "flow",
+            name: SAML_FIRST_BROKER_FLOW,
+            why: "a first-time SAML login is handed to this flow to match the \
+                  assertion against an existing census voter",
+        }],
+    },
+    AuthPreset {
+        name: "voter_link_plus_dob",
+        summary: "A voter-specific link carries the member id read-only; the voter \
+                  types their date of birth, then a one-time code.",
+        uses_otp: true,
+        build: voter_link_dob_patch,
+        required_parameters: &[],
+        optional_parameters: &[
+            PARAM_OTP_SENDER_ID,
+            PARAM_OTP_LENGTH,
+            PARAM_OTP_TTL_SECONDS,
+        ],
+        requires: &[
+            Requirement {
+                kind: "authenticator",
+                name: OTP_AUTHENTICATOR,
+                why: "the one-time code step is bound to this authenticator's \
+                      config",
+            },
+            Requirement {
+                kind: "authenticator_config",
+                name: DEFERRED_AUTHENTICATOR_CONFIG,
+                why: "the login form's fields and prefill policy are set on this \
+                      config",
+            },
+        ],
+    },
+];
+
+/// The preset named, whatever the case and padding.
+pub fn get(name: &str) -> Option<&'static AuthPreset> {
+    let name = name.trim().to_lowercase();
+    PRESETS.iter().find(|preset| preset.name == name)
+}
+
+/// Every preset name, sorted.
+pub fn names() -> Vec<&'static str> {
+    PRESETS.iter().map(|preset| preset.name).collect()
+}
+
+/// Keys the presets may consume.
+///
+/// A caller keeps these out of the "carried but not interpreted" bucket even when
+/// no preset is selected: reporting a key as uninterpreted while a preset would
+/// have acted on it contradicts itself.
+pub fn all_preset_parameters() -> Vec<&'static str> {
+    let mut keys: Vec<&'static str> =
+        PRESETS.iter().flat_map(AuthPreset::consumes).collect();
+    keys.sort_unstable();
+    keys.dedup();
+    keys
+}
+
+/// A `json!` object as a `Map`. The macro's input is an object literal in every
+/// call above, so the panic is unreachable.
+fn object(value: Value) -> Map<String, Value> {
+    match value {
+        Value::Object(object) => object,
+        _ => unreachable!("preset patches are written as object literals"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(values: &[(&str, &str)]) -> PresetInput {
+        PresetInput::new(
+            values
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), json!(*value)))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn the_presets_are_listed_in_a_stable_order() {
+        // A CLI's --help and an SPA's dropdown both read this.
+        assert_eq!(
+            names(),
+            [
+                "digital_certificates",
+                "otp_email_or_sms",
+                "saml_sso_idp_initiated",
+                "voter_link_plus_dob",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_preset_is_found_however_it_is_written() {
+        assert_eq!(get("otp_email_or_sms").unwrap().name, "otp_email_or_sms");
+        assert_eq!(
+            get("  OTP_Email_Or_SMS ").unwrap().name,
+            "otp_email_or_sms"
+        );
+        assert!(get("otp").is_none());
+        assert!(get(NONE).is_none());
+    }
+
+    #[test]
+    fn every_preset_declares_what_the_realm_must_already_have() {
+        // A preset naming a flow the target realm lacks is reported rather than
+        // applied blindly, which is only possible if it says what it needs.
+        for preset in PRESETS {
+            assert!(!preset.requires.is_empty(), "{}", preset.name);
+            for requirement in preset.requires {
+                assert!(
+                    ["flow", "authenticator", "authenticator_config"]
+                        .contains(&requirement.kind),
+                    "{}: {}",
+                    preset.name,
+                    requirement.kind
+                );
+                assert!(!requirement.why.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn every_preset_consumes_the_auth_type_that_selects_it() {
+        for preset in PRESETS {
+            assert!(preset.consumes().contains(&PARAM_AUTH_TYPE));
+        }
+        assert!(all_preset_parameters().contains(&PARAM_SAML_METADATA_URL));
+        assert!(all_preset_parameters().contains(&PARAM_OTP_LENGTH));
+    }
+
+    #[test]
+    fn the_saml_provider_carries_only_a_metadata_url() {
+        // enabledFromMetadata is what makes it portable: no endpoint and no
+        // certificate is written, so nothing here goes stale or belongs to one
+        // environment.
+        let patch = get("saml_sso_idp_initiated").unwrap().build(&input(&[(
+            PARAM_SAML_METADATA_URL,
+            "https://idp/metadata",
+        )]));
+        let provider = &patch.patch["identityProviders"][0];
+
+        assert_eq!(provider["alias"], json!("client-saml-idp"));
+        assert_eq!(
+            provider["config"]["metadataDescriptorUrl"],
+            json!("https://idp/metadata")
+        );
+        assert_eq!(provider["config"]["enabledFromMetadata"], json!("true"));
+        assert!(provider["config"].get("singleSignOnServiceUrl").is_none());
+        assert!(provider["config"].get("signingCertificate").is_none());
+    }
+
+    #[test]
+    fn the_saml_assertion_is_matched_to_a_census_voter_not_used_to_create_one()
+    {
+        // The census is the roll of who may vote.
+        let patch = get("saml_sso_idp_initiated").unwrap().build(&input(&[(
+            PARAM_SAML_METADATA_URL,
+            "https://idp/metadata",
+        )]));
+        let config = &patch.patch["identityProviders"][0]["config"];
+        assert_eq!(config["principalType"], json!("ATTRIBUTE"));
+        assert_eq!(config["principalAttribute"], json!("username"));
+        assert_eq!(config["allowCreate"], json!("false"));
+    }
+
+    #[test]
+    fn saml_leaves_no_local_password_or_registration_path() {
+        // The IdP is the authority on who the voter is.
+        let patch = get("saml_sso_idp_initiated").unwrap().build(&input(&[(
+            PARAM_SAML_METADATA_URL,
+            "https://idp/metadata",
+        )]));
+        assert_eq!(patch.patch["registrationAllowed"], json!(false));
+        assert_eq!(patch.patch["resetPasswordAllowed"], json!(false));
+        assert_eq!(patch.patch["loginWithEmailAllowed"], json!(false));
+    }
+
+    #[test]
+    fn the_saml_alias_and_principal_attribute_can_be_set() {
+        // The broker endpoint the IdP posts to is derived from the alias.
+        let patch = get("saml_sso_idp_initiated").unwrap().build(&input(&[
+            (PARAM_SAML_METADATA_URL, "https://idp/metadata"),
+            (PARAM_SAML_IDP_ALIAS, "acme-idp"),
+            (PARAM_SAML_PRINCIPAL_ATTRIBUTE, "employeeNumber"),
+        ]));
+        let provider = &patch.patch["identityProviders"][0];
+        assert_eq!(provider["alias"], json!("acme-idp"));
+        assert_eq!(
+            provider["config"]["principalAttribute"],
+            json!("employeeNumber")
+        );
+    }
+
+    #[test]
+    fn the_otp_step_follows_whatever_the_voter_actually_has() {
+        // BOTH is availability-driven, not a demand for both channels:
+        // Utils.sendCode guards each on a non-empty address.
+        let patch = get("otp_email_or_sms").unwrap().build(&input(&[]));
+        let config = &patch.patch["authenticatorConfig"][0]["config"];
+        assert_eq!(config["messageCourierAttribute"], json!("BOTH"));
+        assert_eq!(config["length"], json!("6"));
+        assert_eq!(config["ttl"], json!("900"));
+        assert_eq!(config["senderId"], json!("Sequent"));
+    }
+
+    #[test]
+    fn the_otp_config_is_bound_to_the_authenticator_that_runs_it() {
+        // Registering the config without binding it leaves the step unconfigured.
+        let patch = get("otp_email_or_sms").unwrap().build(&input(&[]));
+        assert_eq!(
+            patch.bind_authenticator_config,
+            Some((OTP_AUTHENTICATOR.to_string(), OTP_CONFIG_ALIAS.to_string()))
+        );
+    }
+
+    #[test]
+    fn the_otp_length_and_lifetime_can_be_set_and_arrive_as_strings() {
+        // Keycloak config values are strings, whatever a spreadsheet cell was.
+        let patch =
+            get("otp_email_or_sms")
+                .unwrap()
+                .build(&PresetInput::new(vec![
+                    (PARAM_OTP_LENGTH.to_string(), json!(8)),
+                    (PARAM_OTP_TTL_SECONDS.to_string(), json!(300)),
+                    (PARAM_OTP_SENDER_ID.to_string(), json!("SEIU")),
+                ]));
+        let config = &patch.patch["authenticatorConfig"][0]["config"];
+        assert_eq!(config["length"], json!("8"));
+        assert_eq!(config["ttl"], json!("300"));
+        assert_eq!(config["senderId"], json!("SEIU"));
+    }
+
+    #[test]
+    fn there_is_no_forgotten_password_link_where_there_is_no_password() {
+        let patch = get("otp_email_or_sms").unwrap().build(&input(&[]));
+        assert_eq!(patch.patch["resetPasswordAllowed"], json!(false));
+        assert_eq!(patch.patch["bruteForceProtected"], json!(true));
+    }
+
+    #[test]
+    fn the_link_preset_adds_a_login_form_on_top_of_the_otp_step() {
+        let patch = get("voter_link_plus_dob").unwrap().build(&input(&[]));
+        let configs = patch.patch["authenticatorConfig"].as_array().unwrap();
+        assert_eq!(configs.len(), 2);
+        assert_eq!(configs[0]["alias"], json!(OTP_CONFIG_ALIAS));
+        assert_eq!(configs[1]["alias"], json!(DEFERRED_AUTHENTICATOR_CONFIG));
+        assert_eq!(
+            configs[1]["config"]["search-attributes"],
+            json!("username,dateOfBirth")
+        );
+    }
+
+    #[test]
+    fn a_date_of_birth_is_never_prefillable_from_the_link() {
+        // If it were, the link alone would authenticate the voter — and links get
+        // forwarded.
+        let patch = get("voter_link_plus_dob").unwrap().build(&input(&[]));
+        let profile = patch.user_profile.expect("a user profile patch");
+        assert_eq!(
+            profile["username"]["annotations"]["loginHintPrefillPolicy"],
+            json!("READ_ONLY")
+        );
+        assert_eq!(
+            profile["dateOfBirth"]["annotations"]["loginHintPrefillPolicy"],
+            json!("IGNORE")
+        );
+        assert_eq!(
+            profile["dateOfBirth"]["required"]["roles"],
+            json!(["user"])
+        );
+    }
+
+    #[test]
+    fn the_certificates_preset_sets_the_alias_import_special_cases_and_no_urls()
+    {
+        // Import rewrites this provider's URLs and generates its client secret, so
+        // writing endpoints would be overwritten at best.
+        let patch = get("digital_certificates").unwrap().build(&input(&[]));
+        let provider = &patch.patch["identityProviders"][0];
+        assert_eq!(provider["alias"], json!(CERTIFICATES_IDP_ALIAS));
+        assert_eq!(provider["providerId"], json!("keycloak-oidc"));
+        assert_eq!(provider["enabled"], json!(true));
+        assert!(provider.get("config").is_none());
+    }
+
+    #[test]
+    fn only_the_presets_that_send_a_code_say_they_use_otp() {
+        // What decides whether "no voter can be sent a code" is a real problem.
+        assert!(get("otp_email_or_sms").unwrap().uses_otp);
+        assert!(get("voter_link_plus_dob").unwrap().uses_otp);
+        assert!(!get("saml_sso_idp_initiated").unwrap().uses_otp);
+        assert!(!get("digital_certificates").unwrap().uses_otp);
+    }
+
+    #[test]
+    fn no_preset_writes_an_environment_specific_url() {
+        // The reason presets are patches: every realm available to copy from is
+        // saturated with the hosts of the environment it came from.
+        for preset in PRESETS {
+            let built = preset.build(&input(&[(
+                PARAM_SAML_METADATA_URL,
+                "https://idp.example.org/metadata",
+            )]));
+            let encoded = serde_json::to_string(&built.patch).unwrap();
+            for host in [
+                "localhost",
+                "127.0.0.1",
+                ".sequentech.io",
+                "https://sequent",
+            ] {
+                assert!(
+                    !encoded.contains(host),
+                    "{} writes {host}",
+                    preset.name
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2976.** Base branch is
`feat/meta-12769-tables/main`, so this diff shows only what is added on top.

The last of janitor's Python: the four authentication presets, the realm settings an
event already implies, and the permission-label check that explains an empty
Elections list.

## Presets are patches, not realms

A realm is ~165 kB of interdependent Keycloak configuration whose client URLs belong
to the environment it was exported from — and the importer takes
`keycloak_event_realm` **wholesale**, so a present realm *replaces* the
environment's provisioned default rather than merging into it. So a preset is
applied to a realm someone exported from a working event, and is always also kept on
its own so nothing the document asked for is silently dropped. With no base export,
no realm is emitted and the warning says exactly that.

Two things a deep merge cannot express are now **struct fields** rather than magic
keys inside the patch, which is how the Python carried them: binding an
authenticator config, and patching the user profile. That removes the
strip-the-directives step the writer used to need, and with it the chance of
forgetting it.

## The realm work worth reading

**`identityProviders` and `authenticatorConfig` are merged by alias, not replaced.**
They are referenced by alias from elsewhere in the realm, so replacing either
wholesale would strip providers the environment configured on purpose.

**The realm name is derived from tenant and event**, because the voting portal and
the smart-link URLs derive it the same way. A base export's own event id is swapped
out of its client URLs first, because import remaps every UUID it finds and a stale
one would be remapped to something unrelated.

**The user profile is parsed, patched and re-serialised**, not merged: it lives
inside a Keycloak component as a single JSON string.

**A preset naming a flow or authenticator the target realm lacks is warned about**
rather than applied blindly — possible only because each preset states what it needs
and why.

## The event configures its own login page

The platform carries none of this across: it never syncs `supportedLocales`, and has
no path at all from an event name to a realm display name. So the event's own
languages, title and login CSS become realm settings.

Language codes go through the platform's own `iso_639_2t_to_bcp47` rather than a
second copy of it — the Python transcribed all 177 entries by hand. **Basque and
Dutch are missing from that table** and pass through unconverted; both
implementations always behaved that way, so it is a gap in `util::locale` rather
than a regression here, and a test says so.

CSS is escaped for `java.text.MessageFormat` — quotes before braces, so the quotes
this adds are not themselves doubled — and written for **every enabled locale**:
Keycloak looks the message up in the voter's language, so CSS under `en` alone
vanishes the moment a voter switches to Spanish. A stylesheet copied out of a
working realm arrives already quoted and is unwrapped first.

**`uses_otp` now gates the voter-reachability warning.** Under SAML or digital
certificates the client's identity provider authenticates the voter, so "56 of 56
voters cannot be sent a one-time code" is noise rather than a finding.

## The permission-label check

The one that matters most in practice. An election whose label no administrator
holds **imports cleanly, reports no error, and then does not appear in the Elections
list at all**. It happened on the first real import of the SEIU1000 event, where the
document labelled an election `dlc-officers-dburs` while its own administrators
carried `dlc-officers`. Nothing anywhere said so.

Warnings rather than errors, because the document is not the whole picture:
administrators may already exist in the target tenant carrying labels this file
knows nothing about.

## Verified

- `cargo test -p sequent-core --lib --features election_config_xlsx,election_config_templates election_config` — **315 passed**, 0 failed (250 before, 65 new).
- `cargo check -p sequent-core --features default_features` clean; `cargo check -p windmill` clean.
- `cargo build` emits no warnings for this module; `cargo fmt --check` clean; `cargo clippy --lib --tests` silent on it.
- A test asserts no preset writes an environment-specific host, which is the property that makes them portable at all.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

_Not applicable — this level is a library module with no UI._
