### PR TITLE
✨ Fold janitor into step-cli

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -527,6 +527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,18 +1773,20 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.26.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+checksum = "5fa68281b1a76b54a62156474adb06bb380a67e07dd60656e3217152b42183f3"
 dependencies = [
+ "atoi_simd",
  "byteorder",
  "chrono",
  "codepage",
  "encoding_rs",
+ "fast-float2",
  "log",
- "quick-xml 0.31.0",
+ "quick-xml 0.41.0",
  "serde",
- "zip 2.4.2",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -3043,6 +3055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +3812,12 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -7749,22 +7773,22 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "encoding_rs",
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -9757,6 +9781,7 @@ dependencies = [
  "url",
  "uuid",
  "windmill",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -10805,6 +10830,12 @@ dependencies = [
  "thiserror 2.0.17",
  "utf-8",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -12796,6 +12827,20 @@ dependencies = [
  "flate2",
  "indexmap 2.12.0",
  "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.12.0",
+ "memchr",
+ "typed-path",
  "zopfli",
 ]
 

--- a/packages/sequent-core/Cargo.toml
+++ b/packages/sequent-core/Cargo.toml
@@ -126,7 +126,7 @@ csv = "1.3.0"
 
 # reading authoring spreadsheets; optional so front ends with no workbook to read
 # do not carry it into their WASM bundle
-calamine = { version = "0.26", features = ["dates"], optional = true }
+calamine = { version = "0.36", features = ["dates"], optional = true }
 
 # uuid5 for the deterministic ids a generated bundle uses. The `uuid` crate is not
 # used for this: its v4 feature pulls getrandom, whose WASM support is version

--- a/packages/sequent-core/src/election_config/build.rs
+++ b/packages/sequent-core/src/election_config/build.rs
@@ -772,7 +772,7 @@ impl<'a> Builder<'a> {
 
         if elections.is_empty() {
             self.problem(
-                sheet_origin("Elections"),
+                Origin::sheet("Elections"),
                 Code::MissingField,
                 "an election event needs at least one election",
             );
@@ -834,7 +834,7 @@ impl<'a> Builder<'a> {
 
         if contests.is_empty() {
             self.problem(
-                sheet_origin("Contests"),
+                Origin::sheet("Contests"),
                 Code::MissingField,
                 "an election event needs at least one contest",
             );
@@ -927,11 +927,7 @@ impl<'a> Builder<'a> {
                 .find(|(_, seen_name)| seen_name == name)
             {
                 self.problem(
-                    Origin {
-                        sheet: "Areas".to_string(),
-                        row: 0,
-                        column: Some("name".to_string()),
-                    },
+                    Origin::column("Areas", "name"),
                     Code::DuplicateId,
                     format!(
                         "two areas are both named '{name}' ('{earlier}' and \
@@ -1002,7 +998,7 @@ impl<'a> Builder<'a> {
 
         if areas.is_empty() {
             self.problem(
-                sheet_origin("Areas"),
+                Origin::sheet("Areas"),
                 Code::MissingField,
                 "an election event needs at least one area; every voter \
                  belongs to one",
@@ -1062,7 +1058,7 @@ impl<'a> Builder<'a> {
 
         if links.is_empty() {
             self.problem(
-                sheet_origin("AreaContests"),
+                Origin::sheet("AreaContests"),
                 Code::BallotCoverage,
                 "no area is linked to any contest, so no voter would see a \
                  ballot",
@@ -1164,14 +1160,6 @@ fn event_row(workbook: &Workbook) -> Result<Row, Problem> {
                  one election event"
             ),
         )),
-    }
-}
-
-fn sheet_origin(sheet: &str) -> Origin {
-    Origin {
-        sheet: sheet.to_string(),
-        row: 0,
-        column: None,
     }
 }
 

--- a/packages/sequent-core/src/election_config/build_realm.rs
+++ b/packages/sequent-core/src/election_config/build_realm.rs
@@ -62,17 +62,9 @@ impl Builder<'_> {
         let Some(preset) = presets::get(&name) else {
             // Whichever said it wrong is where the author has to look.
             let origin = if explicit.is_some() {
-                Origin {
-                    sheet: "auth preset option".to_string(),
-                    row: 0,
-                    column: None,
-                }
+                Origin::sheet("auth preset option")
             } else {
-                Origin {
-                    sheet: "Parameters".to_string(),
-                    row: 0,
-                    column: Some("value".to_string()),
-                }
+                Origin::column("Parameters", "value")
             };
             let message = format!(
                 "'{name}' is not an authentication preset; expected one of {}",
@@ -107,11 +99,7 @@ impl Builder<'_> {
                 wanted.join(", ")
             );
             self.problem(
-                Origin {
-                    sheet: "Parameters".to_string(),
-                    row: 0,
-                    column: None,
-                },
+                Origin::sheet("Parameters"),
                 Code::MissingField,
                 message,
             );
@@ -434,11 +422,7 @@ impl Builder<'_> {
                     "the realm's user profile is not readable JSON: {error}"
                 );
                 self.problem(
-                    Origin {
-                        sheet: "base export".to_string(),
-                        row: 0,
-                        column: None,
-                    },
+                    Origin::sheet("base export"),
                     Code::InvalidValue,
                     message,
                 );

--- a/packages/sequent-core/src/election_config/build_tables.rs
+++ b/packages/sequent-core/src/election_config/build_tables.rs
@@ -798,11 +798,7 @@ impl Builder<'_> {
 
         if roles.is_empty() {
             self.problem(
-                Origin {
-                    sheet: sheet.name.clone(),
-                    row: 1,
-                    column: None,
-                },
+                Origin::sheet(sheet.name.clone()),
                 Code::MissingField,
                 "the Permissions matrix has no role columns; expected the first \
                  column to hold permissions and one further column per role",
@@ -948,11 +944,7 @@ impl Builder<'_> {
 
         for column in offenders {
             self.problem(
-                Origin {
-                    sheet: sheet.to_string(),
-                    row: 1,
-                    column: Some(column),
-                },
+                Origin::column(sheet, column),
                 Code::InvalidValue,
                 "the importer rejects this column name; only letters, digits, \
                  '.', '_' and '-' are allowed",

--- a/packages/sequent-core/src/election_config/sheet.rs
+++ b/packages/sequent-core/src/election_config/sheet.rs
@@ -93,13 +93,43 @@ pub fn normalise_sheet_name(name: &str) -> String {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Origin {
     pub sheet: String,
+
+    /// The row as the spreadsheet numbers them, or `0` for the sheet as a whole.
+    ///
+    /// Spreadsheets count from one, so zero cannot name a real row and is free to
+    /// mean "this is about the sheet, not a row in it" — which is what a missing
+    /// column or an empty sheet is about.
     pub row: usize,
+
     pub column: Option<String>,
+}
+
+impl Origin {
+    /// A problem with a sheet rather than with any row of it.
+    pub fn sheet(name: impl Into<String>) -> Self {
+        Origin {
+            sheet: name.into(),
+            row: 0,
+            column: None,
+        }
+    }
+
+    /// A problem with a whole column.
+    pub fn column(name: impl Into<String>, column: impl Into<String>) -> Self {
+        Origin {
+            sheet: name.into(),
+            row: 0,
+            column: Some(column.into()),
+        }
+    }
 }
 
 impl fmt::Display for Origin {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "sheet '{}' row {}", self.sheet, self.row)?;
+        write!(formatter, "sheet '{}'", self.sheet)?;
+        if self.row > 0 {
+            write!(formatter, " row {}", self.row)?;
+        }
         if let Some(column) = &self.column {
             write!(formatter, " column '{column}'")?;
         }
@@ -713,6 +743,19 @@ mod tests {
         let problem = sheet.rows[0].require("title").unwrap_err();
         assert_eq!(problem.code, Code::MissingField);
         assert_eq!(problem.path, "sheet 'Elections' row 2 column 'title'");
+    }
+
+    #[test]
+    fn an_origin_about_a_whole_sheet_does_not_claim_a_row() {
+        // "row 0" names no row a spreadsheet has, and reads as a bug.
+        assert_eq!(
+            Origin::sheet("Parameters").to_string(),
+            "sheet 'Parameters'"
+        );
+        assert_eq!(
+            Origin::column("Voters", "home address").to_string(),
+            "sheet 'Voters' column 'home address'"
+        );
     }
 
     #[test]

--- a/packages/sequent-core/src/election_config/xlsx.rs
+++ b/packages/sequent-core/src/election_config/xlsx.rs
@@ -256,8 +256,15 @@ mod tests {
                         // actually exercised. Anything else is an inline string,
                         // which avoids needing a shared-string table. A value
                         // wrapped in single quotes is forced to text, for the
-                        // codes an author formats as text on purpose.
-                        if let Some(literal) = value.strip_prefix('\'') {
+                        // codes an author formats as text on purpose, and one
+                        // opening with `=` becomes a formula whose cached result
+                        // is a string — the shape real workbooks use for a phone
+                        // number, and the one that used to lose its leading plus.
+                        if let Some(result) = value.strip_prefix('=') {
+                            xml.push_str(&format!(
+                                r#"<c r="{reference}" t="str"><f>"{result}"</f><v>{result}</v></c>"#
+                            ));
+                        } else if let Some(literal) = value.strip_prefix('\'') {
                             xml.push_str(&format!(
                                 r#"<c r="{reference}" t="inlineStr"><is><t>{literal}</t></is></c>"#
                             ));
@@ -322,6 +329,45 @@ mod tests {
 
         // And the documentation tab is reported rather than silently ignored.
         assert_eq!(workbook.unread_sheets(), vec!["Read Me"]);
+    }
+
+    #[test]
+    fn an_international_phone_number_keeps_its_leading_plus() {
+        // Real workbooks compute contact details with a formula, and its cached
+        // result is a string in the file. calamine before 0.36 tried a float parse
+        // on that string first — and Rust's float parser accepts a leading plus —
+        // so "+33645312453" arrived as the number 33645312453. A voter's phone
+        // number silently lost its country prefix, and nothing said so.
+        let bytes = tiny_xlsx(&[(
+            "Admin Users",
+            &[
+                &["username", "sequent.read-only.mobile-number"],
+                &["admin1", "=+33645312453"],
+            ],
+        )]);
+        let workbook = read_xlsx(&bytes).unwrap();
+        assert_eq!(
+            workbook.rows("adminusers")[0]
+                .get("sequent.read-only.mobile-number"),
+            Some(&json!("+33645312453"))
+        );
+    }
+
+    #[test]
+    fn a_formula_whose_result_is_text_stays_text_even_when_it_looks_numeric() {
+        // What `t="str"` means in the file: the cached result *is* a string. A
+        // formula that computes a number is written as a numeric cell instead, so
+        // trusting the marker is right — and it is what keeps a member id computed
+        // by a formula from losing its leading zeros.
+        let bytes = tiny_xlsx(&[(
+            "Voters",
+            &[&["username", "member_id"], &["v1", "=007"]],
+        )]);
+        let workbook = read_xlsx(&bytes).unwrap();
+        assert_eq!(
+            workbook.rows("voters")[0].get("member_id"),
+            Some(&json!("007"))
+        );
     }
 
     #[test]

--- a/packages/step-cli/Cargo.toml
+++ b/packages/step-cli/Cargo.toml
@@ -18,7 +18,7 @@ strum_macros = "0.27"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 graphql_client = "0.14"
 rayon = "1.5"
-sequent-core = { path="../sequent-core", features = ["keycloak", "probe", "reports","default_features"] }
+sequent-core = { path="../sequent-core", features = ["keycloak", "probe", "reports", "default_features", "election_config_xlsx", "election_config_archive"] }
 windmill = { path="../windmill" }
 strand = { path="../strand" }
 immudb-rs = { path="../immudb-rs" }
@@ -27,6 +27,8 @@ electoral-log = { path="../electoral-log" }
 uuid = { version = "1.5", features = ["v4", "fast-rng"] }
 fake = { version = "4", features = ["derive"] }
 csv = "1.1"
+# reading a base export straight out of an export archive
+zip = "2.1"
 rand = "0.9"
 chrono = "0.4"
 tokio = { version = "1.38", features = ["full"] }

--- a/packages/step-cli/src/commands/build_election_event.rs
+++ b/packages/step-cli/src/commands/build_election_event.rs
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Build an importable election event from an authoring workbook.
+//!
+//! This is janitor, folded into `step-cli`. Every decision it makes lives in
+//! `sequent_core::election_config`, which is also what windmill validates with and
+//! what the browser-side tools will run — so a bundle that builds here is a bundle
+//! the platform accepts, and there is no second implementation to drift.
+//!
+//! All this file does is talk to the filesystem and to whoever ran it. Reading a
+//! workbook, building, validating and laying out the files are all pure functions
+//! in the core, which is why nothing is written until every one of them has
+//! succeeded: a workbook with a dangling reference leaves no half-written output
+//! directory behind.
+
+use anyhow::{anyhow, Context, Result};
+use clap::Args;
+use colored::Colorize;
+use sequent_core::election_config::render::ENTITY_TEMPLATES;
+use sequent_core::election_config::xlsx::read_xlsx;
+use sequent_core::election_config::{
+    archive, build, presets, validate, BuildOptions, Bundle, ImportElectionEventSchema, Problem,
+    Severity, TemplateSet, ValidationReport,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Build an importable election event from an `.xlsx` workbook
+#[derive(Args)]
+#[command(about)]
+pub struct BuildElectionEvent {
+    /// Path to the authoring workbook
+    #[arg(short = 'w', long, value_name = "WORKBOOK")]
+    workbook: PathBuf,
+
+    /// Directory to write the bundle into, under a subdirectory named after the
+    /// event
+    #[arg(short = 'o', long, value_name = "OUT_DIR", default_value = "out")]
+    out_dir: PathBuf,
+
+    /// Tenant id to write into the file
+    ///
+    /// Import remaps it onto the tenant of the importing request, so getting it
+    /// wrong cannot send an event to the wrong tenant. It does name the
+    /// `export_permissions-<tenant>.csv` file, which nothing rewrites.
+    #[arg(short = 't', long, value_name = "TENANT_ID")]
+    tenant_id: Option<String>,
+
+    /// An existing export (`.json` or `.zip`) to inherit platform defaults and a
+    /// Keycloak realm from
+    ///
+    /// Without one no realm is emitted, and the platform loads its own provisioned
+    /// default instead.
+    #[arg(short = 'b', long, value_name = "BASE_EXPORT")]
+    base_export: Option<PathBuf>,
+
+    /// Directory of `.hbs` files overriding the built-in entity templates
+    #[arg(long, value_name = "TEMPLATES_DIR")]
+    templates_dir: Option<PathBuf>,
+
+    /// Authentication preset, overriding the workbook's `auth_type`
+    ///
+    /// `none` leaves the realm alone whatever the workbook declares.
+    #[arg(long, value_name = "PRESET")]
+    auth_preset: Option<String>,
+
+    /// Name for the output directory and archive
+    #[arg(long, value_name = "SLUG")]
+    slug: Option<String>,
+
+    /// Refuse to write anything if there are warnings
+    ///
+    /// Worth using in CI: a warning here means the bundle imports and the
+    /// configuration probably is not what its author meant.
+    #[arg(long)]
+    strict: bool,
+
+    /// Validate and report, writing nothing
+    #[arg(long)]
+    check_only: bool,
+}
+
+impl BuildElectionEvent {
+    pub fn run(&self) {
+        match self.build() {
+            Ok(()) => (),
+            Err(error) => {
+                eprintln!("{} {error:#}", "error:".red().bold());
+                std::process::exit(1);
+            }
+        }
+    }
+
+    fn build(&self) -> Result<()> {
+        if let Some(preset) = &self.auth_preset {
+            let known =
+                preset.eq_ignore_ascii_case(presets::NONE) || presets::get(preset).is_some();
+            if !known {
+                return Err(anyhow!(
+                    "'{preset}' is not an authentication preset. Expected {} or {}.",
+                    presets::NONE,
+                    presets::names().join(", ")
+                ));
+            }
+        }
+
+        let bytes = fs::read(&self.workbook)
+            .with_context(|| format!("could not read {}", self.workbook.display()))?;
+        let workbook = read_xlsx(&bytes).map_err(problem_error)?;
+
+        for unread in workbook.unread_sheets() {
+            // A misspelled tab is silently ignored otherwise, and the missing
+            // entities look like an authoring mistake somewhere else entirely.
+            println!(
+                "{} sheet '{unread}' is not one this reads, and was ignored",
+                "note:".cyan()
+            );
+        }
+
+        let templates = self.templates()?;
+        for overridden in templates.overridden() {
+            println!("{} using your own '{overridden}' template", "note:".cyan());
+        }
+
+        let options = BuildOptions {
+            tenant_id: self.tenant_id.clone(),
+            base_export: self.base_export()?,
+            slug: self.slug.clone(),
+            created_at: None,
+            auth_preset: self.auth_preset.clone(),
+        };
+
+        let bundle = match build(&workbook, &templates, &options) {
+            Ok(bundle) => bundle,
+            Err(report) => {
+                report_problems(&report);
+                return Err(anyhow!(
+                    "{} problem(s) in {}",
+                    report.errors().count(),
+                    self.workbook.display()
+                ));
+            }
+        };
+
+        // The same validation windmill runs before importing, on the bundle as
+        // written. A workbook can be internally consistent and still describe an
+        // event the platform would reject.
+        let schema: ImportElectionEventSchema = serde_json::from_value(bundle.export.clone())
+            .context(
+                "the built bundle does not match the import schema, which is a \
+                 bug in this tool rather than in the workbook",
+            )?;
+        let checked = validate(&schema);
+
+        report_problems(&bundle.warnings);
+        report_problems(&checked);
+
+        if checked.has_errors() {
+            return Err(anyhow!(
+                "{} problem(s) in the bundle this workbook describes",
+                checked.errors().count()
+            ));
+        }
+
+        let warnings = bundle.warnings.warnings().count() + checked.warnings().count();
+        if self.strict && warnings > 0 {
+            return Err(anyhow!("{warnings} warning(s), and --strict was given"));
+        }
+
+        if self.check_only {
+            println!(
+                "{} {} would build, with {warnings} warning(s)",
+                "ok:".green().bold(),
+                bundle.event_external_id
+            );
+            return Ok(());
+        }
+
+        self.write(&bundle)?;
+        Ok(())
+    }
+
+    /// The built-in templates, with any `.hbs` file in `--templates-dir` on top.
+    fn templates(&self) -> Result<TemplateSet> {
+        let Some(directory) = &self.templates_dir else {
+            return TemplateSet::builtin().map_err(problem_error);
+        };
+        if !directory.is_dir() {
+            return Err(anyhow!(
+                "templates directory not found: {}",
+                directory.display()
+            ));
+        }
+
+        let mut sources: Vec<(String, String)> = Vec::new();
+        for name in ENTITY_TEMPLATES {
+            let candidate = directory.join(format!("{name}.hbs"));
+            if candidate.is_file() {
+                let source = fs::read_to_string(&candidate)
+                    .with_context(|| format!("could not read {}", candidate.display()))?;
+                sources.push(((*name).to_string(), source));
+            }
+        }
+
+        // Anything else in the directory is a name nothing renders, which is
+        // almost always a typo. Saying so beats rendering the built-in and
+        // leaving its author staring at output that ignores their edit.
+        for entry in fs::read_dir(directory)
+            .with_context(|| format!("could not list {}", directory.display()))?
+        {
+            let path = entry?.path();
+            let is_template = path.extension().is_some_and(|extension| extension == "hbs");
+            let is_known = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| ENTITY_TEMPLATES.contains(&stem));
+            if is_template && !is_known {
+                println!(
+                    "{} {} is not an entity template and was ignored. Expected \
+                     one of: {}.",
+                    "warning:".yellow(),
+                    path.display(),
+                    ENTITY_TEMPLATES.join(", ")
+                );
+            }
+        }
+
+        let borrowed: Vec<(&str, &str)> = sources
+            .iter()
+            .map(|(name, source)| (name.as_str(), source.as_str()))
+            .collect();
+        TemplateSet::with_overrides(&borrowed).map_err(problem_error)
+    }
+
+    /// Read a base export from a `.json` file or an export `.zip`.
+    fn base_export(&self) -> Result<Option<serde_json::Value>> {
+        let Some(path) = &self.base_export else {
+            return Ok(None);
+        };
+        let bytes = fs::read(path).with_context(|| format!("could not read {}", path.display()))?;
+
+        let is_zip = path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"));
+        if !is_zip {
+            return serde_json::from_slice(&bytes)
+                .with_context(|| format!("{} is not valid JSON", path.display()))
+                .map(Some);
+        }
+
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+            .with_context(|| format!("{} is not a zip", path.display()))?;
+        let member = (0..zip.len())
+            .map(|index| zip.by_index(index).map(|file| file.name().to_string()))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .find(|name| {
+                let base = name.rsplit('/').next().unwrap_or(name);
+                base.starts_with("export_election_event") && base.ends_with(".json")
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "{} has no export_election_event*.json member; is it an \
+                     election event export?",
+                    path.display()
+                )
+            })?;
+
+        let file = zip.by_name(&member)?;
+        serde_json::from_reader(file)
+            .with_context(|| format!("{member} is not valid JSON"))
+            .map(Some)
+    }
+
+    /// Write the bundle, the archive, and everything that travels beside it.
+    fn write(&self, bundle: &Bundle) -> Result<()> {
+        let layout = archive::layout(bundle);
+        let directory = self.out_dir.join(&bundle.slug);
+
+        // Replaced rather than merged into: a stale member left over from a
+        // previous run is a file someone would upload.
+        if directory.exists() {
+            fs::remove_dir_all(&directory)
+                .with_context(|| format!("could not clear {}", directory.display()))?;
+        }
+        fs::create_dir_all(&directory)
+            .with_context(|| format!("could not create {}", directory.display()))?;
+
+        for artifact in layout.importable.iter().chain(layout.auxiliary.iter()) {
+            write_artifact(&directory, &artifact.name, &artifact.bytes)?;
+        }
+
+        let archive_bytes = archive::zip(&layout.importable).map_err(problem_error)?;
+        let archive_path = directory.join(&layout.archive_name);
+        fs::write(&archive_path, &archive_bytes)
+            .with_context(|| format!("could not write {}", archive_path.display()))?;
+
+        println!(
+            "{} {}",
+            "built".green().bold(),
+            bundle.event_external_id.bold()
+        );
+        println!(
+            "  import this: {}",
+            archive_path.display().to_string().bold()
+        );
+        for artifact in &layout.importable {
+            println!("    {}", artifact.name);
+        }
+        if !layout.auxiliary.is_empty() {
+            println!("  beside it, not part of the import:");
+            for artifact in &layout.auxiliary {
+                println!("    {}", directory.join(&artifact.name).display());
+            }
+        }
+        if bundle.admin_users.is_some() {
+            println!(
+                "  {} admin_users.csv may carry clear-text passwords. It is a \
+                 secret, not a deliverable.",
+                "warning:".yellow()
+            );
+        }
+        Ok(())
+    }
+}
+
+fn write_artifact(directory: &Path, name: &str, bytes: &[u8]) -> Result<()> {
+    let path = directory.join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("could not create {}", parent.display()))?;
+    }
+    fs::write(&path, bytes).with_context(|| format!("could not write {}", path.display()))
+}
+
+/// Print every problem, errors first, in the order they were found.
+fn report_problems(report: &ValidationReport) {
+    for problem in report.errors() {
+        eprintln!(
+            "{} {}: {}",
+            "error:".red().bold(),
+            problem.path,
+            problem.message
+        );
+    }
+    for problem in report.warnings() {
+        eprintln!(
+            "{} {}: {}",
+            "warning:".yellow().bold(),
+            problem.path,
+            problem.message
+        );
+    }
+}
+
+/// A single problem as an error, for the paths that fail before there is a report.
+fn problem_error(problem: Problem) -> anyhow::Error {
+    let label = match problem.severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    };
+    anyhow!("{label}: {}: {}", problem.path, problem.message)
+}

--- a/packages/step-cli/src/commands/build_election_event.rs
+++ b/packages/step-cli/src/commands/build_election_event.rs
@@ -37,8 +37,8 @@ pub struct BuildElectionEvent {
 
     /// Directory to write the bundle into, under a subdirectory named after the
     /// event
-    #[arg(short = 'o', long, value_name = "OUT_DIR", default_value = "out")]
-    out_dir: PathBuf,
+    #[arg(short = 'o', long, value_name = "OUT", default_value = "out")]
+    out: PathBuf,
 
     /// Tenant id to write into the file
     ///
@@ -78,8 +78,19 @@ pub struct BuildElectionEvent {
     strict: bool,
 
     /// Validate and report, writing nothing
+    ///
+    /// Named after the importer's own `check_only`, which does the same thing on
+    /// the server.
     #[arg(long)]
     check_only: bool,
+
+    /// Timestamp for every generated entity
+    ///
+    /// Fixed by default so regenerating an unchanged workbook produces
+    /// byte-identical output. The importer overwrites these, so this only exists
+    /// to make a rebuild diffable.
+    #[arg(long, value_name = "CREATED_AT")]
+    created_at: Option<String>,
 }
 
 impl BuildElectionEvent {
@@ -128,7 +139,7 @@ impl BuildElectionEvent {
             tenant_id: self.tenant_id.clone(),
             base_export: self.base_export()?,
             slug: self.slug.clone(),
-            created_at: None,
+            created_at: self.created_at.clone(),
             auth_preset: self.auth_preset.clone(),
         };
 
@@ -277,7 +288,7 @@ impl BuildElectionEvent {
     /// Write the bundle, the archive, and everything that travels beside it.
     fn write(&self, bundle: &Bundle) -> Result<()> {
         let layout = archive::layout(bundle);
-        let directory = self.out_dir.join(&bundle.slug);
+        let directory = self.out.join(&bundle.slug);
 
         // Replaced rather than merged into: a stale member left over from a
         // previous run is a file someone would upload.

--- a/packages/step-cli/src/commands/mod.rs
+++ b/packages/step-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+pub mod build_election_event;
 pub mod cast_vote;
 pub mod complete_key_ceremony;
 pub mod configure;

--- a/packages/step-cli/src/main.rs
+++ b/packages/step-cli/src/main.rs
@@ -28,6 +28,7 @@ enum MainCommand {
 
 #[derive(Subcommand)]
 enum StepCommands {
+    BuildElectionEvent(commands::build_election_event::BuildElectionEvent),
     Config(commands::configure::Config),
     CreateElectionEvent(commands::create_election_event::CreateElectionEventCLI),
     CreateElection(commands::create_election::CreateElection),
@@ -71,6 +72,7 @@ fn main() {
 
     match &cli.command {
         MainCommand::Step(step_cmd) => match step_cmd {
+            StepCommands::BuildElectionEvent(cmd) => cmd.run(),
             StepCommands::Config(cmd) => cmd.run(),
             StepCommands::CreateElectionEvent(create_event) => create_event.run(),
             StepCommands::CreateElection(create_election) => create_election.run(),


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**Stacked on https://github.com/sequentech/step/pull/2978.** Base branch is
`feat/meta-12769-archive/main`, so this diff shows only what is added on top.

janitor, folded into `step-cli`:

```bash
step-cli step build-election-event -w workbook.xlsx -o out --auth-preset none
```

Every decision it makes lives in `sequent_core::election_config` — the same module
windmill validates with and the browser-side tools will run. The command itself only
talks to the filesystem and to whoever ran it. Reading a workbook, building,
validating and laying out the files are all pure functions in the core, which is why
nothing is written until every one of them has succeeded: a workbook with a dangling
reference leaves no half-written output directory behind.

## It produces the same bundle the Python does

Run against the real SEIU1000 workbook and diffed against janitor's output for the
same file, with the same `--tenant-id`:

| | |
|---|---|
| `export_voters-….csv` | **byte-identical** |
| `export_scheduled_events-….csv` | **byte-identical** |
| `export_reports-….csv` | **byte-identical** |
| `export_permissions-….csv` | **byte-identical** |
| `admin_users.csv` | **byte-identical** |
| `templates/*.hbs`, `templates.json` | **byte-identical** |
| `keycloak_admin_realm_patch.json` | **byte-identical** |
| `export_election_event-….json` | **identical when parsed** (2-space indent instead of 1) |
| `keycloak_event_realm_patch.json` | same keys, same patch body |

The event id and the derived tenant id match the Python's to the character, which is
what the pinned `ids` tests predicted. Every warning matches too, including the
`dlc-officers-dburs` permission label that made every election invisible on the first
real import.

## The diff caught a real bug

`admin_users.csv` did *not* match at first: an international phone number arrived as
`33645312453` instead of `+33645312453`.

The workbook computes contact details with a formula, so the cell is `t="str"` with a
cached string result. calamine 0.26 tried a float parse on that string first — and
Rust's float parser accepts a leading `+` — so the number lost its country prefix,
silently. `Utils.sendCode` would then have texted a number with no country code.

Fixed by bumping calamine to **0.36**, where `t="str"` returns a string
unconditionally. Two tests pin it: one for the leading plus, one for a formula result
that is text but looks numeric (a member id of `007`).

This is the class of defect the whole unification exists to catch, and it was caught
by having two implementations to compare rather than by reading the code.

## What the command does

- `--check-only` validates and reports, writing nothing.
- `--strict` refuses to write when there are warnings. Worth having in CI: a warning
  means the bundle imports and the configuration probably is not what its author
  meant.
- `--base-export` takes a `.json` or an export `.zip`, reading
  `export_election_event*.json` out of the archive.
- `--templates-dir` overrides any of the eight entity templates, and says which it
  took. A `.hbs` file whose name is not an entity template is reported rather than
  ignored, because that is a typo and rendering the builtin instead would leave its
  author staring at output that ignores their edit.
- `--auth-preset none` builds without configuring authentication — which the SEIU
  workbook needs, since it declares SAML and leaves the IdP metadata URL blank
  pending the client's identity provider.
- Unread sheets are named, so a misspelled tab does not silently drop its entities.
- The output distinguishes what to import from what travels beside it, and says
  outright that `admin_users.csv` is a secret.

Validation runs twice on purpose, and they are different questions: the builder
reports what is wrong with the *workbook*, in sheet-and-row terms an author can act
on, and `validate()` then reports what would be wrong with the *bundle* — the same
check windmill runs before importing.

## Verified

- `cargo test -p sequent-core --lib --features election_config_xlsx,election_config_archive election_config` — **331 passed**, 0 failed (328 before, 3 new).
- `cargo check` clean for `sequent-core` (each feature gate), `windmill` and `step-cli`.
- No warnings from the new command; `cargo fmt --check` and `cargo clippy` clean.
- End-to-end against the real SEIU1000 workbook, as above. The workbook and its output
  were kept out of the repository and deleted from the build host afterwards.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

```
built seiu1000-leadership-2027
  import this: out/seiu1000-leadership-2027/seiu1000-leadership-2027.zip
    export_election_event-e8e06504-….json
    export_voters-e8e06504-….csv
    export_scheduled_events-e8e06504-….csv
    export_reports-e8e06504-….csv
  beside it, not part of the import:
    out/seiu1000-leadership-2027/admin_users.csv
    out/seiu1000-leadership-2027/export_permissions-….csv
    out/seiu1000-leadership-2027/templates/…
    out/seiu1000-leadership-2027/keycloak_event_realm_patch.json
  warning: admin_users.csv may carry clear-text passwords. It is a secret, not a deliverable.
```

_A screenshot of the imported event follows once this is run against a live
environment._
