### PR TITLE
✨ One definition of the import bundle, and the importer validates against it

### DIFF
--- a/packages/sequent-core/examples/validate_bundle.rs
+++ b/packages/sequent-core/examples/validate_bundle.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Validate an election event bundle from a file.
+//!
+//! `cargo run -p sequent-core --features default_features --example validate_bundle -- <path>`
+//!
+//! A thin harness for checking a real export against the shared rules; the same
+//! call step-cli and the browser make.
+
+use sequent_core::election_config::{validate, ImportElectionEventSchema};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args()
+        .nth(1)
+        .ok_or("usage: validate_bundle <path>")?;
+    let text = std::fs::read_to_string(&path)?;
+    let bundle: ImportElectionEventSchema = serde_json::from_str(&text)?;
+
+    let report = validate(&bundle);
+    print!("{report}");
+    println!(
+        "{} error(s), {} warning(s)",
+        report.errors().count(),
+        report.warnings().count()
+    );
+    if report.has_errors() {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -24,5 +24,7 @@
 //! and <https://github.com/sequentech/meta/issues/12769>.
 
 pub mod report;
+pub mod schema;
 
 pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};
+pub use schema::ImportElectionEventSchema;

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The election event import bundle: what it contains, and whether it is valid.
+//!
+//! This is the single definition of the format shared by everything that
+//! produces or consumes an import — windmill's importer on the server, and the
+//! configuration tools in `beyond/packages` in the browser.
+//!
+//! It lives here rather than in `beyond` because the dependency between the
+//! repositories runs one way: `beyond` is a git submodule of step and
+//! path-depends on this crate, so step cannot depend on `beyond`. Anything
+//! windmill must use has to be here. `sequent-core` also already compiles to
+//! WASM and is already vendored into the front ends as a package, so both
+//! consumers reach this module through paths that already carry production
+//! code.
+//!
+//! Everything in this module must stay **pure** — no database, no IO, no
+//! clock — or it cannot run in a browser, and the browser is where a delivery
+//! engineer wants the answer.
+//!
+//! See `beyond/docs/docusaurus/docs/engineering/election-config-architecture.md`
+//! and <https://github.com/sequentech/meta/issues/12769>.
+
+pub mod report;
+
+pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -23,8 +23,15 @@
 //! See `beyond/docs/docusaurus/docs/engineering/election-config-architecture.md`
 //! and <https://github.com/sequentech/meta/issues/12769>.
 
+pub mod problem;
 pub mod report;
 pub mod schema;
+pub mod validate;
 
+#[cfg(test)]
+mod validate_tests;
+
+pub use problem::{Code, Problem, Report as ValidationReport, Severity};
 pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};
 pub use schema::ImportElectionEventSchema;
+pub use validate::validate;

--- a/packages/sequent-core/src/election_config/problem.rs
+++ b/packages/sequent-core/src/election_config/problem.rs
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What validation reports.
+//!
+//! Structured rather than a formatted string, because the same problem has to be
+//! rendered three ways: a line in `step-cli`'s output, a row in a browser's
+//! problem list, and an error from a server-side import. Each wants the pieces
+//! arranged differently, and only the caller knows which.
+//!
+//! Every problem carries a machine-readable [`Code`] so a front end can group,
+//! translate or link them without matching on English text.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Whether a problem stops an import or merely deserves saying out loud.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    /// The bundle will not import, or will import into something broken.
+    Error,
+    /// The bundle imports, but something about it is very likely a mistake.
+    ///
+    /// A warning is not a lesser error: it is a statement that this file is
+    /// self-consistent but probably not what its author meant. An election with
+    /// no voting window imports perfectly and then never opens.
+    Warning,
+}
+
+/// What kind of problem this is.
+///
+/// Stable identifiers: a front end may match on these, so renaming one is a
+/// breaking change in a way that rewording a message is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Code {
+    /// A required field is absent or empty.
+    MissingField,
+    /// A value is not one the platform accepts.
+    InvalidValue,
+    /// A reference points at something not in the bundle.
+    DanglingReference,
+    /// Two entities share an identifier.
+    DuplicateId,
+    /// The area parent chain loops.
+    AreaCycle,
+    /// A contest's vote counts contradict each other or its candidate list.
+    ContestArithmetic,
+    /// `voting_type` and `counting_algorithm` disagree.
+    TallyMismatch,
+    /// Something that would be on a ballot is not, or vice versa.
+    BallotCoverage,
+    /// An entity is scoped to a permission label, which hides it.
+    PermissionLabel,
+    /// An election has no scheduled voting window.
+    MissingSchedule,
+}
+
+/// One thing wrong with a bundle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Problem {
+    pub severity: Severity,
+    pub code: Code,
+
+    /// Where in the bundle, as a dotted path — `contests[2].max_votes`.
+    ///
+    /// Indexed rather than named because a bundle is what is being validated;
+    /// the tool that produced it maps this back to a wizard step or a
+    /// spreadsheet cell, which only it can do.
+    pub path: String,
+
+    /// What is wrong, in one sentence, in English.
+    pub message: String,
+
+    /// The entity's `external_id` where it has one.
+    ///
+    /// The bundle's UUIDs are regenerated on import and mean nothing to whoever
+    /// has to fix the source, whereas an `external_id` is what they typed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_id: Option<String>,
+}
+
+impl Problem {
+    pub fn error(
+        code: Code,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Problem {
+            severity: Severity::Error,
+            code,
+            path: path.into(),
+            message: message.into(),
+            external_id: None,
+        }
+    }
+
+    pub fn warning(
+        code: Code,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Problem {
+            severity: Severity::Warning,
+            code,
+            path: path.into(),
+            message: message.into(),
+            external_id: None,
+        }
+    }
+
+    pub fn about(mut self, external_id: Option<&str>) -> Self {
+        self.external_id = external_id.map(str::to_string);
+        self
+    }
+}
+
+impl fmt::Display for Problem {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self.severity {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+        };
+        write!(formatter, "{label}: {}: {}", self.path, self.message)
+    }
+}
+
+/// Everything validation found, in the order it found it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Report {
+    pub problems: Vec<Problem>,
+}
+
+impl Report {
+    pub fn push(&mut self, problem: Problem) {
+        self.problems.push(problem);
+    }
+
+    /// Whether the bundle should be refused.
+    pub fn has_errors(&self) -> bool {
+        self.problems
+            .iter()
+            .any(|problem| problem.severity == Severity::Error)
+    }
+
+    pub fn errors(&self) -> impl Iterator<Item = &Problem> {
+        self.iter_severity(Severity::Error)
+    }
+
+    pub fn warnings(&self) -> impl Iterator<Item = &Problem> {
+        self.iter_severity(Severity::Warning)
+    }
+
+    fn iter_severity(
+        &self,
+        severity: Severity,
+    ) -> impl Iterator<Item = &Problem> {
+        self.problems
+            .iter()
+            .filter(move |problem| problem.severity == severity)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.problems.is_empty()
+    }
+}
+
+impl fmt::Display for Report {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for problem in &self.problems {
+            writeln!(formatter, "  {problem}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_report_with_only_warnings_is_importable() {
+        // The distinction is the point: a warning must not block a build.
+        let mut report = Report::default();
+        report.push(Problem::warning(
+            Code::MissingSchedule,
+            "elections[0]",
+            "no window",
+        ));
+        assert!(!report.has_errors());
+        assert_eq!(report.warnings().count(), 1);
+        assert_eq!(report.errors().count(), 0);
+    }
+
+    #[test]
+    fn one_error_condemns_the_report() {
+        let mut report = Report::default();
+        report.push(Problem::warning(Code::MissingSchedule, "a", "b"));
+        report.push(Problem::error(Code::MissingField, "c", "d"));
+        assert!(report.has_errors());
+    }
+
+    #[test]
+    fn a_problem_reads_as_a_line() {
+        let problem = Problem::error(
+            Code::DanglingReference,
+            "candidates[3].contest_id",
+            "no contest with that id is in the bundle",
+        );
+        assert_eq!(
+            problem.to_string(),
+            "error: candidates[3].contest_id: no contest with that id is in the bundle"
+        );
+    }
+
+    #[test]
+    fn the_code_survives_serialization() {
+        // A front end matches on this rather than on the English.
+        let problem = Problem::error(Code::TallyMismatch, "p", "m")
+            .about(Some("president"));
+        let json = serde_json::to_value(&problem).unwrap();
+        assert_eq!(json["code"], "tally_mismatch");
+        assert_eq!(json["severity"], "error");
+        assert_eq!(json["external_id"], "president");
+    }
+
+    #[test]
+    fn an_absent_external_id_is_omitted_rather_than_null() {
+        let problem = Problem::error(Code::MissingField, "p", "m");
+        let json = serde_json::to_value(&problem).unwrap();
+        assert!(json.get("external_id").is_none());
+    }
+}

--- a/packages/sequent-core/src/election_config/report.rs
+++ b/packages/sequent-core/src/election_config/report.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Report definitions, as they appear in an import bundle.
+//!
+//! Moved here from `windmill::postgres::reports` and
+//! `windmill::services::reports::template_renderer` so that the tools which
+//! *write* an import describe reports the same way the importer reads them.
+//! windmill re-exports these, so its own call sites are unchanged.
+//!
+//! The database mapping (`ReportWrapper`, `TryFrom<Row>`) deliberately stays in
+//! windmill: it needs `tokio_postgres`, which has no place in a module that has
+//! to compile to WASM.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumString, IntoStaticStr};
+
+/// How a generated report document is protected.
+///
+/// Serialized `snake_case`. There are exactly two: a report is either readable
+/// or encrypted with a password configured alongside it.
+#[allow(non_camel_case_types)]
+#[derive(
+    Display,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    EnumString,
+    IntoStaticStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum EReportEncryption {
+    Unencrypted,
+    ConfiguredPassword,
+}
+
+/// Schedule for a report that regenerates itself and mails the result.
+///
+/// Every field defaults, because a report without a cron config is the normal
+/// case and an absent key must not fail deserialization.
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone, Default)]
+pub struct ReportCronConfig {
+    #[serde(default)]
+    pub is_active: bool,
+    #[serde(default)]
+    pub last_document_produced: Option<String>,
+    #[serde(default)]
+    pub cron_expression: String,
+    #[serde(default)]
+    pub email_recipients: Vec<String>,
+    #[serde(default)]
+    pub executer_username: String,
+}
+
+/// One report definition.
+///
+/// `permission_label` is a list here, unlike `Election::permission_label`, which
+/// is a single string. Both are matched against the administrator's
+/// `permission_labels` attribute, and an entity carrying a label nobody holds is
+/// invisible in the Admin Portal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Report {
+    pub id: String,
+    pub election_event_id: String,
+    pub tenant_id: String,
+    pub election_id: Option<String>,
+    pub report_type: String,
+    pub template_alias: Option<String>,
+    pub encryption_policy: EReportEncryption,
+    pub cron_config: Option<ReportCronConfig>,
+    pub created_at: DateTime<Utc>,
+    pub permission_label: Option<Vec<String>>,
+}
+
+/// The kinds of report the platform can generate.
+///
+/// `Report::report_type` is a `String` rather than this enum because the column
+/// is free text in the database; this is the set a writer should choose from.
+#[allow(non_camel_case_types)]
+#[derive(
+    Display, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, EnumString,
+)]
+pub enum ReportType {
+    INITIALIZATION_REPORT,
+    ELECTORAL_RESULTS,
+    BALLOT_IMAGES,
+    BALLOT_RECEIPT,
+    ACTIVITY_LOGS,
+    MANUAL_VERIFICATION,
+    PARTICIPATION_REPORT,
+    CREDENTIALS,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn encryption_policy_serializes_snake_case() {
+        // The importer reads this straight out of a CSV column, so the wire form
+        // is part of the file format rather than an implementation detail.
+        assert_eq!(
+            serde_json::to_string(&EReportEncryption::ConfiguredPassword)
+                .unwrap(),
+            "\"configured_password\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EReportEncryption::Unencrypted).unwrap(),
+            "\"unencrypted\""
+        );
+    }
+
+    #[test]
+    fn encryption_policy_parses_from_the_csv_spelling() {
+        assert_eq!(
+            EReportEncryption::from_str("configured_password").unwrap(),
+            EReportEncryption::ConfiguredPassword
+        );
+        assert!(EReportEncryption::from_str("generated_password").is_err());
+    }
+
+    #[test]
+    fn cron_config_tolerates_an_empty_object() {
+        // An absent key must not fail deserialization: most reports have no cron.
+        let parsed: ReportCronConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(parsed, ReportCronConfig::default());
+        assert!(!parsed.is_active);
+    }
+
+    #[test]
+    fn cron_config_round_trips_the_shape_the_workbook_writes() {
+        let source = r#"{"is_active":true,"last_document_produced":null,
+            "cron_expression":"46 0 * * *","email_recipients":["ops@example.org"],
+            "executer_username":"admin"}"#;
+        let parsed: ReportCronConfig = serde_json::from_str(source).unwrap();
+        assert!(parsed.is_active);
+        assert_eq!(parsed.cron_expression, "46 0 * * *");
+        assert_eq!(parsed.email_recipients, vec!["ops@example.org"]);
+    }
+
+    #[test]
+    fn every_report_type_round_trips() {
+        for name in [
+            "INITIALIZATION_REPORT",
+            "ELECTORAL_RESULTS",
+            "BALLOT_IMAGES",
+            "BALLOT_RECEIPT",
+            "ACTIVITY_LOGS",
+            "MANUAL_VERIFICATION",
+            "PARTICIPATION_REPORT",
+            "CREDENTIALS",
+        ] {
+            let parsed = ReportType::from_str(name)
+                .unwrap_or_else(|_| panic!("{name} should be a ReportType"));
+            assert_eq!(parsed.to_string(), name);
+        }
+    }
+
+    #[test]
+    fn permission_label_is_a_list() {
+        // Election::permission_label is a single string; getting these the wrong
+        // way round fails deserialization at import time.
+        let source = r#"{"id":"a","election_event_id":"b","tenant_id":"c",
+            "election_id":null,"report_type":"ACTIVITY_LOGS","template_alias":null,
+            "encryption_policy":"unencrypted","cron_config":null,
+            "created_at":"2026-01-01T00:00:00Z","permission_label":["x","y"]}"#;
+        let parsed: Report = serde_json::from_str(source).unwrap();
+        assert_eq!(parsed.permission_label, Some(vec!["x".into(), "y".into()]));
+    }
+}

