### PR TITLE
✨ Turn a bundle into the files it ships as

### DIFF
--- a/packages/sequent-core/Cargo.toml
+++ b/packages/sequent-core/Cargo.toml
@@ -134,6 +134,10 @@ calamine = { version = "0.26", features = ["dates"], optional = true }
 # randomness.
 sha1 = { version = "0.10", optional = true }
 
+# writing the importable archive; optional so a front end that only validates a
+# bundle carries no zip writer
+zip = { version = "2.1", optional = true }
+
 
 # WASM plugin management
 wasmtime = {version = "41.0.2", optional = true}
@@ -142,8 +146,6 @@ wasmtime-wasi = {version = "41.0.2", optional = true}
 [dev-dependencies]
 ptree = "0.5"
 wasm-bindgen-test = "0.3.42"
-# writes the tiny .xlsx the reader's tests read, so no binary fixture is committed
-zip = "2.1"
 
 [features]
 wasmtest = ["wasm", "dep:web-sys", "strand/wasmtest"]
@@ -166,10 +168,13 @@ default_features = ["dep:strand", "dep:num-bigint", "dep:tempfile", "dep:ammonia
 # Reading .xlsx into an election_config::sheet::Workbook. Separate from
 # default_features because admin-portal and voting-portal have no workbook to
 # read and should not pay for a spreadsheet parser in their bundle.
-election_config_xlsx = ["default_features", "dep:calamine"]
+election_config_xlsx = ["default_features", "dep:calamine", "dep:zip"]
 # Rendering the base entity templates. Separate from `reports`, which also brings
 # a headless browser and three AWS SDKs; this needs only the template engine.
 election_config_templates = ["default_features", "dep:handlebars"]
+# Writing the importable zip. Separate again: a front end that only validates an
+# existing bundle has nothing to write.
+election_config_archive = ["election_config_templates", "dep:zip"]
 
 sqlite = ["dep:tokio", "dep:rusqlite"]
 time = ["dep:time"]

--- a/packages/sequent-core/src/election_config/archive.rs
+++ b/packages/sequent-core/src/election_config/archive.rs
@@ -1,0 +1,642 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What a bundle becomes as files, and the zip the Admin Portal accepts.
+//!
+//! Pure, like the rest of the module: this returns named byte blobs and never
+//! touches a filesystem. `step-cli` writes them to a directory; a browser offers
+//! them as downloads. Which is the whole reason the split exists — a bundle with a
+//! dangling reference leaves no half-written output behind either way, because
+//! nothing is written until everything is built.
+//!
+//! Two groups, and the line between them matters. The **importable** members go
+//! inside the zip. The **auxiliary** files go beside it: administrators, roles and
+//! communication templates are tenant- or portal-scoped, and putting them in the
+//! zip would mean importing an election event could silently create administrator
+//! accounts.
+
+use crate::election_config::build::{
+    Bundle, CommunicationTemplate, PlainTable,
+};
+use crate::election_config::emit::{json_csv, member, plain_csv};
+use serde_json::{json, Map, Value};
+
+/// One file a bundle becomes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Artifact {
+    /// Path relative to the output directory. May contain `/`.
+    pub name: String,
+    pub bytes: Vec<u8>,
+}
+
+impl Artifact {
+    fn text(name: impl Into<String>, text: String) -> Self {
+        Artifact {
+            name: name.into(),
+            bytes: text.into_bytes(),
+        }
+    }
+
+    /// A JSON file, pretty-printed with a trailing newline.
+    ///
+    /// Two-space indentation throughout, which is `serde_json`'s and differs from
+    /// the one-space the Python used for the event document. Cosmetic — the
+    /// importer parses it — but it does mean the first regeneration of an existing
+    /// event reindents the whole file once.
+    fn json(name: impl Into<String>, value: &Value) -> Self {
+        let mut text = serde_json::to_string_pretty(value)
+            .unwrap_or_else(|_| "null".to_string());
+        text.push('\n');
+        Artifact::text(name, text)
+    }
+
+    fn csv(name: impl Into<String>, table: &PlainTable) -> Self {
+        let columns: Vec<&str> =
+            table.columns.iter().map(String::as_str).collect();
+        Artifact::text(name, plain_csv(&columns, &table.rows))
+    }
+}
+
+/// Everything a bundle is written as.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Layout {
+    /// The members of the importable zip.
+    pub importable: Vec<Artifact>,
+
+    /// What the zip should be called.
+    pub archive_name: String,
+
+    /// Files that belong beside the zip, never inside it.
+    pub auxiliary: Vec<Artifact>,
+}
+
+/// Turn a built bundle into the files it is written as.
+pub fn layout(bundle: &Bundle) -> Layout {
+    let suffix = &bundle.event_id;
+
+    let mut importable = vec![
+        Artifact::json(
+            member::file_name(member::ELECTION_EVENT, suffix, "json"),
+            &bundle.export,
+        ),
+        Artifact::csv(
+            member::file_name(member::VOTERS, suffix, "csv"),
+            &bundle.voters,
+        ),
+    ];
+
+    // The scheduled-events member is the JSON-in-CSV shape, always written even
+    // when empty: the voting window lives here, so an absent file and an empty one
+    // should not be told apart by whether the source had a sheet.
+    let schedule_columns: Vec<&str> = bundle
+        .scheduled_events
+        .columns
+        .iter()
+        .map(String::as_str)
+        .collect();
+    importable.push(Artifact::text(
+        member::file_name(member::SCHEDULED_EVENTS, suffix, "csv"),
+        json_csv(&schedule_columns, &bundle.scheduled_events.rows),
+    ));
+
+    if let Some(reports) = &bundle.reports {
+        importable.push(Artifact::csv(
+            member::file_name(member::REPORTS, suffix, "csv"),
+            reports,
+        ));
+    }
+
+    Layout {
+        importable,
+        archive_name: format!("{}.zip", bundle.slug),
+        auxiliary: auxiliary(bundle),
+    }
+}
+
+/// Files the source describes that are not part of the event import.
+fn auxiliary(bundle: &Bundle) -> Vec<Artifact> {
+    let mut written = Vec::new();
+
+    if let Some(admin_users) = &bundle.admin_users {
+        written.push(Artifact::csv("admin_users.csv", admin_users));
+    }
+
+    if let Some(role_permissions) = &bundle.role_permissions {
+        // Named after the tenant because nothing rewrites this file's name on the
+        // way in — which is the one place the tenant id actually matters.
+        written.push(Artifact::csv(
+            format!("export_permissions-{}.csv", bundle.tenant_id),
+            role_permissions,
+        ));
+    }
+
+    if !bundle.templates.is_empty() {
+        let mut manifest = Vec::new();
+        for template in &bundle.templates {
+            let file_name = template.file_name();
+            written.push(Artifact::text(
+                format!("templates/{file_name}"),
+                template.document.clone(),
+            ));
+            manifest.push(template_entry(template, &file_name));
+        }
+        written.push(Artifact::json(
+            "templates/templates.json",
+            &Value::Array(manifest),
+        ));
+    }
+
+    if !bundle.admin_realm_patch.is_empty() {
+        written.push(Artifact::json(
+            "keycloak_admin_realm_patch.json",
+            &Value::Object(bundle.admin_realm_patch.clone()),
+        ));
+    }
+
+    if !bundle.realm_patch.patch.is_empty() {
+        written.push(Artifact::json(
+            "keycloak_event_realm_patch.json",
+            &realm_patch_document(bundle),
+        ));
+    }
+
+    written
+}
+
+fn template_entry(template: &CommunicationTemplate, file_name: &str) -> Value {
+    json!({
+        "name": template.name,
+        "alias": template.alias,
+        "file": file_name,
+        "type": template.template_type,
+        "communication_method": template.communication_method,
+        "selected_methods": template.selected_methods,
+    })
+}
+
+/// The realm patch as a file someone can read and apply.
+///
+/// Written even when it was already applied to a base export's realm: it is the
+/// readable statement of what the source asked of the realm, and it is what you
+/// apply by hand when there was no realm here to apply it to. The comment says
+/// which of those happened, because the two need opposite things done next.
+fn realm_patch_document(bundle: &Bundle) -> Value {
+    let applied = bundle
+        .export
+        .get("keycloak_event_realm")
+        .is_some_and(|realm| !realm.is_null());
+
+    let comment = if applied {
+        match bundle.auth_preset {
+            Some(preset) => format!(
+                "Realm changes this source asks for. Already applied to the realm \
+                 in the event zip, via the '{preset}' preset."
+            ),
+            None => "Realm changes this source asks for. Already applied to the \
+                     realm in the event zip."
+                .to_string(),
+        }
+    } else {
+        "Realm changes this source asks for. NOT applied: no base export was \
+         given, so the event zip carries no realm and the platform will load its \
+         own default. Apply this to that realm."
+            .to_string()
+    };
+
+    let mut document = Map::new();
+    document.insert("_comment".to_string(), json!(comment));
+    document.insert("auth_preset".to_string(), json!(bundle.auth_preset));
+    document.insert(
+        "patch".to_string(),
+        Value::Object(bundle.realm_patch.patch.clone()),
+    );
+
+    // The two directives are separate fields on RealmPatch rather than keys inside
+    // the patch, so there is nothing to strip out here — but they are worth stating
+    // for whoever has to apply the patch by hand, since neither is a plain merge.
+    if let Some((authenticator, config_alias)) =
+        &bundle.realm_patch.bind_authenticator_config
+    {
+        document.insert(
+            "bind_authenticator_config".to_string(),
+            json!({
+                "_comment": "Not a merge: point every execution of this \
+                             authenticator at this config alias.",
+                "authenticator": authenticator,
+                "config_alias": config_alias,
+            }),
+        );
+    }
+    if let Some(user_profile) = &bundle.realm_patch.user_profile {
+        document.insert(
+            "user_profile".to_string(),
+            json!({
+                "_comment": "Not a merge: the user profile is a stringified JSON \
+                             blob inside the \
+                             org.keycloak.userprofile.UserProfileProvider \
+                             component. Parse it, apply these changes to the \
+                             matching entries of its `attributes` list, and write \
+                             it back as a string.",
+                "attributes": user_profile,
+            }),
+        );
+    }
+
+    Value::Object(document)
+}
+
+/// Zip the members at the archive root, reproducibly.
+///
+/// A fixed timestamp and a fixed mode on every entry: without them the archive's
+/// bytes change on every run, and "regenerating produced no diff" stops being
+/// something anyone can check.
+#[cfg(feature = "election_config_archive")]
+pub fn zip(
+    members: &[Artifact],
+) -> Result<Vec<u8>, crate::election_config::Problem> {
+    use crate::election_config::problem::Code;
+    use std::io::{Cursor, Write};
+    use zip::write::SimpleFileOptions;
+
+    /// 2026-01-01T00:00:00, matching what the Python wrote.
+    fn fixed_time() -> zip::DateTime {
+        zip::DateTime::from_date_and_time(2026, 1, 1, 0, 0, 0)
+            .unwrap_or_default()
+    }
+
+    let failed = |error: zip::result::ZipError| {
+        crate::election_config::Problem::error(
+            Code::InvalidValue,
+            "archive",
+            format!("could not be written: {error}"),
+        )
+    };
+
+    let mut buffer = Vec::new();
+    {
+        let mut writer = zip::ZipWriter::new(Cursor::new(&mut buffer));
+        let options = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated)
+            .last_modified_time(fixed_time())
+            // 0o644, the mode a normal export has.
+            .unix_permissions(0o644);
+
+        for artifact in members {
+            writer
+                .start_file(artifact.name.clone(), options)
+                .map_err(failed)?;
+            writer.write_all(&artifact.bytes).map_err(|error| {
+                crate::election_config::Problem::error(
+                    Code::InvalidValue,
+                    format!("archive.{}", artifact.name),
+                    format!("could not be written: {error}"),
+                )
+            })?;
+        }
+        writer.finish().map_err(failed)?;
+    }
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::election_config::build::{build, BuildOptions};
+    use crate::election_config::paths::Cell;
+    use crate::election_config::render::TemplateSet;
+    use crate::election_config::sheet::{Sheet, Workbook};
+
+    fn text(value: &str) -> Cell {
+        Cell::text(value)
+    }
+
+    /// The smallest document that builds, plus whatever a test needs.
+    fn bundle(extra: Vec<(&str, Vec<Vec<Cell>>)>) -> Bundle {
+        let mut sheets = vec![
+            (
+                "ElectionEvent",
+                vec![
+                    vec![
+                        text("external_id"),
+                        text("presentation.i18n.en.name"),
+                    ],
+                    vec![text("union-2027"), text("Union Election 2027")],
+                ],
+            ),
+            (
+                "Elections",
+                vec![vec![text("external_id")], vec![text("statewide")]],
+            ),
+            (
+                "Contests",
+                vec![
+                    vec![text("external_id"), text("election.external_id")],
+                    vec![text("president"), text("statewide")],
+                ],
+            ),
+            (
+                "Areas",
+                vec![
+                    vec![text("external_id"), text("name")],
+                    vec![text("area-north"), text("North")],
+                ],
+            ),
+            (
+                "AreaContests",
+                vec![
+                    vec![text("area.external_id"), text("contest.external_id")],
+                    vec![text("area-north"), text("president")],
+                ],
+            ),
+        ];
+        sheets.extend(extra);
+
+        let workbook = Workbook::new(
+            sheets
+                .into_iter()
+                .map(|(name, grid)| Sheet::from_grid(name, &grid).unwrap())
+                .collect(),
+        )
+        .unwrap();
+
+        let templates = TemplateSet::builtin().unwrap();
+        build(&workbook, &templates, &BuildOptions::default())
+            .expect("a clean build")
+    }
+
+    fn names(artifacts: &[Artifact]) -> Vec<&str> {
+        artifacts.iter().map(|a| a.name.as_str()).collect()
+    }
+
+    #[test]
+    fn the_zip_holds_the_members_the_importer_dispatches_on() {
+        // Anything named otherwise is silently ignored rather than rejected.
+        let bundle = bundle(vec![]);
+        let layout = layout(&bundle);
+        assert_eq!(
+            names(&layout.importable),
+            [
+                format!("export_election_event-{}.json", bundle.event_id),
+                format!("export_voters-{}.csv", bundle.event_id),
+                format!("export_scheduled_events-{}.csv", bundle.event_id),
+            ]
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+        );
+        assert_eq!(layout.archive_name, "union-2027.zip");
+    }
+
+    #[test]
+    fn the_reports_member_appears_only_when_there_are_reports() {
+        // An empty reports CSV is not a valid one.
+        assert!(!names(&layout(&bundle(vec![])).importable)
+            .iter()
+            .any(|name| name.starts_with("export_reports")));
+
+        let with_reports = bundle(vec![(
+            "Reports",
+            vec![vec![text("report_type")], vec![text("tally")]],
+        )]);
+        assert!(names(&layout(&with_reports).importable)
+            .iter()
+            .any(|name| name.starts_with("export_reports")));
+    }
+
+    #[test]
+    fn the_scheduled_events_member_is_written_even_when_empty() {
+        // The voting window lives in it, so whether the file exists must not
+        // depend on whether the source had a sheet.
+        let layout = layout(&bundle(vec![]));
+        let schedule = layout
+            .importable
+            .iter()
+            .find(|artifact| {
+                artifact.name.starts_with("export_scheduled_events")
+            })
+            .expect("the schedule member");
+        let text = String::from_utf8(schedule.bytes.clone()).unwrap();
+        assert_eq!(text, "id,tenant_id,election_event_id,created_at,stopped_at,archived_at,labels,annotations,event_processor,cron_config,event_payload,task_id\n");
+    }
+
+    #[test]
+    fn administrators_are_written_beside_the_zip_and_never_inside_it() {
+        // Importing an election event must not be able to create administrator
+        // accounts.
+        let bundle = bundle(vec![(
+            "Admin Users",
+            vec![
+                vec![text("username"), text("permission_labels")],
+                vec![text("admin1"), text("statewide-officers")],
+            ],
+        )]);
+        let layout = layout(&bundle);
+        assert!(names(&layout.auxiliary).contains(&"admin_users.csv"));
+        assert!(!names(&layout.importable).contains(&"admin_users.csv"));
+    }
+
+    #[test]
+    fn the_permissions_file_is_named_after_the_tenant() {
+        // Nothing rewrites this file's name on the way in, which is the one place
+        // the tenant id actually matters.
+        let bundle = bundle(vec![(
+            "Permissions",
+            vec![
+                vec![text("permission"), text("admin")],
+                vec![text("election:read"), text("x")],
+            ],
+        )]);
+        let layout = layout(&bundle);
+        assert!(names(&layout.auxiliary).contains(
+            &format!("export_permissions-{}.csv", bundle.tenant_id).as_str()
+        ));
+    }
+
+    #[test]
+    fn each_template_becomes_a_file_and_a_manifest_entry() {
+        let bundle = bundle(vec![(
+            "Templates",
+            vec![
+                vec![
+                    text("name"),
+                    text("alias"),
+                    text("type"),
+                    text("template.document"),
+                ],
+                vec![
+                    text("Voter Credentials"),
+                    text("voter_credentials"),
+                    text("VOTER_CREDENTIALS"),
+                    text("Hello {{name}}"),
+                ],
+            ],
+        )]);
+        let layout = layout(&bundle);
+
+        let document = layout
+            .auxiliary
+            .iter()
+            .find(|a| a.name == "templates/voter_credentials.hbs")
+            .expect("the template file");
+        assert_eq!(document.bytes, b"Hello {{name}}");
+
+        let manifest = layout
+            .auxiliary
+            .iter()
+            .find(|a| a.name == "templates/templates.json")
+            .expect("the manifest");
+        let parsed: Value =
+            serde_json::from_slice(&manifest.bytes).expect("valid JSON");
+        assert_eq!(parsed[0]["alias"], json!("voter_credentials"));
+        assert_eq!(parsed[0]["file"], json!("voter_credentials.hbs"));
+        assert_eq!(parsed[0]["type"], json!("VOTER_CREDENTIALS"));
+    }
+
+    #[test]
+    fn the_realm_patch_says_it_was_not_applied_when_there_was_no_realm() {
+        // Whoever reads it has to know whether to apply it by hand.
+        let bundle = bundle(vec![]);
+        let layout = layout(&bundle);
+        let patch = layout
+            .auxiliary
+            .iter()
+            .find(|a| a.name == "keycloak_event_realm_patch.json")
+            .expect("the realm patch");
+        let parsed: Value = serde_json::from_slice(&patch.bytes).unwrap();
+        assert!(parsed["_comment"].as_str().unwrap().contains("NOT applied"));
+        assert_eq!(
+            parsed["patch"]["displayName"],
+            json!("Union Election 2027")
+        );
+    }
+
+    #[test]
+    fn the_realm_patch_states_the_directives_that_are_not_merges() {
+        // A reader applying it by hand cannot deduce either from the patch itself.
+        let bundle = bundle(vec![(
+            "Parameters",
+            vec![
+                vec![text("type"), text("key"), text("value")],
+                vec![
+                    text("settings"),
+                    text("auth_type"),
+                    text("voter_link_plus_dob"),
+                ],
+            ],
+        )]);
+        let layout = layout(&bundle);
+        let patch = layout
+            .auxiliary
+            .iter()
+            .find(|a| a.name == "keycloak_event_realm_patch.json")
+            .expect("the realm patch");
+        let parsed: Value = serde_json::from_slice(&patch.bytes).unwrap();
+
+        assert_eq!(parsed["auth_preset"], json!("voter_link_plus_dob"));
+        assert_eq!(
+            parsed["bind_authenticator_config"]["authenticator"],
+            json!("message-otp-authenticator")
+        );
+        assert!(parsed["user_profile"]["attributes"]["dateOfBirth"].is_object());
+        // And nothing internal leaked into the mergeable part.
+        for key in parsed["patch"].as_object().unwrap().keys() {
+            assert!(!key.starts_with('_'), "{key} leaked into the patch");
+        }
+    }
+
+    #[test]
+    fn a_bundle_with_nothing_extra_writes_no_auxiliary_files_but_the_realm_patch(
+    ) {
+        let layout = layout(&bundle(vec![]));
+        assert_eq!(
+            names(&layout.auxiliary),
+            ["keycloak_event_realm_patch.json"]
+        );
+    }
+
+    #[test]
+    fn every_json_artifact_parses_and_ends_in_a_newline() {
+        // A file without one is a nuisance in every diff it appears in.
+        let bundle = bundle(vec![(
+            "Templates",
+            vec![
+                vec![text("alias"), text("template.document")],
+                vec![text("otp"), text("hello")],
+            ],
+        )]);
+        let layout = layout(&bundle);
+        for artifact in layout.importable.iter().chain(layout.auxiliary.iter())
+        {
+            if artifact.name.ends_with(".json") {
+                serde_json::from_slice::<Value>(&artifact.bytes)
+                    .unwrap_or_else(|error| {
+                        panic!("{}: {error}", artifact.name)
+                    });
+                assert_eq!(
+                    artifact.bytes.last(),
+                    Some(&b'\n'),
+                    "{}",
+                    artifact.name
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "election_config_archive")]
+    #[test]
+    fn the_archive_holds_exactly_the_importable_members_at_its_root() {
+        use std::io::Cursor;
+
+        let bundle = bundle(vec![(
+            "Admin Users",
+            vec![vec![text("username")], vec![text("admin1")]],
+        )]);
+        let layout = layout(&bundle);
+        let bytes = zip(&layout.importable).expect("a zip");
+
+        let mut archive =
+            ::zip::ZipArchive::new(Cursor::new(bytes)).expect("readable");
+        let mut inside: Vec<String> = (0..archive.len())
+            .map(|index| archive.by_index(index).unwrap().name().to_string())
+            .collect();
+        inside.sort();
+        let mut expected: Vec<String> =
+            layout.importable.iter().map(|a| a.name.clone()).collect();
+        expected.sort();
+        assert_eq!(inside, expected);
+
+        // No directories, and the administrators are not in there.
+        assert!(inside.iter().all(|name| !name.contains('/')));
+    }
+
+    #[cfg(feature = "election_config_archive")]
+    #[test]
+    fn zipping_the_same_bundle_twice_gives_the_same_bytes() {
+        // The point of the fixed timestamp and mode: without them "regenerating
+        // produced no diff" is not something anyone can check.
+        let layout = layout(&bundle(vec![]));
+        assert_eq!(
+            zip(&layout.importable).unwrap(),
+            zip(&layout.importable).unwrap()
+        );
+    }
+
+    #[cfg(feature = "election_config_archive")]
+    #[test]
+    fn a_member_survives_the_round_trip_byte_for_byte() {
+        use std::io::Read;
+
+        let layout = layout(&bundle(vec![]));
+        let bytes = zip(&layout.importable).unwrap();
+        let mut archive =
+            ::zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+
+        for expected in &layout.importable {
+            let mut member = archive.by_name(&expected.name).unwrap();
+            let mut got = Vec::new();
+            member.read_to_end(&mut got).unwrap();
+            assert_eq!(got, expected.bytes, "{}", expected.name);
+        }
+    }
+}

--- a/packages/sequent-core/src/election_config/build_realm.rs
+++ b/packages/sequent-core/src/election_config/build_realm.rs
@@ -519,8 +519,8 @@ impl Builder<'_> {
         // Insertion-ordered so the message does not depend on a hash.
         let mut used: Vec<(String, Vec<String>)> = Vec::new();
         let note = |used: &mut Vec<(String, Vec<String>)>,
-                        label: String,
-                        entity: String| {
+                    label: String,
+                    entity: String| {
             match used.iter_mut().find(|(seen, _)| seen == &label) {
                 Some((_, entities)) => entities.push(entity),
                 None => used.push((label, vec![entity])),

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -28,6 +28,11 @@
 #[cfg(feature = "election_config_templates")]
 pub mod build;
 
+/// What a bundle becomes as files. Needs the builder, so it shares its feature;
+/// the zip writer itself is behind `election_config_archive`.
+#[cfg(feature = "election_config_templates")]
+pub mod archive;
+
 pub mod branding;
 pub mod emit;
 pub mod ids;
@@ -53,6 +58,8 @@ pub mod xlsx;
 #[cfg(test)]
 mod validate_tests;
 
+#[cfg(feature = "election_config_templates")]
+pub use archive::{layout, Artifact, Layout};
 #[cfg(feature = "election_config_templates")]
 pub use build::{
     build, BuildOptions, Bundle, CommunicationTemplate, JsonTable, PlainTable,


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2977.** Base branch is
`feat/meta-12769-realm/main`, so this diff shows only what is added on top.

The last piece before a CLI: what a built bundle is written as, and the zip the
Admin Portal accepts.

Pure, like the rest of the module — named byte blobs, no filesystem. `step-cli`
writes them to a directory, a browser offers them as downloads, and neither leaves a
half-written output behind, because nothing is written until everything is built.

## The line between the two groups

**Importable** members go inside the zip. **Auxiliary** files go beside it:
administrators, roles and communication templates are tenant- or portal-scoped, and
putting them in the zip would mean importing an election event could silently create
administrator accounts. A test asserts `admin_users.csv` is in one list and not the
other.

## Two opposite rules, both deliberate

**The scheduled-events member is written even when empty.** The voting window lives
in it, so whether the file exists must not depend on whether the source had a sheet.

**The reports member is absent when there are none**, because an empty reports CSV is
not a valid one.

## The realm patch says what happened to it

Written whether or not it was applied, with a comment saying which — the two cases
need opposite things done next:

```json
{
  "_comment": "Realm changes this source asks for. NOT applied: no base export was given, …",
  "auth_preset": "voter_link_plus_dob",
  "patch": { … },
  "bind_authenticator_config": {
    "_comment": "Not a merge: point every execution of this authenticator at this config alias.",
    …
  },
  "user_profile": {
    "_comment": "Not a merge: the user profile is a stringified JSON blob inside the … component.",
    …
  }
}
```

Because the two directives are struct fields on `RealmPatch` rather than magic keys
inside the patch, there is nothing to strip out here — so the file can instead state
each one explicitly with a note that it is not a merge. Whoever applies the patch by
hand cannot deduce either from the patch itself.

## The zip is reproducible

A fixed timestamp and a fixed mode on every entry. Without them the archive's bytes
change on every run and "regenerating produced no diff" stops being something anyone
can check. A test zips the same bundle twice and compares; another reads every member
back out and asserts it survived byte for byte.

Behind a new **`election_config_archive`** feature, with the layout half behind the
builder's. A front end that only validates an existing bundle has nothing to write
and should carry no zip writer.

## One deliberate difference from the Python

Every JSON file is two-space indented, rather than one-space for the event document
and two for the rest. Cosmetic — the importer parses it — but it does mean the first
regeneration of an existing event reindents that file once.

## Verified

- `cargo test -p sequent-core --lib --features election_config_xlsx,election_config_archive election_config` — **328 passed**, 0 failed (315 before, 13 new).
- `cargo check -p sequent-core` clean with `default_features` alone, and with `election_config_templates` but not `election_config_archive` — both gates hold.
- `cargo check -p windmill` clean.
- `cargo build` emits no warnings for this module; `cargo fmt --check` clean; `cargo clippy --lib --tests` silent on it.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

_Not applicable — this level is a library module with no UI. The next level, the
`step-cli` subcommand, is where there is output to show._