--- a/packages/sequent-core/src/election_config/schema.rs
+++ b/packages/sequent-core/src/election_config/schema.rs
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The election event import bundle.
+//!
+//! This is the shape of `export_election_event-<uuid>.json`, and the single
+//! definition of it. It was previously declared in
+//! `windmill::services::import::import_election_event`, which meant every tool
+//! that *wrote* an import had to reproduce it — janitor in Handlebars templates,
+//! the Election Architect in a hand-built TypeScript object — and each
+//! reproduction drifted.
+//!
+//! windmill re-exports this, so its own call sites are unchanged.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::types::hasura::core::{
+    Application, Area, AreaContest, Candidate, Contest, Election,
+    ElectionEvent, KeysCeremony,
+};
+use crate::types::scheduled_event::ScheduledEvent;
+use crate::util::version::HISTORICAL_DEFAULT_VERSION;
+
+use super::report::Report;
+
+/// Everything an election event import carries.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ImportElectionEventSchema {
+    /// The tenant the bundle was exported from.
+    ///
+    /// A `String` rather than a `Uuid` on purpose. Import replaces this value
+    /// with the tenant of the importing request regardless of what it says
+    /// (`replace_ids`: "always replace to ensure consistency"), so it is a
+    /// placeholder rather than a destination, and every consumer only ever
+    /// stringifies it.
+    ///
+    /// Keeping it a `String` also keeps `uuid` out of this module. That crate is
+    /// only enabled by the `keycloak` feature here, and pulling it into
+    /// `default_features` would put `getrandom` in the WASM build for no benefit.
+    /// Its format is checked by validation instead, which reports a readable
+    /// problem where a `Uuid` field would have produced an opaque serde error.
+    pub tenant_id: String,
+
+    /// The Keycloak realm, carried opaquely.
+    ///
+    /// Deliberately a `Value` and not a `RealmRepresentation`: that type comes
+    /// from the `keycloak` crate, which pulls `reqwest`, and this module has to
+    /// compile to WASM. Nothing is lost — serde round-trips it exactly, and
+    /// windmill deserializes it into the typed form where it actually talks to
+    /// Keycloak.
+    ///
+    /// Validating a realm needs a live Keycloak, so it is not something the
+    /// shared validation could check even if the type were available.
+    pub keycloak_event_realm: Option<Value>,
+
+    pub election_event: ElectionEvent,
+    pub elections: Vec<Election>,
+    pub contests: Vec<Contest>,
+    pub candidates: Vec<Candidate>,
+    pub areas: Vec<Area>,
+    pub area_contests: Vec<AreaContest>,
+
+    /// The voting window.
+    ///
+    /// Normally `None`: the importer reads scheduled events from the
+    /// `export_scheduled_events-<uuid>.csv` member of the zip, not from here.
+    pub scheduled_events: Option<Vec<ScheduledEvent>>,
+
+    /// Report definitions.
+    ///
+    /// Normally empty for the same reason: `insert_reports` is only ever called
+    /// from `process_reports_file`, so reports travel in
+    /// `export_reports-<uuid>.csv` and a populated array here is silently
+    /// dropped. The field is required by the format, so it must still be present.
+    pub reports: Vec<Report>,
+
+    pub keys_ceremonies: Option<Vec<KeysCeremony>>,
+    pub applications: Option<Vec<Application>>,
+
+    /// The platform version that wrote the bundle.
+    ///
+    /// Defaults to the first version that recorded one, so bundles predating the
+    /// field still import.
+    #[serde(default = "default_version")]
+    pub version: String,
+}
+
+fn default_version() -> String {
+    HISTORICAL_DEFAULT_VERSION.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The smallest bundle that deserializes. Every field here is one the format
+    /// requires; anything omitted below has a serde default.
+    const MINIMAL: &str = r#"{
+        "tenant_id": "9384db41-1b21-4b93-a6aa-edfc007136d8",
+        "keycloak_event_realm": null,
+        "election_event": {
+            "id": "11111111-1111-5111-8111-111111111111",
+            "tenant_id": "9384db41-1b21-4b93-a6aa-edfc007136d8",
+            "is_archived": false,
+            "encryption_protocol": "RSA256"
+        },
+        "elections": [],
+        "contests": [],
+        "candidates": [],
+        "areas": [],
+        "area_contests": [],
+        "scheduled_events": null,
+        "reports": [],
+        "keys_ceremonies": [],
+        "applications": []
+    }"#;
+
+    #[test]
+    fn a_minimal_bundle_deserializes() {
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(MINIMAL).unwrap();
+        assert_eq!(parsed.election_event.encryption_protocol, "RSA256");
+        assert!(parsed.keycloak_event_realm.is_none());
+    }
+
+    #[test]
+    fn a_missing_version_falls_back_to_the_historical_default() {
+        // Bundles written before the field existed must still import.
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(MINIMAL).unwrap();
+        assert_eq!(parsed.version, HISTORICAL_DEFAULT_VERSION);
+    }
+
+    #[test]
+    fn the_realm_round_trips_untouched() {
+        // Carried opaquely, so whatever the exporter wrote comes back byte for
+        // byte — including keys this crate has never heard of.
+        let source = MINIMAL.replace(
+            "\"keycloak_event_realm\": null",
+            r#""keycloak_event_realm": {"realm":"r","displayName":"D","somethingNew":[1,2]}"#,
+        );
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(&source).unwrap();
+        let realm = parsed.keycloak_event_realm.as_ref().unwrap();
+        assert_eq!(realm["displayName"], "D");
+        assert_eq!(realm["somethingNew"], serde_json::json!([1, 2]));
+
+        let round_tripped = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(&round_tripped["keycloak_event_realm"], realm);
+    }
+
+    #[test]
+    fn a_missing_required_field_is_rejected() {
+        // encryption_protocol is not Option, so its absence fails the whole file
+        // at parse time. This is the error the shared validation exists to
+        // pre-empt with something readable.
+        //
+        // Built by removing the key from the parsed tree rather than by editing
+        // the text: a string replacement that stops matching would silently pass
+        // this test instead of failing it.
+        let mut tree: serde_json::Value =
+            serde_json::from_str(MINIMAL).unwrap();
+        let removed = tree["election_event"]
+            .as_object_mut()
+            .unwrap()
+            .remove("encryption_protocol");
+        assert!(removed.is_some(), "the fixture should have had the field");
+
+        let parsed: Result<ImportElectionEventSchema, _> =
+            serde_json::from_value(tree);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn tenant_id_is_carried_as_written() {
+        // Import replaces it, so it is a placeholder; it must survive unaltered
+        // so that replace_ids can map it.
+        let parsed: ImportElectionEventSchema =
+            serde_json::from_str(MINIMAL).unwrap();
+        assert_eq!(parsed.tenant_id, "9384db41-1b21-4b93-a6aa-edfc007136d8");
+    }
+}

--- a/packages/sequent-core/src/election_config/validate.rs
+++ b/packages/sequent-core/src/election_config/validate.rs
@@ -1,0 +1,541 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Whether a bundle can be imported, and whether it should be.
+//!
+//! Pure: no database, no IO, no clock. That is what lets the same code answer in
+//! a browser before an upload and on the server before a transaction, and it is
+//! the constraint to keep in mind when adding a rule. Anything needing the
+//! database — does this tenant exist, is this area name already taken — belongs
+//! in windmill on top of this pass, not here.
+//!
+//! The rules come from two places: what the importer rejects, and what janitor
+//! learned the hard way. The second kind matters most. A bundle can satisfy every
+//! type in the schema and still be wrong in a way nobody notices until election
+//! day — a contest on no ballot, rankings counted by plurality, an election
+//! scoped to a permission label that no administrator holds. Those import
+//! cleanly and fail silently, so they are checked here.
+
+use std::collections::{HashMap, HashSet};
+
+use super::problem::{Code, Problem, Report};
+use super::schema::ImportElectionEventSchema;
+
+/// `CountingAlgType` in `crate::types::ceremonies`, by its serde rename.
+pub const COUNTING_ALGORITHMS: &[&str] = &[
+    "plurality-at-large",
+    "instant-runoff",
+    "borda-nauru",
+    "borda",
+    "borda-mas-madrid",
+    "pairwise-beta",
+    "desborda3",
+    "desborda2",
+    "desborda",
+    "cumulative",
+];
+
+/// The algorithms `CountingAlgType::is_preferential` returns true for.
+///
+/// The split is load-bearing rather than cosmetic: ballot encoding follows the
+/// algorithm, so a preferential contest counted by plurality imports cleanly and
+/// then reads the rankings a voter entered as unordered selections.
+pub const PREFERENTIAL_ALGORITHMS: &[&str] = &[
+    "instant-runoff",
+    "borda",
+    "borda-nauru",
+    "borda-mas-madrid",
+    "pairwise-beta",
+    "desborda",
+    "desborda2",
+    "desborda3",
+];
+
+/// `IVotingType` in the Admin Portal. Rust carries `voting_type` as a free-form
+/// `String`, so the portal's enum is the only authority on what it may hold.
+pub const VOTING_TYPES: &[&str] = &["preferential", "non-preferential"];
+
+/// Check a bundle and report everything wrong with it.
+///
+/// Never stops at the first problem: fixing a configuration one error per run is
+/// miserable, and the caller usually wants the whole list at once.
+pub fn validate(bundle: &ImportElectionEventSchema) -> Report {
+    let mut report = Report::default();
+
+    check_identity(bundle, &mut report);
+    check_references(bundle, &mut report);
+    check_area_tree(bundle, &mut report);
+    check_contests(bundle, &mut report);
+    check_ballot_coverage(bundle, &mut report);
+    check_permission_labels(bundle, &mut report);
+    check_unique_ids(bundle, &mut report);
+
+    report
+}
+
+fn check_identity(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    // The schema carries tenant_id as a String so the module stays WASM-safe;
+    // this is where the format check it lost comes back, as a readable problem
+    // rather than an opaque serde error.
+    if bundle.tenant_id.trim().is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "tenant_id",
+            "the bundle has no tenant id",
+        ));
+    } else if !looks_like_uuid(&bundle.tenant_id) {
+        report.push(Problem::error(
+            Code::InvalidValue,
+            "tenant_id",
+            format!("'{}' is not a UUID", bundle.tenant_id),
+        ));
+    }
+
+    let event = &bundle.election_event;
+    if event.id.trim().is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "election_event.id",
+            "the election event has no id",
+        ));
+    }
+    if event.encryption_protocol.trim().is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "election_event.encryption_protocol",
+            "the election event has no encryption protocol",
+        ));
+    }
+
+    if bundle.elections.is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "elections",
+            "an election event needs at least one election",
+        ));
+    }
+    if bundle.areas.is_empty() {
+        report.push(Problem::error(
+            Code::MissingField,
+            "areas",
+            "an election event needs at least one area; every voter belongs to one",
+        ));
+    }
+}
+
+fn check_references(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    let election_ids: HashSet<&str> =
+        bundle.elections.iter().map(|e| e.id.as_str()).collect();
+    let contest_ids: HashSet<&str> =
+        bundle.contests.iter().map(|c| c.id.as_str()).collect();
+    let area_ids: HashSet<&str> =
+        bundle.areas.iter().map(|a| a.id.as_str()).collect();
+
+    for (index, contest) in bundle.contests.iter().enumerate() {
+        if !election_ids.contains(contest.election_id.as_str()) {
+            report.push(
+                Problem::error(
+                    Code::DanglingReference,
+                    format!("contests[{index}].election_id"),
+                    "points at an election that is not in the bundle",
+                )
+                .about(contest.external_id.as_deref()),
+            );
+        }
+    }
+
+    for (index, candidate) in bundle.candidates.iter().enumerate() {
+        match candidate.contest_id.as_deref() {
+            None => report.push(
+                Problem::error(
+                    Code::MissingField,
+                    format!("candidates[{index}].contest_id"),
+                    "a candidate must belong to a contest",
+                )
+                .about(candidate.external_id.as_deref()),
+            ),
+            Some(id) if !contest_ids.contains(id) => report.push(
+                Problem::error(
+                    Code::DanglingReference,
+                    format!("candidates[{index}].contest_id"),
+                    "points at a contest that is not in the bundle",
+                )
+                .about(candidate.external_id.as_deref()),
+            ),
+            Some(_) => {}
+        }
+    }
+
+    for (index, link) in bundle.area_contests.iter().enumerate() {
+        if !area_ids.contains(link.area_id.as_str()) {
+            report.push(Problem::error(
+                Code::DanglingReference,
+                format!("area_contests[{index}].area_id"),
+                "points at an area that is not in the bundle",
+            ));
+        }
+        if !contest_ids.contains(link.contest_id.as_str()) {
+            report.push(Problem::error(
+                Code::DanglingReference,
+                format!("area_contests[{index}].contest_id"),
+                "points at a contest that is not in the bundle",
+            ));
+        }
+    }
+}
+
+fn check_area_tree(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    let parents: HashMap<&str, Option<&str>> = bundle
+        .areas
+        .iter()
+        .map(|area| (area.id.as_str(), area.parent_id.as_deref()))
+        .collect();
+
+    for (index, area) in bundle.areas.iter().enumerate() {
+        let Some(parent) = area.parent_id.as_deref() else {
+            continue;
+        };
+
+        if !parents.contains_key(parent) {
+            report.push(Problem::error(
+                Code::DanglingReference,
+                format!("areas[{index}].parent_id"),
+                "points at a parent area that is not in the bundle",
+            ));
+            continue;
+        }
+
+        // An infinite tree hangs the Admin Portal rather than failing the import.
+        let mut seen: HashSet<&str> = HashSet::from([area.id.as_str()]);
+        let mut cursor = Some(parent);
+        while let Some(current) = cursor {
+            if !seen.insert(current) {
+                report.push(Problem::error(
+                    Code::AreaCycle,
+                    format!("areas[{index}].parent_id"),
+                    format!(
+                        "area '{}' is part of a parent cycle",
+                        area.name.as_deref().unwrap_or(&area.id)
+                    ),
+                ));
+                break;
+            }
+            cursor = parents.get(current).copied().flatten();
+        }
+    }
+}
+
+fn check_contests(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    let mut candidates_per_contest: HashMap<&str, usize> = HashMap::new();
+    for candidate in &bundle.candidates {
+        if let Some(contest_id) = candidate.contest_id.as_deref() {
+            *candidates_per_contest.entry(contest_id).or_insert(0) += 1;
+        }
+    }
+
+    for (index, contest) in bundle.contests.iter().enumerate() {
+        let path = |field: &str| format!("contests[{index}].{field}");
+        let about = contest.external_id.as_deref();
+
+        let min_votes = contest.min_votes;
+        let max_votes = contest.max_votes;
+        let winners = contest.winning_candidates_num;
+
+        for (field, value) in [
+            ("min_votes", min_votes),
+            ("max_votes", max_votes),
+            ("winning_candidates_num", winners),
+        ] {
+            if value.is_none() {
+                report.push(
+                    Problem::error(
+                        Code::MissingField,
+                        path(field),
+                        format!("a contest needs {field}"),
+                    )
+                    .about(about),
+                );
+            }
+        }
+
+        if let (Some(min), Some(max)) = (min_votes, max_votes) {
+            if min > max {
+                report.push(
+                    Problem::error(
+                        Code::ContestArithmetic,
+                        path("min_votes"),
+                        format!("min_votes {min} is above max_votes {max}"),
+                    )
+                    .about(about),
+                );
+            }
+        }
+
+        let voting_type = contest.voting_type.as_deref();
+        match voting_type {
+            Some(value) if VOTING_TYPES.contains(&value) => {}
+            other => report.push(
+                Problem::error(
+                    Code::InvalidValue,
+                    path("voting_type"),
+                    format!(
+                        "{} is not a voting type; expected one of {}",
+                        other
+                            .map(|v| format!("'{v}'"))
+                            .unwrap_or("nothing".into()),
+                        VOTING_TYPES.join(", ")
+                    ),
+                )
+                .about(about),
+            ),
+        }
+
+        let algorithm = contest.counting_algorithm.as_deref();
+        match algorithm {
+            Some(value) if COUNTING_ALGORITHMS.contains(&value) => {
+                let preferential = PREFERENTIAL_ALGORITHMS.contains(&value);
+                match voting_type {
+                    Some("preferential") if !preferential => report.push(
+                        Problem::error(
+                            Code::TallyMismatch,
+                            path("counting_algorithm"),
+                            format!(
+                                "a preferential contest counted by '{value}', which \
+                                 ignores rankings"
+                            ),
+                        )
+                        .about(about),
+                    ),
+                    Some("non-preferential") if preferential => report.push(
+                        Problem::error(
+                            Code::TallyMismatch,
+                            path("counting_algorithm"),
+                            format!(
+                                "a non-preferential contest counted by '{value}', \
+                                 which needs ranked ballots"
+                            ),
+                        )
+                        .about(about),
+                    ),
+                    _ => {}
+                }
+            }
+            other => report.push(
+                Problem::error(
+                    Code::InvalidValue,
+                    path("counting_algorithm"),
+                    format!(
+                        "{} is not a counting algorithm; expected one of {}",
+                        other
+                            .map(|v| format!("'{v}'"))
+                            .unwrap_or("nothing".into()),
+                        COUNTING_ALGORITHMS.join(", ")
+                    ),
+                )
+                .about(about),
+            ),
+        }
+
+        let available = candidates_per_contest
+            .get(contest.id.as_str())
+            .copied()
+            .unwrap_or(0);
+        if available == 0 {
+            report.push(
+                Problem::error(
+                    Code::BallotCoverage,
+                    path("id"),
+                    "the contest has no candidates",
+                )
+                .about(about),
+            );
+        } else {
+            if let Some(winners) = winners {
+                if winners > available as i64 {
+                    report.push(
+                        Problem::error(
+                            Code::ContestArithmetic,
+                            path("winning_candidates_num"),
+                            format!(
+                                "elects {winners} of {available} candidates"
+                            ),
+                        )
+                        .about(about),
+                    );
+                }
+            }
+            if let Some(max) = max_votes {
+                if max > available as i64 {
+                    report.push(
+                        Problem::error(
+                            Code::ContestArithmetic,
+                            path("max_votes"),
+                            format!("allows {max} selections among {available} candidates"),
+                        )
+                        .about(about),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn check_ballot_coverage(
+    bundle: &ImportElectionEventSchema,
+    report: &mut Report,
+) {
+    // Neither of these breaks the import. Both mean somebody's vote is missing on
+    // election day, which is the most expensive time to find out.
+    let linked_contests: HashSet<&str> = bundle
+        .area_contests
+        .iter()
+        .map(|link| link.contest_id.as_str())
+        .collect();
+    let linked_areas: HashSet<&str> = bundle
+        .area_contests
+        .iter()
+        .map(|link| link.area_id.as_str())
+        .collect();
+    let parents: HashSet<&str> = bundle
+        .areas
+        .iter()
+        .filter_map(|area| area.parent_id.as_deref())
+        .collect();
+
+    for (index, contest) in bundle.contests.iter().enumerate() {
+        if !linked_contests.contains(contest.id.as_str()) {
+            report.push(
+                Problem::error(
+                    Code::BallotCoverage,
+                    format!("contests[{index}]"),
+                    "appears on no area's ballot, so nobody can vote in it",
+                )
+                .about(contest.external_id.as_deref()),
+            );
+        }
+    }
+
+    for (index, area) in bundle.areas.iter().enumerate() {
+        // A parent area is a grouping; only leaf areas carry a ballot.
+        if linked_areas.contains(area.id.as_str())
+            || parents.contains(area.id.as_str())
+        {
+            continue;
+        }
+        report.push(Problem::error(
+            Code::BallotCoverage,
+            format!("areas[{index}]"),
+            format!(
+                "area '{}' has no contests and is not a parent of another area, so \
+                 its voters would see an empty ballot",
+                area.name.as_deref().unwrap_or(&area.id)
+            ),
+        ));
+    }
+}
+
+fn check_permission_labels(
+    bundle: &ImportElectionEventSchema,
+    report: &mut Report,
+) {
+    // Hasura filters election and report on
+    //   permission_label IS NULL OR permission_label IN X-Hasura-Permission-Labels
+    // so an entity carrying a label is invisible to every administrator who does
+    // not hold it — including whoever runs the import. The bundle cannot know who
+    // holds what, so this is a warning naming the label rather than a refusal.
+    let mut labels: Vec<String> = Vec::new();
+
+    for election in &bundle.elections {
+        if let Some(label) = election.permission_label.as_deref() {
+            if !label.trim().is_empty()
+                && !labels.iter().any(|seen| seen == label)
+            {
+                labels.push(label.to_string());
+            }
+        }
+    }
+    for report_definition in &bundle.reports {
+        for label in report_definition.permission_label.iter().flatten() {
+            if !label.trim().is_empty()
+                && !labels.iter().any(|seen| seen == label)
+            {
+                labels.push(label.clone());
+            }
+        }
+    }
+
+    if !labels.is_empty() {
+        report.push(Problem::warning(
+            Code::PermissionLabel,
+            "elections[].permission_label",
+            format!(
+                "permission labels in use: {}. Anything carrying a label is hidden \
+                 from every administrator without it, so whoever imports this needs \
+                 one of them on their own 'permission_labels' attribute or the Admin \
+                 Portal will show them an empty list.",
+                labels.join(", ")
+            ),
+        ));
+    }
+}
+
+fn check_unique_ids(bundle: &ImportElectionEventSchema, report: &mut Report) {
+    // Two entities sharing an id means one silently overwrites the other. The ids
+    // are checked across every collection at once, not per collection: a contest
+    // and an area sharing one collides just as badly.
+    let groups: [(&str, Vec<&str>); 5] = [
+        (
+            "elections",
+            bundle.elections.iter().map(|e| e.id.as_str()).collect(),
+        ),
+        (
+            "contests",
+            bundle.contests.iter().map(|c| c.id.as_str()).collect(),
+        ),
+        (
+            "candidates",
+            bundle.candidates.iter().map(|c| c.id.as_str()).collect(),
+        ),
+        (
+            "areas",
+            bundle.areas.iter().map(|a| a.id.as_str()).collect(),
+        ),
+        (
+            "area_contests",
+            bundle.area_contests.iter().map(|l| l.id.as_str()).collect(),
+        ),
+    ];
+
+    let mut seen: HashMap<&str, &str> = HashMap::new();
+    for (kind, ids) in &groups {
+        for id in ids {
+            if let Some(previous) = seen.insert(id, kind) {
+                report.push(Problem::error(
+                    Code::DuplicateId,
+                    *kind,
+                    format!("id {id} is also used by {previous}"),
+                ));
+            }
+        }
+    }
+}
+
+/// Whether a string is shaped like a hyphenated UUID.
+///
+/// Deliberately not `Uuid::parse_str`: that crate is only enabled by the
+/// `keycloak` feature here, and pulling it into `default_features` would put
+/// `getrandom` in the WASM build to check a string's shape.
+fn looks_like_uuid(value: &str) -> bool {
+    let groups: Vec<&str> = value.split('-').collect();
+    groups.len() == 5
+        && [8usize, 4, 4, 4, 12]
+            .iter()
+            .zip(&groups)
+            .all(|(expected, group)| {
+                group.len() == *expected
+                    && group
+                        .chars()
+                        .all(|character| character.is_ascii_hexdigit())
+            })
+}

--- a/packages/sequent-core/src/election_config/validate.rs
+++ b/packages/sequent-core/src/election_config/validate.rs
@@ -343,10 +343,10 @@ fn check_contests(bundle: &ImportElectionEventSchema, report: &mut Report) {
             .unwrap_or(0);
         if available == 0 {
             report.push(
-                Problem::error(
+                Problem::warning(
                     Code::BallotCoverage,
                     path("id"),
-                    "the contest has no candidates",
+                    "the contest has no candidates, so nobody can vote in it",
                 )
                 .about(about),
             );
@@ -406,7 +406,7 @@ fn check_ballot_coverage(
     for (index, contest) in bundle.contests.iter().enumerate() {
         if !linked_contests.contains(contest.id.as_str()) {
             report.push(
-                Problem::error(
+                Problem::warning(
                     Code::BallotCoverage,
                     format!("contests[{index}]"),
                     "appears on no area's ballot, so nobody can vote in it",
@@ -423,7 +423,7 @@ fn check_ballot_coverage(
         {
             continue;
         }
-        report.push(Problem::error(
+        report.push(Problem::warning(
             Code::BallotCoverage,
             format!("areas[{index}]"),
             format!(

--- a/packages/sequent-core/src/election_config/validate_tests.rs
+++ b/packages/sequent-core/src/election_config/validate_tests.rs
@@ -253,10 +253,16 @@ fn a_negative_vote_count_does_not_wrap_into_a_huge_number() {
 }
 
 #[test]
-fn a_contest_with_no_candidates_is_rejected() {
+fn a_contest_with_no_candidates_is_a_warning_not_an_error() {
+    // An event still being configured has these, and the platform's own export of
+    // one has to re-import. See the round-trip test at the bottom.
     let mut bundle = sound();
     bundle.candidates.clear();
-    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+    let report = validate(&bundle);
+    assert!(!report.has_errors());
+    assert!(report
+        .warnings()
+        .any(|problem| problem.code == Code::BallotCoverage));
 }
 
 // -- tally system -----------------------------------------------------------
@@ -326,15 +332,19 @@ fn every_non_preferential_algorithm_is_accepted_with_unranked_voting() {
 // -- ballot coverage --------------------------------------------------------
 
 #[test]
-fn a_contest_on_no_ballot_is_rejected() {
+fn a_contest_on_no_ballot_is_a_warning_not_an_error() {
     // Does not break the import; means nobody can vote in it.
     let mut bundle = sound();
     bundle.area_contests.clear();
-    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+    let report = validate(&bundle);
+    assert!(!report.has_errors());
+    assert!(report
+        .warnings()
+        .any(|problem| problem.code == Code::BallotCoverage));
 }
 
 #[test]
-fn a_leaf_area_with_no_ballot_is_rejected() {
+fn a_leaf_area_with_no_ballot_is_a_warning_not_an_error() {
     let mut bundle = sound();
     let orphan = bundle.areas[1].clone();
     let mut orphan = orphan;
@@ -344,9 +354,9 @@ fn a_leaf_area_with_no_ballot_is_rejected() {
     bundle.areas.push(orphan);
 
     let report = validate(&bundle);
+    assert!(!report.has_errors());
     assert!(report
-        .problems
-        .iter()
+        .warnings()
         .any(|problem| problem.code == Code::BallotCoverage
             && problem.message.contains("Nowhere")));
 }
@@ -443,4 +453,40 @@ fn the_report_serializes_for_a_front_end() {
     assert!(first["severity"].is_string());
     assert!(first["path"].is_string());
     assert!(first["message"].is_string());
+}
+
+// -- round tripping ---------------------------------------------------------
+
+#[test]
+fn an_event_still_being_configured_can_be_re_imported() {
+    // The property that decides where the severity line falls. windmill refuses an
+    // import on errors, so anything the platform can itself export must validate
+    // without them — otherwise this check breaks disaster recovery to enforce a
+    // rule about authoring.
+    //
+    // A half-built event: a contest with no candidates yet, one not yet on a
+    // ballot, and an area nobody has assigned contests to.
+    let mut bundle = sound();
+    bundle.candidates.clear();
+    bundle.area_contests.clear();
+
+    let report = validate(&bundle);
+    assert!(
+        !report.has_errors(),
+        "a mid-configuration export must still import, but got:\n{report}"
+    );
+    assert!(
+        !report.is_empty(),
+        "it should still be reported, just not fatally"
+    );
+}
+
+#[test]
+fn an_inconsistent_bundle_is_still_refused() {
+    // The other side of that line: warnings are for consistent-but-odd, not for
+    // anything goes.
+    let mut bundle = sound();
+    bundle.candidates[0].contest_id =
+        Some("f0000000-0000-5000-8000-000000000000".into());
+    assert!(validate(&bundle).has_errors());
 }

--- a/packages/sequent-core/src/election_config/validate_tests.rs
+++ b/packages/sequent-core/src/election_config/validate_tests.rs
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super::validate`].
+//!
+//! Each starts from a bundle that passes and breaks exactly one thing, so a
+//! failure names the rule rather than a pile of unrelated problems. The builder
+//! below is deliberately the smallest bundle that validates cleanly — if it ever
+//! stops doing so, [`a_sound_bundle_has_no_errors`] fails first and says why.
+
+use super::problem::{Code, Severity};
+use super::schema::ImportElectionEventSchema;
+use super::validate::validate;
+
+const TENANT: &str = "3f0c9d21-7b4e-4a55-9c3a-1d2e5f6a7b80";
+
+/// A bundle that validates cleanly: one election, one contest with two
+/// candidates, a parent area and a leaf that carries the ballot.
+fn sound() -> ImportElectionEventSchema {
+    let json = serde_json::json!({
+        "tenant_id": TENANT,
+        "keycloak_event_realm": null,
+        "election_event": {
+            "id": "e0000000-0000-5000-8000-000000000000",
+            "tenant_id": TENANT,
+            "is_archived": false,
+            "encryption_protocol": "RSA256"
+        },
+        "elections": [{
+            "id": "e1000000-0000-5000-8000-000000000000",
+            "tenant_id": TENANT,
+            "election_event_id": "e0000000-0000-5000-8000-000000000000",
+            "external_id": "officers"
+        }],
+        "contests": [{
+            "id": "c1000000-0000-5000-8000-000000000000",
+            "tenant_id": TENANT,
+            "election_event_id": "e0000000-0000-5000-8000-000000000000",
+            "election_id": "e1000000-0000-5000-8000-000000000000",
+            "external_id": "president",
+            "min_votes": 0,
+            "max_votes": 1,
+            "winning_candidates_num": 1,
+            "voting_type": "non-preferential",
+            "counting_algorithm": "plurality-at-large"
+        }],
+        "candidates": [
+            {
+                "id": "d1000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "contest_id": "c1000000-0000-5000-8000-000000000000",
+                "external_id": "pres-a"
+            },
+            {
+                "id": "d2000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "contest_id": "c1000000-0000-5000-8000-000000000000",
+                "external_id": "pres-b"
+            }
+        ],
+        "areas": [
+            {
+                "id": "a1000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "name": "North Region"
+            },
+            {
+                "id": "a2000000-0000-5000-8000-000000000000",
+                "tenant_id": TENANT,
+                "election_event_id": "e0000000-0000-5000-8000-000000000000",
+                "name": "North Local 1",
+                "parent_id": "a1000000-0000-5000-8000-000000000000"
+            }
+        ],
+        "area_contests": [{
+            "id": "b1000000-0000-5000-8000-000000000000",
+            "area_id": "a2000000-0000-5000-8000-000000000000",
+            "contest_id": "c1000000-0000-5000-8000-000000000000"
+        }],
+        "scheduled_events": null,
+        "reports": [],
+        "keys_ceremonies": [],
+        "applications": []
+    });
+    serde_json::from_value(json).expect("the sound fixture should deserialize")
+}
+
+/// Every error code the report carries, for terse assertions.
+fn error_codes(bundle: &ImportElectionEventSchema) -> Vec<Code> {
+    validate(bundle)
+        .problems
+        .iter()
+        .filter(|problem| problem.severity == Severity::Error)
+        .map(|problem| problem.code)
+        .collect()
+}
+
+#[test]
+fn a_sound_bundle_has_no_errors() {
+    let report = validate(&sound());
+    assert!(
+        !report.has_errors(),
+        "the fixture should validate cleanly, but got:\n{report}"
+    );
+}
+
+// -- identity ---------------------------------------------------------------
+
+#[test]
+fn a_malformed_tenant_id_is_reported_readably() {
+    // The schema carries this as a String so the module stays WASM-safe; this is
+    // the check that replaces the one a Uuid field used to do at parse time.
+    let mut bundle = sound();
+    bundle.tenant_id = "not-a-uuid".into();
+    assert!(error_codes(&bundle).contains(&Code::InvalidValue));
+}
+
+#[test]
+fn an_empty_tenant_id_is_reported_as_missing_not_malformed() {
+    let mut bundle = sound();
+    bundle.tenant_id = "  ".into();
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+#[test]
+fn a_uuid_is_accepted_in_any_case() {
+    let mut bundle = sound();
+    bundle.tenant_id = TENANT.to_uppercase();
+    assert!(!validate(&bundle).has_errors());
+}
+
+#[test]
+fn an_event_with_no_elections_is_rejected() {
+    let mut bundle = sound();
+    bundle.elections.clear();
+    bundle.contests.clear();
+    bundle.candidates.clear();
+    bundle.area_contests.clear();
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+// -- references -------------------------------------------------------------
+
+#[test]
+fn a_contest_pointing_at_no_election_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].election_id =
+        "f0000000-0000-5000-8000-000000000000".into();
+    assert!(error_codes(&bundle).contains(&Code::DanglingReference));
+}
+
+#[test]
+fn a_candidate_pointing_at_no_contest_is_rejected() {
+    let mut bundle = sound();
+    bundle.candidates[0].contest_id =
+        Some("f0000000-0000-5000-8000-000000000000".into());
+    assert!(error_codes(&bundle).contains(&Code::DanglingReference));
+}
+
+#[test]
+fn a_candidate_with_no_contest_at_all_is_rejected() {
+    let mut bundle = sound();
+    bundle.candidates[0].contest_id = None;
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+#[test]
+fn a_problem_names_the_external_id_not_the_uuid() {
+    // Import regenerates every UUID, so the id in the bundle means nothing to
+    // whoever has to fix the source. The external_id is what they typed.
+    let mut bundle = sound();
+    bundle.contests[0].election_id =
+        "f0000000-0000-5000-8000-000000000000".into();
+    let report = validate(&bundle);
+    let problem = report
+        .problems
+        .iter()
+        .find(|problem| problem.code == Code::DanglingReference)
+        .expect("expected a dangling reference");
+    assert_eq!(problem.external_id.as_deref(), Some("president"));
+    assert_eq!(problem.path, "contests[0].election_id");
+}
+
+// -- area tree --------------------------------------------------------------
+
+#[test]
+fn an_area_pointing_at_no_parent_is_rejected() {
+    let mut bundle = sound();
+    bundle.areas[1].parent_id =
+        Some("f0000000-0000-5000-8000-000000000000".into());
+    assert!(error_codes(&bundle).contains(&Code::DanglingReference));
+}
+
+#[test]
+fn an_area_cycle_is_rejected() {
+    // An infinite tree hangs the Admin Portal rather than failing the import.
+    let mut bundle = sound();
+    let leaf = bundle.areas[1].id.clone();
+    bundle.areas[0].parent_id = Some(leaf);
+    assert!(error_codes(&bundle).contains(&Code::AreaCycle));
+}
+
+#[test]
+fn an_area_that_is_its_own_parent_is_rejected() {
+    let mut bundle = sound();
+    let own = bundle.areas[1].id.clone();
+    bundle.areas[1].parent_id = Some(own);
+    assert!(error_codes(&bundle).contains(&Code::AreaCycle));
+}
+
+// -- contest arithmetic -----------------------------------------------------
+
+#[test]
+fn min_votes_above_max_votes_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].min_votes = Some(2);
+    assert!(error_codes(&bundle).contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn a_contest_missing_a_vote_count_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].max_votes = None;
+    assert!(error_codes(&bundle).contains(&Code::MissingField));
+}
+
+#[test]
+fn electing_more_winners_than_there_are_candidates_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].winning_candidates_num = Some(5);
+    bundle.contests[0].max_votes = Some(5);
+    assert!(error_codes(&bundle).contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn allowing_more_selections_than_there_are_candidates_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].max_votes = Some(9);
+    assert!(error_codes(&bundle).contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn a_negative_vote_count_does_not_wrap_into_a_huge_number() {
+    // i64 to usize would make -1 enormous and silently pass the comparison.
+    let mut bundle = sound();
+    bundle.contests[0].winning_candidates_num = Some(-1);
+    let codes = error_codes(&bundle);
+    assert!(!codes.contains(&Code::ContestArithmetic));
+}
+
+#[test]
+fn a_contest_with_no_candidates_is_rejected() {
+    let mut bundle = sound();
+    bundle.candidates.clear();
+    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+}
+
+// -- tally system -----------------------------------------------------------
+
+#[test]
+fn an_unknown_counting_algorithm_is_rejected() {
+    // single-transferable-vote is not a CountingAlgType variant, however
+    // plausible it sounds.
+    let mut bundle = sound();
+    bundle.contests[0].counting_algorithm =
+        Some("single-transferable-vote".into());
+    assert!(error_codes(&bundle).contains(&Code::InvalidValue));
+}
+
+#[test]
+fn an_unknown_voting_type_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].voting_type = Some("ranked".into());
+    assert!(error_codes(&bundle).contains(&Code::InvalidValue));
+}
+
+#[test]
+fn preferential_counted_by_plurality_is_rejected() {
+    // Imports cleanly and then tallies wrongly: ballot encoding follows the
+    // algorithm, so the rankings a voter entered are read as unordered picks.
+    let mut bundle = sound();
+    bundle.contests[0].voting_type = Some("preferential".into());
+    assert!(error_codes(&bundle).contains(&Code::TallyMismatch));
+}
+
+#[test]
+fn non_preferential_counted_by_irv_is_rejected() {
+    let mut bundle = sound();
+    bundle.contests[0].counting_algorithm = Some("instant-runoff".into());
+    assert!(error_codes(&bundle).contains(&Code::TallyMismatch));
+}
+
+#[test]
+fn every_preferential_algorithm_is_accepted_with_ranked_voting() {
+    for algorithm in super::validate::PREFERENTIAL_ALGORITHMS {
+        let mut bundle = sound();
+        bundle.contests[0].voting_type = Some("preferential".into());
+        bundle.contests[0].counting_algorithm = Some((*algorithm).into());
+        assert!(
+            !validate(&bundle).has_errors(),
+            "{algorithm} should be valid for a preferential contest"
+        );
+    }
+}
+
+#[test]
+fn every_non_preferential_algorithm_is_accepted_with_unranked_voting() {
+    let preferential = super::validate::PREFERENTIAL_ALGORITHMS;
+    for algorithm in super::validate::COUNTING_ALGORITHMS {
+        if preferential.contains(algorithm) {
+            continue;
+        }
+        let mut bundle = sound();
+        bundle.contests[0].counting_algorithm = Some((*algorithm).into());
+        assert!(
+            !validate(&bundle).has_errors(),
+            "{algorithm} should be valid for a non-preferential contest"
+        );
+    }
+}
+
+// -- ballot coverage --------------------------------------------------------
+
+#[test]
+fn a_contest_on_no_ballot_is_rejected() {
+    // Does not break the import; means nobody can vote in it.
+    let mut bundle = sound();
+    bundle.area_contests.clear();
+    assert!(error_codes(&bundle).contains(&Code::BallotCoverage));
+}
+
+#[test]
+fn a_leaf_area_with_no_ballot_is_rejected() {
+    let mut bundle = sound();
+    let orphan = bundle.areas[1].clone();
+    let mut orphan = orphan;
+    orphan.id = "a3000000-0000-5000-8000-000000000000".into();
+    orphan.name = Some("Nowhere".into());
+    orphan.parent_id = None;
+    bundle.areas.push(orphan);
+
+    let report = validate(&bundle);
+    assert!(report
+        .problems
+        .iter()
+        .any(|problem| problem.code == Code::BallotCoverage
+            && problem.message.contains("Nowhere")));
+}
+
+#[test]
+fn a_parent_area_needs_no_ballot_of_its_own() {
+    // A parent is a grouping; only leaves carry contests. The sound fixture has
+    // one, so this is really asserting the fixture stays representative.
+    assert!(!validate(&sound()).has_errors());
+}
+
+// -- permission labels ------------------------------------------------------
+
+#[test]
+fn a_permission_label_is_a_warning_not_an_error() {
+    // The bundle cannot know who holds which label, so this must not block a
+    // build — but it is the single most expensive thing to discover after import.
+    let mut bundle = sound();
+    bundle.elections[0].permission_label = Some("officers".into());
+
+    let report = validate(&bundle);
+    assert!(!report.has_errors());
+    assert_eq!(
+        report
+            .warnings()
+            .filter(|problem| problem.code == Code::PermissionLabel)
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn the_warning_names_the_labels_in_use() {
+    let mut bundle = sound();
+    bundle.elections[0].permission_label = Some("officers".into());
+    let report = validate(&bundle);
+    let warning = report
+        .warnings()
+        .find(|problem| problem.code == Code::PermissionLabel)
+        .expect("expected a permission label warning");
+    assert!(warning.message.contains("officers"));
+}
+
+#[test]
+fn no_labels_means_no_warning() {
+    assert_eq!(
+        validate(&sound())
+            .warnings()
+            .filter(|problem| problem.code == Code::PermissionLabel)
+            .count(),
+        0
+    );
+}
+
+// -- identifiers ------------------------------------------------------------
+
+#[test]
+fn two_entities_sharing_an_id_are_rejected() {
+    let mut bundle = sound();
+    let duplicate = bundle.candidates[0].id.clone();
+    bundle.candidates[1].id = duplicate;
+    assert!(error_codes(&bundle).contains(&Code::DuplicateId));
+}
+
+#[test]
+fn an_id_shared_across_collections_is_rejected() {
+    // A contest and an area colliding is just as bad as two contests colliding.
+    let mut bundle = sound();
+    let contest_id = bundle.contests[0].id.clone();
+    bundle.areas[0].id = contest_id;
+    assert!(error_codes(&bundle).contains(&Code::DuplicateId));
+}
+
+// -- reporting --------------------------------------------------------------
+
+#[test]
+fn every_problem_is_reported_not_just_the_first() {
+    // Fixing a configuration one error per run is miserable.
+    let mut bundle = sound();
+    bundle.tenant_id = "nope".into();
+    bundle.contests[0].voting_type = Some("ranked".into());
+    bundle.contests[0].min_votes = Some(99);
+    assert!(error_codes(&bundle).len() >= 3);
+}
+
+#[test]
+fn the_report_serializes_for_a_front_end() {
+    let mut bundle = sound();
+    bundle.contests[0].counting_algorithm = Some("nonsense".into());
+    let report = validate(&bundle);
+    let json = serde_json::to_value(&report).unwrap();
+    let first = &json["problems"][0];
+    assert!(first["code"].is_string());
+    assert!(first["severity"].is_string());
+    assert!(first["path"].is_string());
+    assert!(first["message"].is_string());
+}

--- a/packages/sequent-core/src/lib.rs
+++ b/packages/sequent-core/src/lib.rs
@@ -9,6 +9,13 @@ extern crate cfg_if;
 pub mod ballot;
 #[cfg(feature = "default_features")]
 pub mod ballot_style;
+
+// Gated like types::hasura, whose entities the bundle schema is built from. The
+// WASM build enables default_features (see build_wasm.yml), so this module is
+// present in the browser.
+#[cfg(feature = "default_features")]
+pub mod election_config;
+
 #[cfg(feature = "default_features")]
 pub mod error;
 #[cfg(feature = "default_features")]

--- a/packages/windmill/src/postgres/reports.rs
+++ b/packages/windmill/src/postgres/reports.rs
@@ -18,58 +18,14 @@ use uuid::Uuid;
 
 use crate::services::reports::template_renderer::EReportEncryption;
 
-#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
-pub struct ReportCronConfig {
-    #[serde(default)]
-    pub is_active: bool,
-    #[serde(default)]
-    pub last_document_produced: Option<String>,
-    #[serde(default)]
-    pub cron_expression: String,
-    #[serde(default)]
-    pub email_recipients: Vec<String>,
-    #[serde(default)]
-    pub executer_username: String,
-}
-
-impl Default for ReportCronConfig {
-    fn default() -> Self {
-        ReportCronConfig {
-            is_active: false,
-            last_document_produced: None,
-            cron_expression: Default::default(),
-            email_recipients: Default::default(),
-            executer_username: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Report {
-    pub id: String,
-    pub election_event_id: String,
-    pub tenant_id: String,
-    pub election_id: Option<String>,
-    pub report_type: String,
-    pub template_alias: Option<String>,
-    pub encryption_policy: EReportEncryption,
-    pub cron_config: Option<ReportCronConfig>,
-    pub created_at: DateTime<Utc>,
-    pub permission_label: Option<Vec<String>>,
-}
-
-#[allow(non_camel_case_types)]
-#[derive(Display, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, EnumString)]
-pub enum ReportType {
-    INITIALIZATION_REPORT,
-    ELECTORAL_RESULTS,
-    BALLOT_IMAGES,
-    BALLOT_RECEIPT,
-    ACTIVITY_LOGS,
-    MANUAL_VERIFICATION,
-    PARTICIPATION_REPORT,
-    CREDENTIALS,
-}
+// Report, ReportCronConfig and ReportType now live in
+// sequent_core::election_config, so that the tools which write an import bundle
+// describe reports exactly as the importer reads them. Re-exported here because
+// windmill refers to them by this path in a dozen places.
+//
+// The database mapping stays below: it needs tokio_postgres, which cannot be in
+// a module that compiles to WASM.
+pub use sequent_core::election_config::{Report, ReportCronConfig, ReportType};
 
 pub struct ReportWrapper(pub Report);
 

--- a/packages/windmill/src/services/export/export_election_event.rs
+++ b/packages/windmill/src/services/export/export_election_event.rs
@@ -147,8 +147,10 @@ pub async fn read_export_data(
         std::env::var(ENV_VAR_APP_VERSION).unwrap_or_else(|_| DEV_APP_VERSION.to_string());
 
     let import_election_event_schema = ImportElectionEventSchema {
-        tenant_id: parse_uuid_v4(&tenant_id)?,
-        keycloak_event_realm: Some(realm),
+        // parse_uuid_v4 still runs: the schema now carries a String, but an
+        // export must not emit a tenant id that is not a UUID.
+        tenant_id: parse_uuid_v4(&tenant_id)?.to_string(),
+        keycloak_event_realm: Some(serde_json::to_value(realm)?),
         election_event: election_event,
         elections: export_elections,
         contests: contests.clone(),

--- a/packages/windmill/src/services/import/import_election_event.rs
+++ b/packages/windmill/src/services/import/import_election_event.rs
@@ -110,28 +110,20 @@ use sequent_core::types::keycloak::{
 };
 use sequent_core::types::scheduled_event::*;
 use sequent_core::util::temp_path::{generate_temp_file, get_file_size};
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ImportElectionEventSchema {
-    pub tenant_id: Uuid,
-    pub keycloak_event_realm: Option<RealmRepresentation>,
-    pub election_event: ElectionEvent,
-    pub elections: Vec<Election>,
-    pub contests: Vec<Contest>,
-    pub candidates: Vec<Candidate>,
-    pub areas: Vec<Area>,
-    pub area_contests: Vec<AreaContest>,
-    pub scheduled_events: Option<Vec<ScheduledEvent>>,
-    pub reports: Vec<Report>,
-    pub keys_ceremonies: Option<Vec<KeysCeremony>>,
-    pub applications: Option<Vec<Application>>,
-    #[serde(default = "default_version")]
-    pub version: String,
-}
-
-/// Set the default version of an imported election event to be compatible with version 9, which is the first version to include this feature.
-fn default_version() -> String {
-    HISTORICAL_DEFAULT_VERSION.to_string()
-}
+// The bundle schema now lives in sequent_core::election_config, so that the tools
+// which write an import describe it the same way this importer reads it.
+// Re-exported because windmill refers to it by this path throughout.
+//
+// Two field types differ from the struct that used to be here, both so the module
+// can compile to WASM for the browser-side tools:
+//
+//   tenant_id            String, not Uuid. Import replaces it with the importing
+//                        request's tenant regardless, and every use here
+//                        stringifies it. Its format is checked by validation.
+//   keycloak_event_realm serde_json::Value, not RealmRepresentation. That type
+//                        comes from the keycloak crate, which pulls reqwest.
+//                        Deserialized into the typed form where it is used.
+pub use sequent_core::election_config::ImportElectionEventSchema;
 
 #[instrument(err)]
 pub async fn upsert_b3_and_elog(
@@ -579,7 +571,7 @@ pub async fn get_election_event_schema(
     // with a more obscure error when trying to deserialize data that is incompatible with the current version.
     let raw: serde_json::Value = serde_json::from_str(data_str)
         .map_err(|e| anyhow!("Failed to parse import data as JSON: {e}"))?;
-    let default_ver = default_version();
+    let default_ver = HISTORICAL_DEFAULT_VERSION.to_string();
     let imported_version = raw
         .get(VERSION_KEY)
         .and_then(|v| v.as_str())
@@ -670,10 +662,18 @@ pub async fn process_election_event_file(
         default_language = Some(data.election_event.get_default_language());
     }
 
+    // The bundle carries the realm opaquely; this is where it becomes typed.
+    let keycloak_event_realm: Option<RealmRepresentation> = data
+        .keycloak_event_realm
+        .clone()
+        .map(deserialize_value)
+        .transpose()
+        .with_context(|| "Error deserializing keycloak_event_realm")?;
+
     upsert_keycloak_realm(
         tenant_id.as_str(),
         &election_event_id,
-        data.keycloak_event_realm.clone(),
+        keycloak_event_realm,
         default_language
     )
     .await
@@ -1421,7 +1421,8 @@ pub async fn process_document(
             if file_name.contains(EDocuments::CERTIFICATES.to_file_name()) {
                 let pem_content = String::from_utf8(file_contents.clone())
                     .context("Failed to decode certificates PEM as UTF-8")?;
-                let tenant_uuid = election_event_schema.tenant_id;
+                let tenant_uuid = Uuid::parse_str(&election_event_schema.tenant_id)
+                    .context("Invalid tenant_id in the imported bundle")?;
                 let election_event_uuid = Uuid::parse_str(&election_event_schema.election_event.id)
                     .context("Failed to parse election event UUID")?;
                 let pem_chunks = split_pem_bundle(&pem_content);

--- a/packages/windmill/src/services/import/import_election_event.rs
+++ b/packages/windmill/src/services/import/import_election_event.rs
@@ -123,6 +123,7 @@ use sequent_core::util::temp_path::{generate_temp_file, get_file_size};
 //   keycloak_event_realm serde_json::Value, not RealmRepresentation. That type
 //                        comes from the keycloak crate, which pulls reqwest.
 //                        Deserialized into the typed form where it is used.
+use sequent_core::election_config;
 pub use sequent_core::election_config::ImportElectionEventSchema;
 
 #[instrument(err)]
@@ -580,7 +581,45 @@ pub async fn get_election_event_schema(
         .map_err(|_| anyhow!("Environment variable {ENV_VAR_APP_VERSION} should be set"))?;
     check_version_compatibility(imported_version, &current_version)?;
     let original_data: ImportElectionEventSchema = deserialize_str(data_str)?;
+    check_bundle(&original_data)?;
     replace_ids(data_str, &original_data, event_id, tenant_id.clone())
+}
+
+/// Run the shared validation, refusing the import if it found anything fatal.
+///
+/// The same code answers in the browser before an upload, so a bundle the
+/// configuration tools accepted reaches this and passes. When one does not, the
+/// operator gets every problem at once rather than the first — and the same
+/// wording they would have seen client-side.
+///
+/// Validates the bundle as written, before `replace_ids` rewrites the
+/// identifiers: a problem naming an id the author never chose is not much use to
+/// them.
+///
+/// This is deliberately additive. It does not replace the checks that follow —
+/// those need the database, and this pass by design does not touch it.
+#[instrument(err, skip_all)]
+fn check_bundle(data: &ImportElectionEventSchema) -> Result<()> {
+    let report = election_config::validate(data);
+
+    for problem in report.warnings() {
+        event!(Level::WARN, "election event import: {problem}");
+    }
+
+    if report.has_errors() {
+        let listing = report
+            .errors()
+            .map(|problem| format!("  {problem}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let count = report.errors().count();
+        let noun = if count == 1 { "problem" } else { "problems" };
+        return Err(anyhow!(
+            "The election event bundle cannot be imported; {count} {noun} found:\n{listing}"
+        ));
+    }
+
+    Ok(())
 }
 
 #[instrument(err, skip_all)]

--- a/packages/windmill/src/services/reports/template_renderer.rs
+++ b/packages/windmill/src/services/reports/template_renderer.rs
@@ -82,16 +82,9 @@ pub enum ReportOriginatedFrom {
     ReportsTab,
 }
 
-#[allow(non_camel_case_types)]
-#[derive(
-    Display, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, EnumString, IntoStaticStr,
-)]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-pub enum EReportEncryption {
-    Unencrypted,
-    ConfiguredPassword,
-}
+// Moved to sequent_core::election_config so the import writers and the importer
+// agree on the wire form. Re-exported: windmill refers to it by this path.
+pub use sequent_core::election_config::EReportEncryption;
 
 pub const DEFAULT_ITEMS_PER_REPORT_LIMIT: usize = 1000;
 /// Trait that defines the behavior for rendering templates


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**1 of 3.** Base is `main`. The other two are stacked on this one:
[build a bundle from a workbook](https://github.com/sequentech/step/pull/2982), then
[the tools over it](https://github.com/sequentech/step/pull/2983).

**This is the only one of the three that changes existing behaviour**, so it is worth
the closest read. The other two are additions.

Three tools build or check an election event import, and no two of them shared a
line: windmill's importer, janitor's Python, the Election Architect's TypeScript.
Each reimplemented the bundle schema, the CSV byte shapes, and validation — and each
got them subtly differently. Every defect found while building janitor was a place
where one implementation disagreed with the platform.

This moves the definition to one place and makes the server use it.

## What moves

`ImportElectionEventSchema` and the report types leave windmill for
`sequent-core::election_config`. windmill re-exports both, so its ~10 call sites are
untouched. The `TryFrom<Row>` mapping stays in windmill — it needs `tokio_postgres`,
which cannot be in a module that compiles to WASM.

Two fields change shape so the module can reach a browser: `keycloak_event_realm`
becomes an opaque `serde_json::Value`, and `tenant_id` a `String` with a shape check
in validation. The `keycloak` crate would pull `reqwest`, and `uuid` would pull
`getrandom`. Neither field loses anything, and the export path still runs
`parse_uuid_v4`.

## What is new

`election_config::validate` — pure checks returning structured `Problem`s, each with
a machine-readable code, a dotted path and the entity's `external_id`. No database,
no IO, no clock, because it has to run in a browser and the browser is where a
delivery engineer wants the answer.

windmill now runs it on the bundle **as written**, before `replace_ids` rewrites the
identifiers — a problem naming an id the author never chose is no use to them — and
refuses the import if anything fatal turns up. The operator gets every problem at
once, in the same wording the browser-side tools will show.

## The part that deserves scrutiny: ballot coverage is now a warning

Wiring validation into the import path means **a bundle that used to import can now
be refused**, including the platform's own export re-imported for disaster recovery.

Three rules were fatal and should not have been: a contest with no candidates yet, a
contest not yet on any area's ballot, an area nobody has assigned contests to. An
event still being configured legitimately looks like that. Those bundles are
self-consistent and import into a working event; they just mean nobody votes there
yet. Refusing them would break recovery to enforce a rule about authoring.

| | |
|---|---|
| **Error** | The bundle is internally inconsistent, or would be rejected or corrupted by the platform |
| **Warning** | The bundle is consistent, but the configuration looks unintended |

Authoring tools treat warnings as blocking through a strict mode rather than by lying
about the severity here. Two tests pin the line from both sides:
`an_event_still_being_configured_can_be_re_imported` and
`an_inconsistent_bundle_is_still_refused`.

## Checked against real data

A `validate_bundle` example — the same call `step-cli` and the browser make — for
checking an export from a shell. Run against the generated SEIU1000 bundle it reports
0 errors and 1 warning: the permission label that made every election invisible on
the first real import of that event.

## Verified

- `cargo test -p sequent-core --lib --features default_features election_config` — 52 passed.
- `cargo test -p windmill --lib` — 235 passed, 2 ignored, unchanged from `main`.
- `cargo check -p windmill` and `cargo fmt --check` clean.

## Reading it

Four commits, each one thing:

1. `♻️` report types moved in
2. `♻️` the bundle schema moved out of windmill
3. `✨` the shared validation
4. `✨` windmill validating before importing

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

_To be added — the failure message an operator sees on a rejected import._
