### PR TITLE
✨ step-cli and the browser over the shared core

### DIFF
--- a/.devcontainer/scripts/rebuild-election-config-wasm.sh
+++ b/.devcontainer/scripts/rebuild-election-config-wasm.sh
@@ -51,7 +51,12 @@ node -e '
 ' "${OUT_DIR}" "${PACKAGE_NAME}"
 
 echo "==> Packing..."
-wasm-pack -v pack "${OUT_DIR}"
+# `npm pack` rather than `wasm-pack pack`, which takes the *crate* directory and
+# looks for a `pkg` child inside it — so with a custom --out-dir it goes hunting
+# for pkg-election-config/pkg and fails. `wasm-pack pack` is a wrapper around
+# `npm pack` in the output directory, which is exactly this, and it drops the
+# tarball in the directory it runs from.
+(cd "${OUT_DIR}" && npm pack)
 
 echo
 echo "==> Built ${OUT_DIR}/${PACKAGE_NAME}-0.1.0.tgz"

--- a/.devcontainer/scripts/rebuild-election-config-wasm.sh
+++ b/.devcontainer/scripts/rebuild-election-config-wasm.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SPDX-FileCopyrightText: 2026 Sequent Tech <legal@sequentech.io>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Builds the WASM package the election-configuration SPAs use.
+#
+# This is a *second* package from the same crate, and it exists so the four front
+# ends that already vendor sequent-core do not have to carry what they will never
+# use. They build with `wasmtest,default_features`, which gives them the bundle
+# schema and the validator. This one adds election_config_xlsx, _templates and
+# _archive — a spreadsheet parser, a template engine and a zip writer, none of which
+# belong in the voting portal.
+#
+# wasm-pack takes the npm package name from the crate name, so both builds would
+# otherwise produce sequent-core-0.1.0.tgz. The rename below is what keeps them
+# apart; everything else is the same pipeline as rebuild-sequent-core-full.sh.
+#
+# Run from inside packages/sequent-core via nix develop:
+#   cd packages/sequent-core && nix develop --command ../../.devcontainer/scripts/rebuild-election-config-wasm.sh
+
+PACKAGE_NAME="sequent-election-config"
+OUT_DIR="pkg-election-config"
+
+echo "==> Checking versions..."
+rustc --version
+wasm-pack --version
+
+echo "==> Building ${PACKAGE_NAME} WASM..."
+wasm-pack build \
+    --mode no-install \
+    --out-name index \
+    --out-dir "${OUT_DIR}" \
+    --release \
+    --target web \
+    --features=wasmtest,default_features,election_config_xlsx,election_config_templates,election_config_archive
+
+echo "==> Renaming the package so it does not collide with sequent-core..."
+# node rather than sed: package.json is JSON, and a regex over it is how a build
+# script starts corrupting files that happen to contain the same string twice.
+node -e '
+  const fs = require("fs");
+  const path = process.argv[1] + "/package.json";
+  const manifest = JSON.parse(fs.readFileSync(path, "utf8"));
+  manifest.name = process.argv[2];
+  manifest.description =
+    "Reading, building and validating a Sequent election event import, in the browser";
+  fs.writeFileSync(path, JSON.stringify(manifest, null, 2) + "\n");
+' "${OUT_DIR}" "${PACKAGE_NAME}"
+
+echo "==> Packing..."
+wasm-pack -v pack "${OUT_DIR}"
+
+echo
+echo "==> Built ${OUT_DIR}/${PACKAGE_NAME}-0.1.0.tgz"
+echo
+echo "    Vendor it into whichever package consumes it, the way the four front ends"
+echo "    vendor sequent-core, and update that package's lockfile hash."

--- a/.github/workflows/build_wasm.yml
+++ b/.github/workflows/build_wasm.yml
@@ -67,6 +67,31 @@ jobs:
             wasm-pack -v pack .
           '
 
+      # A second package from the same crate, for the election-configuration SPAs.
+      # The four front ends above build without these features on purpose: they get
+      # the bundle schema and the validator, and no spreadsheet parser, template
+      # engine or zip writer.
+      #
+      # Built here even though nothing vendors it yet, because this is the only
+      # place that compiles those features for wasm32. `zip`'s default features pull
+      # bzip2, zstd and lzma, which have no wasm32 target — restricting it to
+      # deflate is what makes this build possible, and a CI step is what keeps it
+      # that way when someone adds the next dependency.
+      - name: Check that the election-config WASM package builds
+        working-directory: packages/sequent-core
+        run: |
+          nix develop --command bash -c '
+            set -euo pipefail
+            ../../.devcontainer/scripts/rebuild-election-config-wasm.sh
+          '
+
+      - name: Upload the election-config WASM package
+        uses: actions/upload-artifact@v4
+        with:
+          name: sequent-election-config-wasm
+          path: packages/sequent-core/pkg-election-config/sequent-election-config-0.1.0.tgz
+          if-no-files-found: error
+
       # Note: Commented out because this doesn't work, probably because the paths in the devcontainer and the GitHub Action runner are different, so the hash of the built package doesn't match the hash in yarn.lock.
       # Keeping the commented-out code here for now in case we want to revisit this approach in the future
       # - name: Check that yarn.lock hash matches freshly built package

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ result
 /pkg/
 
 pkg
+pkg-election-config
 .direnv
 
 # Devenv

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -527,6 +527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,18 +1773,20 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.26.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+checksum = "5fa68281b1a76b54a62156474adb06bb380a67e07dd60656e3217152b42183f3"
 dependencies = [
+ "atoi_simd",
  "byteorder",
  "chrono",
  "codepage",
  "encoding_rs",
+ "fast-float2",
  "log",
- "quick-xml 0.31.0",
+ "quick-xml 0.41.0",
  "serde",
- "zip 2.4.2",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -3043,6 +3055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +3812,12 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -7749,22 +7773,22 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "encoding_rs",
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -9757,6 +9781,7 @@ dependencies = [
  "url",
  "uuid",
  "windmill",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -10805,6 +10830,12 @@ dependencies = [
  "thiserror 2.0.17",
  "utf-8",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -12796,6 +12827,20 @@ dependencies = [
  "flate2",
  "indexmap 2.12.0",
  "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.12.0",
+ "memchr",
+ "typed-path",
  "zopfli",
 ]
 

--- a/packages/sequent-core/Cargo.toml
+++ b/packages/sequent-core/Cargo.toml
@@ -134,9 +134,13 @@ calamine = { version = "0.36", features = ["dates"], optional = true }
 # randomness.
 sha1 = { version = "0.10", optional = true }
 
-# writing the importable archive; optional so a front end that only validates a
-# bundle carries no zip writer
-zip = { version = "2.1", optional = true }
+# Writing the importable archive; optional so a front end that only validates a
+# bundle carries no zip writer.
+#
+# default-features = false is load-bearing: the default set pulls bzip2, zstd and
+# lzma, all of which are C libraries with no wasm32 target, and this module has to
+# compile for a browser. Deflate is the only method an import archive uses.
+zip = { version = "2.1", default-features = false, features = ["deflate"], optional = true }
 
 
 # WASM plugin management

--- a/packages/sequent-core/Cargo.toml
+++ b/packages/sequent-core/Cargo.toml
@@ -126,7 +126,7 @@ csv = "1.3.0"
 
 # reading authoring spreadsheets; optional so front ends with no workbook to read
 # do not carry it into their WASM bundle
-calamine = { version = "0.26", features = ["dates"], optional = true }
+calamine = { version = "0.36", features = ["dates"], optional = true }
 
 # uuid5 for the deterministic ids a generated bundle uses. The `uuid` crate is not
 # used for this: its v4 feature pulls getrandom, whose WASM support is version

--- a/packages/sequent-core/src/election_config/architect.rs
+++ b/packages/sequent-core/src/election_config/architect.rs
@@ -42,8 +42,12 @@
 
 use std::cmp::Ordering;
 
+use crate::election_config::archive::{Artifact, Layout};
+use crate::election_config::build::{build, BuildOptions, Bundle};
 use crate::election_config::paths::Cell;
 use crate::election_config::problem::{Code, Problem, Report, Severity};
+use crate::election_config::render::TemplateSet;
+use crate::election_config::schema::ImportElectionEventSchema;
 use crate::election_config::sheet::{Sheet, Workbook};
 use crate::election_config::time::{self, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -1161,6 +1165,101 @@ pub fn side_files(plan: &Blueprint) -> Vec<(String, String)> {
 fn pretty(value: &serde_json::Value) -> String {
     serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string())
         + "\n"
+}
+
+/// Everything a plan produces.
+#[derive(Debug, Clone)]
+pub struct Compiled {
+    pub bundle: Bundle,
+
+    /// The files, split into what goes inside the importable archive and what
+    /// must not. [`side_files`] is already folded into `auxiliary`.
+    pub layout: Layout,
+
+    /// Warnings from every pass. Errors are returned as `Err` instead, so a
+    /// caller holding a `Compiled` is holding something worth writing out.
+    pub report: Report,
+}
+
+/// Turn a plan into what it is for.
+///
+/// This is the function the wizard and the CLI both call, and until it existed
+/// there was nothing joining the two halves of this module: [`to_workbook`] and
+/// [`side_files`] had no callers outside the tests, so a plan could be validated
+/// and mapped but never actually built.
+///
+/// Six steps, none of them new — which is the point. A plan becomes the same rows
+/// a spreadsheet produces, and everything after that is the existing builder:
+///
+/// 1. [`validate_plan`], in the plan's own vocabulary. Errors stop here, because
+///    a problem phrased as `contests[2].winning_candidates_num` is no use to
+///    somebody looking at a wizard.
+/// 2. [`to_workbook`].
+/// 3. [`super::build`].
+/// 4. Deserialize the export into [`ImportElectionEventSchema`] and
+///    [`super::validate`] it — the same second pass `step-cli` and
+///    `buildFromWorkbook` each make. Two implementations that merely looked
+///    similar would not survive this.
+/// 5. [`super::archive::layout`].
+/// 6. [`side_files`] into `auxiliary`, because a ceremony schedule is not part of
+///    an import and putting it inside the archive would suggest otherwise.
+pub fn compile_plan(
+    plan: &Blueprint,
+    templates: &TemplateSet,
+    options: &BuildOptions,
+) -> Result<Compiled, Report> {
+    let mut report = validate_plan(plan);
+    if report.has_errors() {
+        return Err(report);
+    }
+
+    let workbook = to_workbook(plan).map_err(|problem| {
+        let mut failed = Report::default();
+        failed.push(problem);
+        failed
+    })?;
+
+    let bundle = build(&workbook, templates, options)?;
+
+    for problem in bundle.warnings.problems.clone() {
+        report.push(problem);
+    }
+
+    match serde_json::from_value::<ImportElectionEventSchema>(
+        bundle.export.clone(),
+    ) {
+        Ok(schema) => {
+            for problem in super::validate(&schema).problems {
+                report.push(problem);
+            }
+        }
+        Err(error) => report.push(Problem::error(
+            Code::InvalidValue,
+            "bundle",
+            format!(
+                "the built bundle does not match the import schema, which is a \
+                 bug in this tool rather than in the plan: {error}"
+            ),
+        )),
+    }
+
+    if report.has_errors() {
+        return Err(report);
+    }
+
+    let mut layout = super::archive::layout(&bundle);
+    for (name, contents) in side_files(plan) {
+        layout.auxiliary.push(Artifact {
+            name,
+            bytes: contents.into_bytes(),
+        });
+    }
+
+    Ok(Compiled {
+        bundle,
+        layout,
+        report,
+    })
 }
 
 #[cfg(test)]

--- a/packages/sequent-core/src/election_config/architect.rs
+++ b/packages/sequent-core/src/election_config/architect.rs
@@ -45,6 +45,7 @@ use std::cmp::Ordering;
 use crate::election_config::archive::{Artifact, Layout};
 use crate::election_config::build::{build, BuildOptions, Bundle};
 use crate::election_config::paths::Cell;
+use crate::election_config::policy::{Behaviour, Overrides};
 use crate::election_config::problem::{Code, Problem, Report, Severity};
 use crate::election_config::profile::{apply_profile, check_required, Profile};
 use crate::election_config::render::TemplateSet;
@@ -59,7 +60,99 @@ use serde::{Deserialize, Serialize};
 /// somebody spent an afternoon on; being able to say "this is from an older
 /// version" beats failing to deserialize it with a serde error about a missing
 /// field.
-pub const BLUEPRINT_VERSION: u32 = 1;
+pub const BLUEPRINT_VERSION: u32 = 2;
+
+/// Bring a version 1 plan up to date, in place.
+///
+/// Version 1 carried `policies`, a three-value `allowed | warn | restricted`
+/// per policy, applied to every contest identically. Version 2 carries the
+/// platform's own values, per contest.
+///
+/// The mapping below is **version 1's own**, reproduced exactly — including
+/// where it was wrong. `restricted` for an under-vote produced
+/// `warn-only-in-review` and `restricted` for a blank or invalid vote produced
+/// `not-allowed`, and a plan that compiled to those bytes yesterday has to
+/// compile to them today. Getting it *right* for an old plan would silently
+/// change an election somebody has already reviewed; new plans get the
+/// considered defaults instead.
+fn migrate_v1(document: &mut serde_json::Value) {
+    let Some(object) = document.as_object_mut() else {
+        return;
+    };
+    if object.get("version").and_then(serde_json::Value::as_u64) != Some(1) {
+        return;
+    }
+
+    let old = object.remove("policies").unwrap_or(serde_json::Value::Null);
+    let says = |key: &str| -> &str {
+        old.get(key)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("warn")
+    };
+
+    let mut policies = serde_json::Map::new();
+    policies.insert(
+        "over_vote".to_string(),
+        serde_json::json!(match says("over_vote") {
+            "allowed" => "allowed",
+            "restricted" => "not-allowed-with-msg-and-disable",
+            _ => "allowed-with-msg",
+        }),
+    );
+    policies.insert(
+        "under_vote".to_string(),
+        serde_json::json!(match says("under_vote") {
+            "allowed" => "allowed",
+            "restricted" => "warn-only-in-review",
+            _ => "warn",
+        }),
+    );
+    for (key, restricted) in [
+        ("blank_vote", "not-allowed"),
+        ("invalid_vote", "not-allowed"),
+    ] {
+        policies.insert(
+            key.to_string(),
+            serde_json::json!(match says(key) {
+                "allowed" => "allowed",
+                "restricted" => restricted,
+                _ => "warn",
+            }),
+        );
+    }
+
+    object.insert(
+        "defaults".to_string(),
+        serde_json::json!({"policies": policies}),
+    );
+    object.insert("version".to_string(), serde_json::json!(2));
+}
+
+/// Read a saved plan, bringing an older one up to date.
+///
+/// The only way a plan should be deserialized. A plan from a *newer* version is
+/// left alone here and refused by [`validate_plan`], which can say so as a
+/// problem rather than as a serde error about a field nobody has heard of.
+pub fn read_plan(document: &str) -> Result<Blueprint, Problem> {
+    let mut value: serde_json::Value =
+        serde_json::from_str(document).map_err(|error| {
+            Problem::error(
+                Code::InvalidValue,
+                "plan",
+                format!("this is not an election plan: {error}"),
+            )
+        })?;
+
+    migrate_v1(&mut value);
+
+    serde_json::from_value(value).map_err(|error| {
+        Problem::error(
+            Code::InvalidValue,
+            "plan",
+            format!("this plan cannot be read: {error}"),
+        )
+    })
+}
 
 /// What the wizard collected.
 ///
@@ -117,8 +210,12 @@ pub struct Blueprint {
     #[serde(default)]
     pub elections: Vec<PlannedElection>,
 
+    /// How contests behave unless they say otherwise.
+    ///
+    /// Was the only place policies could be set, and applied to every contest
+    /// identically; now the bottom of a three-level resolution.
     #[serde(default)]
-    pub policies: Policies,
+    pub defaults: Behaviour,
 
     /// Anything the wizard has no field for. Carried, not interpreted.
     #[serde(default)]
@@ -244,6 +341,17 @@ pub struct PlannedElection {
     pub external_id: String,
     #[serde(default)]
     pub name: Translated,
+
+    /// One set for every contest here, replacing whatever the contests say.
+    ///
+    /// `None` — the normal case — means each contest resolves the event default
+    /// against its own overrides. `Some` is the old wizard's
+    /// `samePolicyForAllContests`: edited once, and a contest's own overrides
+    /// are not consulted. One field rather than a flag beside a value, because
+    /// "shared is on but there is no shared value" is a state somebody would
+    /// eventually produce and nobody could explain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shared: Option<Overrides>,
     #[serde(default)]
     pub contests: Vec<PlannedContest>,
 }
@@ -269,6 +377,10 @@ pub struct PlannedContest {
 
     #[serde(default)]
     pub candidates: Vec<PlannedCandidate>,
+
+    /// What this contest says about how it behaves, over the event's defaults.
+    #[serde(default, skip_serializing_if = "Overrides::is_empty")]
+    pub overrides: Overrides,
 
     /// Which areas put this contest on their ballot.
     ///
@@ -296,75 +408,19 @@ pub struct PlannedCandidate {
     pub explicit_invalid: bool,
 }
 
-/// What the ballot does when a voter does something unusual.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Policy {
-    /// Let it happen without comment.
-    Allowed,
-    /// Let it happen, but say something first.
-    Warn,
-    /// Do not let it happen.
-    Restricted,
-}
-
-impl Default for Policy {
-    fn default() -> Self {
-        Policy::Warn
-    }
-}
-
-#[derive(
-    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize,
-)]
-pub struct Policies {
-    /// Choosing more than `max_votes`.
-    #[serde(default)]
-    pub over_vote: Policy,
-    /// Choosing nothing at all.
-    #[serde(default)]
-    pub blank_vote: Policy,
-    /// Choosing fewer than `max_votes`.
-    #[serde(default)]
-    pub under_vote: Policy,
-    /// Deliberately spoiling the ballot.
-    #[serde(default)]
-    pub invalid_vote: Policy,
-}
-
-impl Policies {
-    /// The platform's `over_vote_policy` values.
-    fn over_vote(self) -> &'static str {
-        match self.over_vote {
-            Policy::Allowed => "allowed",
-            Policy::Warn => "allowed-with-msg",
-            Policy::Restricted => "not-allowed-with-msg-and-disable",
-        }
-    }
-
-    fn under_vote(self) -> &'static str {
-        match self.under_vote {
-            Policy::Allowed => "allowed",
-            Policy::Warn => "warn",
-            Policy::Restricted => "warn-only-in-review",
-        }
-    }
-
-    fn blank_vote(self) -> &'static str {
-        match self.blank_vote {
-            Policy::Allowed => "allowed",
-            Policy::Warn => "warn",
-            Policy::Restricted => "not-allowed",
-        }
-    }
-
-    fn invalid_vote(self) -> &'static str {
-        match self.invalid_vote {
-            Policy::Allowed => "allowed",
-            Policy::Warn => "warn",
-            Policy::Restricted => "not-allowed",
-        }
-    }
+/// What a contest ends up with.
+///
+/// Most specific last, with one exception: an election that has claimed the
+/// decision does not consult its contests at all. That is a statement about the
+/// election rather than a value copied onto each contest and then silently
+/// stale, which is what would happen if "shared" merely pre-filled them.
+pub fn resolve(
+    plan: &Blueprint,
+    election: &PlannedElection,
+    contest: &PlannedContest,
+) -> Behaviour {
+    let claimed = election.shared.as_ref().unwrap_or(&contest.overrides);
+    plan.defaults.apply(claimed)
 }
 
 /// The area used when a plan names none.
@@ -901,19 +957,20 @@ fn contests_sheet(
     plan: &Blueprint,
     languages: &[String],
 ) -> Result<Sheet, Problem> {
+    // The behaviour columns come from the policy module rather than being
+    // listed here, so a new policy is one declaration rather than a column, a
+    // cell and two places to forget.
+    let behaviour = Behaviour::default().columns();
+
     let mut columns = vec![
         "external_id".to_string(),
         "election.external_id".to_string(),
         "max_votes".to_string(),
-        "min_votes".to_string(),
         "winning_candidates_num".to_string(),
         "description".to_string(),
-        "presentation.over_vote_policy".to_string(),
-        "presentation.under_vote_policy".to_string(),
-        "presentation.blank_vote_policy".to_string(),
-        "presentation.invalid_vote_policy".to_string(),
         "presentation.sort_order".to_string(),
     ];
+    columns.extend(behaviour.iter().map(|(column, _)| (*column).to_string()));
     columns.extend(i18n_columns("presentation", languages));
 
     let mut rows = Vec::new();
@@ -923,17 +980,16 @@ fn contests_sheet(
                 Cell::text(contest.external_id.clone()),
                 Cell::text(election.external_id.clone()),
                 Cell::Int(contest.max_votes),
-                // The wizard does not ask, and a required minimum is a way to
-                // stop somebody voting at all.
-                Cell::Int(0),
                 Cell::Int(contest.winners),
                 Cell::text(contest.description.clone()),
-                Cell::text(plan.policies.over_vote()),
-                Cell::text(plan.policies.under_vote()),
-                Cell::text(plan.policies.blank_vote()),
-                Cell::text(plan.policies.invalid_vote()),
                 Cell::Int(order as i64),
             ];
+            row.extend(
+                resolve(plan, election, contest)
+                    .columns()
+                    .into_iter()
+                    .map(|(_, cell)| cell),
+            );
             row.extend(i18n_values(&contest.name, languages));
             rows.push(row);
         }

--- a/packages/sequent-core/src/election_config/architect.rs
+++ b/packages/sequent-core/src/election_config/architect.rs
@@ -46,6 +46,7 @@ use crate::election_config::archive::{Artifact, Layout};
 use crate::election_config::build::{build, BuildOptions, Bundle};
 use crate::election_config::paths::Cell;
 use crate::election_config::problem::{Code, Problem, Report, Severity};
+use crate::election_config::profile::{apply_profile, check_required, Profile};
 use crate::election_config::render::TemplateSet;
 use crate::election_config::schema::ImportElectionEventSchema;
 use crate::election_config::sheet::{Sheet, Workbook};
@@ -71,7 +72,7 @@ pub const BLUEPRINT_VERSION: u32 = 1;
 /// has no field for (the trustee threshold, the ceremony dates, the points of
 /// contact) and breaks whenever the bundle's shape changes. Saving the plan is both
 /// simpler and lossless.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Blueprint {
     /// [`BLUEPRINT_VERSION`] at the time it was saved.
     pub version: u32,
@@ -161,7 +162,7 @@ impl Translated {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Contact {
     pub name: String,
     #[serde(default)]
@@ -170,7 +171,7 @@ pub struct Contact {
     pub email: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Trustee {
     pub name: String,
     #[serde(default)]
@@ -207,7 +208,7 @@ pub struct Schedule {
     pub milestones: Vec<Milestone>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Milestone {
     pub event: String,
     pub date: String,
@@ -219,7 +220,7 @@ pub struct Milestone {
 /// the voters CSV identifies a voter's area *by name*, so it is an identifier the
 /// importer matches on. Two areas sharing a name would silently put voters in
 /// whichever one the importer found first.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PlannedArea {
     pub external_id: String,
 
@@ -238,7 +239,7 @@ pub struct PlannedArea {
     pub parent_external_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PlannedElection {
     pub external_id: String,
     #[serde(default)]
@@ -247,7 +248,7 @@ pub struct PlannedElection {
     pub contests: Vec<PlannedContest>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PlannedContest {
     pub external_id: String,
     #[serde(default)]
@@ -282,7 +283,7 @@ fn one() -> i64 {
     1
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PlannedCandidate {
     pub external_id: String,
     #[serde(default)]
@@ -1207,8 +1208,27 @@ pub fn compile_plan(
     plan: &Blueprint,
     templates: &TemplateSet,
     options: &BuildOptions,
+    profile: Option<&Profile>,
 ) -> Result<Compiled, Report> {
+    // The profile first, so a locked value is the one that gets validated and
+    // the one that gets built. Checking the plan as written and then forcing the
+    // value afterwards would report problems about text nobody will ship.
+    let applied;
+    let plan = match profile {
+        Some(profile) => {
+            applied = apply_profile(plan, profile)?;
+            &applied
+        }
+        None => plan,
+    };
+
     let mut report = validate_plan(plan);
+    if let Some(profile) = profile {
+        for problem in profile.warnings.problems.clone() {
+            report.push(problem);
+        }
+        check_required(plan, profile, &mut report);
+    }
     if report.has_errors() {
         return Err(report);
     }

--- a/packages/sequent-core/src/election_config/architect_tests.rs
+++ b/packages/sequent-core/src/election_config/architect_tests.rs
@@ -123,8 +123,9 @@ fn says(report: &Report, needle: &str) -> bool {
 #[test]
 fn a_plan_compiles_to_an_archive_the_importer_dispatches_on() {
     let templates = TemplateSet::builtin().unwrap();
-    let compiled = compile_plan(&sound(), &templates, &BuildOptions::default())
-        .expect("a sound plan compiles");
+    let compiled =
+        compile_plan(&sound(), &templates, &BuildOptions::default(), None)
+            .expect("a sound plan compiles");
 
     let importable: Vec<&str> = compiled
         .layout
@@ -144,8 +145,9 @@ fn a_plan_compiles_to_an_archive_the_importer_dispatches_on() {
 #[test]
 fn the_plans_own_files_travel_beside_the_archive_not_inside_it() {
     let templates = TemplateSet::builtin().unwrap();
-    let compiled = compile_plan(&sound(), &templates, &BuildOptions::default())
-        .expect("a sound plan compiles");
+    let compiled =
+        compile_plan(&sound(), &templates, &BuildOptions::default(), None)
+            .expect("a sound plan compiles");
 
     let auxiliary: Vec<&str> = compiled
         .layout
@@ -183,8 +185,9 @@ fn a_plan_with_errors_produces_no_files_and_says_why() {
     plan.trustee_threshold = 9; // more than there are trustees
 
     let templates = TemplateSet::builtin().unwrap();
-    let report = compile_plan(&plan, &templates, &BuildOptions::default())
-        .expect_err("a plan nobody could decrypt must not compile");
+    let report =
+        compile_plan(&plan, &templates, &BuildOptions::default(), None)
+            .expect_err("a plan nobody could decrypt must not compile");
 
     assert!(report.has_errors());
     assert!(says(&report, "could never be decrypted"));

--- a/packages/sequent-core/src/election_config/architect_tests.rs
+++ b/packages/sequent-core/src/election_config/architect_tests.rs
@@ -115,6 +115,81 @@ fn says(report: &Report, needle: &str) -> bool {
         .any(|problem| problem.message.contains(needle))
 }
 
+// -- compiling a plan ------------------------------------------------------
+
+/// Until `compile_plan` existed, `to_workbook` and `side_files` had no callers
+/// outside this file: the plan could be validated and mapped, but nothing joined
+/// those steps to the builder, so no wizard could actually produce anything.
+#[test]
+fn a_plan_compiles_to_an_archive_the_importer_dispatches_on() {
+    let templates = TemplateSet::builtin().unwrap();
+    let compiled = compile_plan(&sound(), &templates, &BuildOptions::default())
+        .expect("a sound plan compiles");
+
+    let importable: Vec<&str> = compiled
+        .layout
+        .importable
+        .iter()
+        .map(|artifact| artifact.name.as_str())
+        .collect();
+
+    assert!(importable
+        .iter()
+        .any(|name| name.starts_with("export_election_event")));
+    assert!(!compiled.report.has_errors());
+}
+
+/// The ceremony schedule, the contacts, the trustees and the plan itself are not
+/// part of an import. Inside the archive they would suggest otherwise.
+#[test]
+fn the_plans_own_files_travel_beside_the_archive_not_inside_it() {
+    let templates = TemplateSet::builtin().unwrap();
+    let compiled = compile_plan(&sound(), &templates, &BuildOptions::default())
+        .expect("a sound plan compiles");
+
+    let auxiliary: Vec<&str> = compiled
+        .layout
+        .auxiliary
+        .iter()
+        .map(|artifact| artifact.name.as_str())
+        .collect();
+    let importable: Vec<&str> = compiled
+        .layout
+        .importable
+        .iter()
+        .map(|artifact| artifact.name.as_str())
+        .collect();
+
+    for expected in [
+        "blueprint.json",
+        "ceremony_schedule.json",
+        "points_of_contact.json",
+        "trustees_list.json",
+    ] {
+        assert!(
+            auxiliary.contains(&expected),
+            "{expected} should sit beside the archive; found {auxiliary:?}"
+        );
+        assert!(
+            !importable.contains(&expected),
+            "{expected} must not be inside the importable archive"
+        );
+    }
+}
+
+#[test]
+fn a_plan_with_errors_produces_no_files_and_says_why() {
+    let mut plan = sound();
+    plan.trustee_threshold = 9; // more than there are trustees
+
+    let templates = TemplateSet::builtin().unwrap();
+    let report = compile_plan(&plan, &templates, &BuildOptions::default())
+        .expect_err("a plan nobody could decrypt must not compile");
+
+    assert!(report.has_errors());
+    assert!(says(&report, "could never be decrypted"));
+}
+
 // -- the property the whole design rests on --------------------------------
 
 #[test]

--- a/packages/sequent-core/src/election_config/architect_tests.rs
+++ b/packages/sequent-core/src/election_config/architect_tests.rs
@@ -5,6 +5,9 @@
 //! Tests for [`super`].
 
 use super::*;
+use crate::election_config::policy::{
+    Behaviour, CandidatesOrder, OverVote, Overrides, PolicyPatch, TallyPatch,
+};
 use crate::election_config::{
     build, validate, BuildOptions, Bundle, ImportElectionEventSchema,
     TemplateSet,
@@ -61,6 +64,7 @@ fn sound() -> Blueprint {
             }],
         },
         elections: vec![PlannedElection {
+            shared: None,
             external_id: "officers".to_string(),
             name: Translated::new("Officers"),
             contests: vec![PlannedContest {
@@ -84,9 +88,10 @@ fn sound() -> Blueprint {
                     },
                 ],
                 areas: vec![],
+                overrides: Overrides::default(),
             }],
         }],
-        policies: Policies::default(),
+        defaults: Behaviour::default(),
         notes: String::new(),
     }
 }
@@ -361,18 +366,138 @@ fn every_contest_lands_on_the_one_area() {
     assert_eq!(bundle.export["area_contests"].as_array().unwrap().len(), 1);
 }
 
+/// The event's defaults reach every contest, in the platform's own words —
+/// no mapping step, so nothing to be lossy about.
 #[test]
-fn the_policies_become_the_platforms_own_values() {
+fn the_event_defaults_reach_every_contest() {
     let mut plan = sound();
-    plan.policies = Policies {
-        over_vote: Policy::Restricted,
-        blank_vote: Policy::Allowed,
-        under_vote: Policy::Warn,
-        invalid_vote: Policy::Restricted,
-    };
+    plan.defaults.policies.over_vote = OverVote::Allowed;
+    plan.defaults.policies.candidates_order = CandidatesOrder::Random;
+
     let presentation =
         compiled(&plan).export["contests"][0]["presentation"].clone();
 
+    assert_eq!(
+        presentation["over_vote_policy"],
+        serde_json::json!("allowed")
+    );
+    assert_eq!(
+        presentation["candidates_order"],
+        serde_json::json!("random")
+    );
+}
+
+/// The gap that made this worth doing: until contests carried a tally, every
+/// one of them took the template's plurality-at-large, so the wizard could not
+/// produce a ranked election at all.
+#[test]
+fn a_contest_can_be_preferential() {
+    let mut plan = sound();
+    plan.elections[0].contests[0].overrides.tally = TallyPatch {
+        voting_type: Some("preferential".to_string()),
+        counting_algorithm: Some("instant-runoff".to_string()),
+        ..Default::default()
+    };
+
+    let contest = compiled(&plan).export["contests"][0].clone();
+
+    assert_eq!(contest["voting_type"], serde_json::json!("preferential"));
+    assert_eq!(
+        contest["counting_algorithm"],
+        serde_json::json!("instant-runoff")
+    );
+}
+
+#[test]
+fn a_contest_overrides_the_event_default() {
+    let mut plan = sound();
+    plan.defaults.policies.over_vote = OverVote::Allowed;
+    plan.elections[0].contests[0].overrides.policies = PolicyPatch {
+        over_vote: Some(OverVote::NotAllowedWithMsgAndDisable),
+        ..Default::default()
+    };
+
+    let presentation =
+        compiled(&plan).export["contests"][0]["presentation"].clone();
+    assert_eq!(
+        presentation["over_vote_policy"],
+        serde_json::json!("not-allowed-with-msg-and-disable")
+    );
+}
+
+/// An election that has claimed the decision does not consult its contests.
+/// The alternative — copying the shared value onto each contest — is how
+/// "shared" goes stale the first time somebody edits one of them.
+#[test]
+fn an_election_that_shares_one_set_ignores_its_contests() {
+    let mut plan = sound();
+    plan.elections[0].shared = Some(Overrides {
+        policies: PolicyPatch {
+            over_vote: Some(OverVote::Allowed),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    plan.elections[0].contests[0].overrides.policies = PolicyPatch {
+        over_vote: Some(OverVote::NotAllowedWithMsgAndDisable),
+        ..Default::default()
+    };
+
+    let presentation =
+        compiled(&plan).export["contests"][0]["presentation"].clone();
+    assert_eq!(
+        presentation["over_vote_policy"],
+        serde_json::json!("allowed"),
+        "the election claimed it, so the contest is not consulted"
+    );
+}
+
+/// Was hard-coded to zero with a comment saying the wizard does not ask, so
+/// "rank at least three" was unexpressible.
+#[test]
+fn a_contest_can_require_a_minimum_number_of_choices() {
+    let mut plan = sound();
+    plan.elections[0].contests[0].overrides.tally.min_votes = Some(3);
+
+    assert_eq!(
+        compiled(&plan).export["contests"][0]["min_votes"],
+        serde_json::json!(3)
+    );
+}
+
+/// A plan saved under version 1 has already been reviewed by somebody. It has
+/// to compile to the bytes it always did — including where version 1's mapping
+/// was wrong, because fixing it here would change an approved election.
+#[test]
+fn a_version_one_plan_compiles_to_the_bytes_it_used_to() {
+    let document = r#"{
+        "version": 1,
+        "external_id": "old",
+        "name": {"en": "Old"},
+        "elections": [{
+            "external_id": "e",
+            "name": {"en": "E"},
+            "contests": [{
+                "external_id": "c",
+                "name": {"en": "C"},
+                "max_votes": 1,
+                "winners": 1,
+                "candidates": [{"external_id": "a", "name": {"en": "A"}}]
+            }]
+        }],
+        "policies": {
+            "over_vote": "restricted",
+            "blank_vote": "allowed",
+            "under_vote": "restricted",
+            "invalid_vote": "restricted"
+        }
+    }"#;
+
+    let plan = read_plan(document).expect("an older plan still opens");
+    assert_eq!(plan.version, BLUEPRINT_VERSION);
+
+    let presentation =
+        compiled(&plan).export["contests"][0]["presentation"].clone();
     assert_eq!(
         presentation["over_vote_policy"],
         serde_json::json!("not-allowed-with-msg-and-disable")
@@ -381,7 +506,11 @@ fn the_policies_become_the_platforms_own_values() {
         presentation["blank_vote_policy"],
         serde_json::json!("allowed")
     );
-    assert_eq!(presentation["under_vote_policy"], serde_json::json!("warn"));
+    assert_eq!(
+        presentation["under_vote_policy"],
+        serde_json::json!("warn-only-in-review"),
+        "version 1 mapped 'restricted' here to a warning; reproduced, not fixed"
+    );
     assert_eq!(
         presentation["invalid_vote_policy"],
         serde_json::json!("not-allowed")
@@ -771,6 +900,7 @@ fn districted() -> Blueprint {
     ];
     // The president is everywhere; the local officer is one local's business.
     plan.elections[0].contests.push(PlannedContest {
+        overrides: Overrides::default(),
         external_id: "local-officer".to_string(),
         name: Translated::new("Local Officer"),
         description: String::new(),

--- a/packages/sequent-core/src/election_config/build.rs
+++ b/packages/sequent-core/src/election_config/build.rs
@@ -772,7 +772,7 @@ impl<'a> Builder<'a> {
 
         if elections.is_empty() {
             self.problem(
-                sheet_origin("Elections"),
+                Origin::sheet("Elections"),
                 Code::MissingField,
                 "an election event needs at least one election",
             );
@@ -834,7 +834,7 @@ impl<'a> Builder<'a> {
 
         if contests.is_empty() {
             self.problem(
-                sheet_origin("Contests"),
+                Origin::sheet("Contests"),
                 Code::MissingField,
                 "an election event needs at least one contest",
             );
@@ -927,11 +927,7 @@ impl<'a> Builder<'a> {
                 .find(|(_, seen_name)| seen_name == name)
             {
                 self.problem(
-                    Origin {
-                        sheet: "Areas".to_string(),
-                        row: 0,
-                        column: Some("name".to_string()),
-                    },
+                    Origin::column("Areas", "name"),
                     Code::DuplicateId,
                     format!(
                         "two areas are both named '{name}' ('{earlier}' and \
@@ -1002,7 +998,7 @@ impl<'a> Builder<'a> {
 
         if areas.is_empty() {
             self.problem(
-                sheet_origin("Areas"),
+                Origin::sheet("Areas"),
                 Code::MissingField,
                 "an election event needs at least one area; every voter \
                  belongs to one",
@@ -1062,7 +1058,7 @@ impl<'a> Builder<'a> {
 
         if links.is_empty() {
             self.problem(
-                sheet_origin("AreaContests"),
+                Origin::sheet("AreaContests"),
                 Code::BallotCoverage,
                 "no area is linked to any contest, so no voter would see a \
                  ballot",
@@ -1164,14 +1160,6 @@ fn event_row(workbook: &Workbook) -> Result<Row, Problem> {
                  one election event"
             ),
         )),
-    }
-}
-
-fn sheet_origin(sheet: &str) -> Origin {
-    Origin {
-        sheet: sheet.to_string(),
-        row: 0,
-        column: None,
     }
 }
 

--- a/packages/sequent-core/src/election_config/build_realm.rs
+++ b/packages/sequent-core/src/election_config/build_realm.rs
@@ -62,17 +62,9 @@ impl Builder<'_> {
         let Some(preset) = presets::get(&name) else {
             // Whichever said it wrong is where the author has to look.
             let origin = if explicit.is_some() {
-                Origin {
-                    sheet: "auth preset option".to_string(),
-                    row: 0,
-                    column: None,
-                }
+                Origin::sheet("auth preset option")
             } else {
-                Origin {
-                    sheet: "Parameters".to_string(),
-                    row: 0,
-                    column: Some("value".to_string()),
-                }
+                Origin::column("Parameters", "value")
             };
             let message = format!(
                 "'{name}' is not an authentication preset; expected one of {}",
@@ -107,11 +99,7 @@ impl Builder<'_> {
                 wanted.join(", ")
             );
             self.problem(
-                Origin {
-                    sheet: "Parameters".to_string(),
-                    row: 0,
-                    column: None,
-                },
+                Origin::sheet("Parameters"),
                 Code::MissingField,
                 message,
             );
@@ -434,11 +422,7 @@ impl Builder<'_> {
                     "the realm's user profile is not readable JSON: {error}"
                 );
                 self.problem(
-                    Origin {
-                        sheet: "base export".to_string(),
-                        row: 0,
-                        column: None,
-                    },
+                    Origin::sheet("base export"),
                     Code::InvalidValue,
                     message,
                 );

--- a/packages/sequent-core/src/election_config/build_tables.rs
+++ b/packages/sequent-core/src/election_config/build_tables.rs
@@ -798,11 +798,7 @@ impl Builder<'_> {
 
         if roles.is_empty() {
             self.problem(
-                Origin {
-                    sheet: sheet.name.clone(),
-                    row: 1,
-                    column: None,
-                },
+                Origin::sheet(sheet.name.clone()),
                 Code::MissingField,
                 "the Permissions matrix has no role columns; expected the first \
                  column to hold permissions and one further column per role",
@@ -948,11 +944,7 @@ impl Builder<'_> {
 
         for column in offenders {
             self.problem(
-                Origin {
-                    sheet: sheet.to_string(),
-                    row: 1,
-                    column: Some(column),
-                },
+                Origin::column(sheet, column),
                 Code::InvalidValue,
                 "the importer rejects this column name; only letters, digits, \
                  '.', '_' and '-' are allowed",

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -50,6 +50,16 @@ pub mod schema;
 pub mod sheet;
 pub mod validate;
 
+/// The browser's view of this module: thin wrappers over the same functions
+/// `step-cli` and windmill call.
+///
+/// Gated the way `crate::wasm` is, so it appears in exactly the builds that have a
+/// JavaScript side. What it exposes depends on the other features — checking an
+/// existing bundle needs neither a template engine nor a spreadsheet parser, and a
+/// front end that only does that should carry neither.
+#[cfg(all(feature = "wasm", feature = "default_features"))]
+pub mod wasm;
+
 /// Reading `.xlsx`, behind its own feature so front ends with no workbook to read
 /// do not carry a spreadsheet library.
 #[cfg(feature = "election_config_xlsx")]

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -39,6 +39,12 @@ pub mod archive;
 pub mod architect;
 
 pub mod branding;
+
+/// What a client's build of the wizard may say. Shares the architect's feature,
+/// since applying a profile means having a plan to apply it to.
+#[cfg(feature = "election_config_templates")]
+pub mod profile;
+
 pub mod emit;
 pub mod ids;
 pub mod paths;
@@ -101,6 +107,8 @@ pub use ids::IdFactory;
 pub use paths::{coerce_cell, deep_merge, expand, Cell};
 pub use presets::{AuthPreset, RealmPatch};
 pub use problem::{Code, Problem, Report as ValidationReport, Severity};
+#[cfg(feature = "election_config_templates")]
+pub use profile::{apply_profile, ClientProfile, Profile};
 #[cfg(feature = "election_config_templates")]
 pub use render::TemplateSet;
 pub use report::{EReportEncryption, Report, ReportCronConfig, ReportType};

--- a/packages/sequent-core/src/election_config/mod.rs
+++ b/packages/sequent-core/src/election_config/mod.rs
@@ -40,6 +40,10 @@ pub mod architect;
 
 pub mod branding;
 
+/// How a ballot behaves, in the platform's own words. Ungated: the bundle
+/// validator needs the value space and carries no feature.
+pub mod policy;
+
 /// What a client's build of the wizard may say. Shares the architect's feature,
 /// since applying a profile means having a plan to apply it to.
 #[cfg(feature = "election_config_templates")]
@@ -105,6 +109,7 @@ pub use build::{
 pub use emit::{json_csv, plain_csv, JsonField};
 pub use ids::IdFactory;
 pub use paths::{coerce_cell, deep_merge, expand, Cell};
+pub use policy::{Policies as ContestPolicies, PolicyPatch, PolicyValue};
 pub use presets::{AuthPreset, RealmPatch};
 pub use problem::{Code, Problem, Report as ValidationReport, Severity};
 #[cfg(feature = "election_config_templates")]

--- a/packages/sequent-core/src/election_config/policy.rs
+++ b/packages/sequent-core/src/election_config/policy.rs
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! How a ballot behaves, in the platform's own words.
+//!
+//! Every enum here is one of the platform's, variant for variant, and serialises
+//! as the exact string `contest.presentation` holds. There is **no mapping
+//! table**, and that is the point: a plan carries what the bundle will say, so
+//! nothing can be lossy and no value the platform rejects can be invented.
+//!
+//! # Why not a friendlier vocabulary
+//!
+//! The obvious design — and the one both previous implementations chose — is a
+//! small `Allowed | Warn | Restricted` and a function that maps it to the wire.
+//! It reads better and it does not work:
+//!
+//! * `Restricted` for an under-vote mapped to `not-allowed`, which is not a
+//!   member of `EUnderVotePolicy`;
+//! * `Warn` for an over-vote, shown only in review, mapped to
+//!   `warn-only-in-review`, which is not a member of `EOverVotePolicy` either;
+//! * candidate order mapped `alphabetic` when `CandidatesOrder` says
+//!   `alphabetical`.
+//!
+//! Three escapes from the value space in one thirty-line file, none of which a
+//! type could catch, and every one of them a contest that imports cleanly and
+//! then behaves in a way nobody chose.
+//!
+//! The deeper objection is that it makes the *plan* a lower-fidelity document
+//! than the bundle it produces, so the wizard can never express a configuration
+//! the Admin Portal can — which makes it a dead end for every election past the
+//! simplest.
+//!
+//! # The dropdown-maze worry
+//!
+//! Five values for over-vote is a lot to put in front of somebody. But
+//! `packages/admin-portal/src/translations/*.ts` already keys human labels off
+//! these exact strings, in eight languages, so the enums *are* the UI
+//! vocabulary and there is nothing to map. A front end shows the three presets
+//! below and reveals the real values behind a "customise" disclosure.
+//!
+//! # Where this lives
+//!
+//! Beside the architect rather than inside it, and ungated, because
+//! [`super::validate`] needs the value space to check a bundle and carries no
+//! feature.
+
+use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumIter, EnumString, IntoStaticStr};
+
+use super::paths::Cell;
+
+/// A `contest.presentation` value whose variants are exactly the platform's.
+pub trait PolicyValue: Copy + Sized + 'static {
+    /// The column this is written to.
+    const COLUMN: &'static str;
+
+    /// The translation namespace in the Admin Portal, so a front end can label
+    /// a value without a second table.
+    const LABELS: &'static str;
+
+    /// Every value, most permissive first — the order somebody reasons in.
+    fn values() -> Vec<Self>;
+
+    fn as_str(self) -> &'static str;
+}
+
+macro_rules! policy_value {
+    (
+        $(#[$outer:meta])*
+        $name:ident, column = $column:literal, labels = $labels:literal,
+        default = $default:ident,
+        { $( $(#[$inner:meta])* $variant:ident ),* $(,)? }
+    ) => {
+        $(#[$outer])*
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq, Hash,
+            Serialize, Deserialize, Display, EnumIter, EnumString, IntoStaticStr,
+        )]
+        #[serde(rename_all = "kebab-case")]
+        #[strum(serialize_all = "kebab-case")]
+        pub enum $name {
+            $( $(#[$inner])* $variant, )*
+        }
+
+        impl Default for $name {
+            fn default() -> Self { $name::$default }
+        }
+
+        impl PolicyValue for $name {
+            const COLUMN: &'static str = $column;
+            const LABELS: &'static str = $labels;
+            fn values() -> Vec<Self> { vec![ $( $name::$variant, )* ] }
+            fn as_str(self) -> &'static str { self.into() }
+        }
+    };
+}
+
+policy_value! {
+    /// What the ballot does when a voter selects more than `max_votes`.
+    ///
+    /// `EOverVotePolicy`. Note it has no plain `warn`: over-voting is either
+    /// permitted with a message or refused, and there is no "warn in review"
+    /// — which is the value the previous implementation emitted for it.
+    OverVote, column = "presentation.over_vote_policy",
+    labels = "overVotePolicy", default = NotAllowedWithMsgAndDisable,
+    {
+        Allowed,
+        AllowedWithMsg,
+        AllowedWithMsgAndAlert,
+        NotAllowedWithMsgAndAlert,
+        NotAllowedWithMsgAndDisable,
+    }
+}
+
+policy_value! {
+    /// Choosing nothing at all. `EBlankVotePolicy`.
+    BlankVote, column = "presentation.blank_vote_policy",
+    labels = "blankVotePolicy", default = WarnOnlyInReview,
+    { Allowed, Warn, WarnOnlyInReview, NotAllowed }
+}
+
+policy_value! {
+    /// Choosing fewer than `max_votes`. `EUnderVotePolicy`.
+    ///
+    /// No `not-allowed`: an under-vote cannot be refused, only warned about,
+    /// which is why mapping a "restricted" choice onto one produced a value the
+    /// platform does not have.
+    UnderVote, column = "presentation.under_vote_policy",
+    labels = "underVotePolicy", default = WarnOnlyInReview,
+    { Allowed, Warn, WarnOnlyInReview, WarnAndAlert }
+}
+
+policy_value! {
+    /// Deliberately spoiling the ballot. `EInvalidVotePolicy`.
+    InvalidVote, column = "presentation.invalid_vote_policy",
+    labels = "invalidVotePolicy", default = WarnInvalidImplicitAndExplicit,
+    { Allowed, Warn, WarnInvalidImplicitAndExplicit, NotAllowed }
+}
+
+policy_value! {
+    /// Ranking two candidates equally. `EDuplicatedRankPolicy`.
+    DuplicatedRank, column = "presentation.duplicated_rank_policy",
+    labels = "duplicatedRankPolicy", default = AllowedWarnAndDialog,
+    { AllowedWarnAndDialog, NotAllowedWarnAndDialog }
+}
+
+policy_value! {
+    /// Leaving a gap in a ranking. `EPreferenceGapsPolicy`.
+    PreferenceGaps, column = "presentation.preference_gaps_policy",
+    labels = "preferenceGapsPolicy", default = AllowedWarnAndDialog,
+    { AllowedWarnAndDialog, NotAllowedWarnAndDialog }
+}
+
+policy_value! {
+    /// The order candidates appear in. `CandidatesOrder`.
+    ///
+    /// `Random` is a written fairness requirement for several clients, and
+    /// `Custom` means the order the plan lists them in.
+    CandidatesOrder, column = "presentation.candidates_order",
+    labels = "candidatesOrder", default = Custom,
+    { Custom, Alphabetical, Random }
+}
+
+/// Declare a set of policies and its patch together.
+///
+/// One invocation, two types. Adding a policy to only one of them is the
+/// mistake this exists to make impossible — and it is the one that would
+/// happen, because the patch is the type nobody remembers.
+macro_rules! policy_set {
+    ($resolved:ident / $patch:ident { $( $field:ident : $ty:ty ),* $(,)? }) => {
+        /// What a contest ends up behaving like.
+        #[derive(
+            Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize,
+        )]
+        pub struct $resolved {
+            $( #[serde(default)] pub $field: $ty, )*
+        }
+
+        /// What one level *says*, as opposed to what a contest *gets*.
+        #[derive(
+            Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize,
+        )]
+        pub struct $patch {
+            $(
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                pub $field: Option<$ty>,
+            )*
+        }
+
+        impl $resolved {
+            /// This set with everything the patch names replaced.
+            pub fn apply(self, patch: &$patch) -> Self {
+                $resolved { $( $field: patch.$field.unwrap_or(self.$field), )* }
+            }
+
+            /// The sheet columns this set writes.
+            pub fn columns(self) -> Vec<(&'static str, Cell)> {
+                vec![ $( (<$ty>::COLUMN, Cell::text(self.$field.as_str())), )* ]
+            }
+        }
+
+        impl $patch {
+            pub fn is_empty(&self) -> bool { true $( && self.$field.is_none() )* }
+        }
+    };
+}
+
+policy_set!(
+    Policies
+        / PolicyPatch {
+            over_vote: OverVote,
+            blank_vote: BlankVote,
+            under_vote: UnderVote,
+            invalid_vote: InvalidVote,
+            duplicated_rank: DuplicatedRank,
+            preference_gaps: PreferenceGaps,
+            candidates_order: CandidatesOrder,
+        }
+);
+
+impl Policies {
+    /// Accept whatever the voter does, and say nothing.
+    ///
+    /// For an election where a spoiled or partial ballot is a legitimate
+    /// choice rather than a mistake to catch.
+    pub fn permissive() -> Self {
+        Policies {
+            over_vote: OverVote::Allowed,
+            blank_vote: BlankVote::Allowed,
+            under_vote: UnderVote::Allowed,
+            invalid_vote: InvalidVote::Allowed,
+            ..Default::default()
+        }
+    }
+
+    /// Say something, but let the voter through. The platform's own defaults.
+    pub fn standard() -> Self {
+        Policies::default()
+    }
+
+    /// Refuse what can be refused, and warn loudly about the rest.
+    pub fn strict() -> Self {
+        Policies {
+            over_vote: OverVote::NotAllowedWithMsgAndDisable,
+            blank_vote: BlankVote::NotAllowed,
+            // Not `NotAllowed` — `EUnderVotePolicy` has no such value, and
+            // inventing one is exactly the bug this module exists to prevent.
+            under_vote: UnderVote::WarnAndAlert,
+            invalid_vote: InvalidVote::NotAllowed,
+            duplicated_rank: DuplicatedRank::NotAllowedWarnAndDialog,
+            preference_gaps: PreferenceGaps::NotAllowedWarnAndDialog,
+            ..Default::default()
+        }
+    }
+}
+
+/// How a contest is voted and counted.
+///
+/// Separate from [`Policies`] because these land on the contest itself rather
+/// than on its presentation, and because two of them have to agree:
+/// [`super::validate`] refuses a preferential contest counted by plurality,
+/// which imports cleanly and then reads a voter's rankings as an unordered set.
+///
+/// Until this existed the wizard could not produce a ranked election at all —
+/// every contest took `contest.hbs`'s defaults, which are non-preferential and
+/// plurality-at-large.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Tally {
+    /// `preferential` or `non-preferential`, per the Admin Portal's `IVotingType`.
+    #[serde(default = "non_preferential")]
+    pub voting_type: String,
+
+    /// One of [`super::validate::COUNTING_ALGORITHMS`].
+    #[serde(default = "plurality")]
+    pub counting_algorithm: String,
+
+    /// How few a voter may choose. Zero means a blank ballot is a ballot.
+    ///
+    /// Was hard-coded to zero, with a comment saying the wizard does not ask —
+    /// so "rank at least three" was unexpressible.
+    #[serde(default)]
+    pub min_votes: i64,
+
+    /// Whether ballots are encrypted. The difference between an election and a
+    /// poll, and unrecoverable if wrong.
+    #[serde(default = "yes")]
+    pub is_encrypted: bool,
+}
+
+fn non_preferential() -> String {
+    "non-preferential".to_string()
+}
+
+fn plurality() -> String {
+    "plurality-at-large".to_string()
+}
+
+fn yes() -> bool {
+    true
+}
+
+impl Default for Tally {
+    fn default() -> Self {
+        Tally {
+            voting_type: non_preferential(),
+            counting_algorithm: plurality(),
+            min_votes: 0,
+            is_encrypted: true,
+        }
+    }
+}
+
+/// What a level says about how its contests are counted.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TallyPatch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voting_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub counting_algorithm: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_votes: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_encrypted: Option<bool>,
+}
+
+impl Tally {
+    pub fn apply(&self, patch: &TallyPatch) -> Tally {
+        Tally {
+            voting_type: patch
+                .voting_type
+                .clone()
+                .unwrap_or_else(|| self.voting_type.clone()),
+            counting_algorithm: patch
+                .counting_algorithm
+                .clone()
+                .unwrap_or_else(|| self.counting_algorithm.clone()),
+            min_votes: patch.min_votes.unwrap_or(self.min_votes),
+            is_encrypted: patch.is_encrypted.unwrap_or(self.is_encrypted),
+        }
+    }
+
+    /// The columns this writes. Not `presentation.*` — these are the contest's.
+    pub fn columns(&self) -> Vec<(&'static str, Cell)> {
+        vec![
+            ("voting_type", Cell::text(self.voting_type.clone())),
+            (
+                "counting_algorithm",
+                Cell::text(self.counting_algorithm.clone()),
+            ),
+            ("min_votes", Cell::Int(self.min_votes)),
+            ("is_encrypted", Cell::Bool(self.is_encrypted)),
+        ]
+    }
+}
+
+impl TallyPatch {
+    pub fn is_empty(&self) -> bool {
+        self.voting_type.is_none()
+            && self.counting_algorithm.is_none()
+            && self.min_votes.is_none()
+            && self.is_encrypted.is_none()
+    }
+}
+
+/// What a level says about how its contests behave, all together.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Overrides {
+    #[serde(default)]
+    pub policies: PolicyPatch,
+    #[serde(default)]
+    pub tally: TallyPatch,
+}
+
+impl Overrides {
+    pub fn is_empty(&self) -> bool {
+        self.policies.is_empty() && self.tally.is_empty()
+    }
+}
+
+/// Everything a contest ends up with.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Behaviour {
+    #[serde(default)]
+    pub policies: Policies,
+    #[serde(default)]
+    pub tally: Tally,
+}
+
+impl Behaviour {
+    /// This, with one level's overrides applied.
+    pub fn apply(&self, overrides: &Overrides) -> Behaviour {
+        Behaviour {
+            policies: self.policies.apply(&overrides.policies),
+            tally: self.tally.apply(&overrides.tally),
+        }
+    }
+
+    /// Every column, presentation and contest together.
+    pub fn columns(&self) -> Vec<(&'static str, Cell)> {
+        let mut all = self.policies.columns();
+        all.extend(self.tally.columns());
+        all
+    }
+}
+
+#[cfg(test)]
+#[path = "policy_tests.rs"]
+mod policy_tests;

--- a/packages/sequent-core/src/election_config/policy_tests.rs
+++ b/packages/sequent-core/src/election_config/policy_tests.rs
@@ -206,3 +206,41 @@ fn the_patch_covers_exactly_the_policies_that_exist() {
         patch.as_object().unwrap().len()
     );
 }
+
+/// The catalog is what stops the value space acquiring a fourth copy, so it has
+/// to actually carry every kind and every value.
+#[test]
+fn the_catalog_covers_every_policy_the_columns_write() {
+    let columns: Vec<&str> = Policies::default()
+        .columns()
+        .into_iter()
+        .map(|(column, _)| column)
+        .collect();
+
+    // One catalog entry per column written, or a picker would be missing a
+    // control for something the bundle carries.
+    let kinds = [
+        OverVote::COLUMN,
+        BlankVote::COLUMN,
+        UnderVote::COLUMN,
+        InvalidVote::COLUMN,
+        DuplicatedRank::COLUMN,
+        PreferenceGaps::COLUMN,
+        CandidatesOrder::COLUMN,
+    ];
+    assert_eq!(columns, kinds);
+
+    // And every kind names a translation namespace, or a front end has nothing
+    // to label its values with and invents its own wording.
+    for labels in [
+        OverVote::LABELS,
+        BlankVote::LABELS,
+        UnderVote::LABELS,
+        InvalidVote::LABELS,
+        DuplicatedRank::LABELS,
+        PreferenceGaps::LABELS,
+        CandidatesOrder::LABELS,
+    ] {
+        assert!(!labels.is_empty());
+    }
+}

--- a/packages/sequent-core/src/election_config/policy_tests.rs
+++ b/packages/sequent-core/src/election_config/policy_tests.rs
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`].
+
+use super::*;
+use strum::IntoEnumIterator;
+
+/// The values the platform will accept, from the enum the Admin Portal uses.
+///
+/// Written out rather than derived, because the whole claim of this module is
+/// that its variants *are* those values. Deriving the expectation from the code
+/// under test would assert nothing.
+const OVER_VOTE: &[&str] = &[
+    "allowed",
+    "allowed-with-msg",
+    "allowed-with-msg-and-alert",
+    "not-allowed-with-msg-and-alert",
+    "not-allowed-with-msg-and-disable",
+];
+const BLANK_VOTE: &[&str] =
+    &["allowed", "warn", "warn-only-in-review", "not-allowed"];
+const UNDER_VOTE: &[&str] =
+    &["allowed", "warn", "warn-only-in-review", "warn-and-alert"];
+const INVALID_VOTE: &[&str] = &[
+    "allowed",
+    "warn",
+    "warn-invalid-implicit-and-explicit",
+    "not-allowed",
+];
+const DUPLICATED_RANK: &[&str] =
+    &["allowed-warn-and-dialog", "not-allowed-warn-and-dialog"];
+const CANDIDATES_ORDER: &[&str] = &["custom", "alphabetical", "random"];
+
+fn rendered<T: PolicyValue + IntoEnumIterator>() -> Vec<&'static str> {
+    T::iter().map(PolicyValue::as_str).collect()
+}
+
+// -- the claim this module makes -------------------------------------------
+
+#[test]
+fn every_variant_renders_as_a_value_the_platform_has() {
+    assert_eq!(rendered::<OverVote>(), OVER_VOTE);
+    assert_eq!(rendered::<BlankVote>(), BLANK_VOTE);
+    assert_eq!(rendered::<UnderVote>(), UNDER_VOTE);
+    assert_eq!(rendered::<InvalidVote>(), INVALID_VOTE);
+    assert_eq!(rendered::<DuplicatedRank>(), DUPLICATED_RANK);
+    assert_eq!(rendered::<PreferenceGaps>(), DUPLICATED_RANK);
+    assert_eq!(rendered::<CandidatesOrder>(), CANDIDATES_ORDER);
+}
+
+/// The three mistakes the previous implementations made, each now unwritable.
+#[test]
+fn the_values_those_mappings_invented_are_not_in_the_value_space() {
+    assert!(
+        !rendered::<UnderVote>().contains(&"not-allowed"),
+        "an under-vote cannot be refused; mapping 'restricted' onto it \
+         produced a value the platform does not have"
+    );
+    assert!(
+        !rendered::<OverVote>().contains(&"warn-only-in-review"),
+        "an over-vote has no review-only warning"
+    );
+    assert!(
+        rendered::<CandidatesOrder>().contains(&"alphabetical")
+            && !rendered::<CandidatesOrder>().contains(&"alphabetic"),
+        "the platform spells it 'alphabetical'"
+    );
+}
+
+#[test]
+fn a_value_round_trips_through_serde_as_its_wire_string() {
+    let text = serde_json::to_string(&UnderVote::WarnOnlyInReview).unwrap();
+    assert_eq!(text, "\"warn-only-in-review\"");
+    let read: UnderVote = serde_json::from_str(&text).unwrap();
+    assert_eq!(read, UnderVote::WarnOnlyInReview);
+}
+
+#[test]
+fn something_that_is_not_a_value_will_not_deserialize() {
+    assert!(serde_json::from_str::<UnderVote>("\"not-allowed\"").is_err());
+}
+
+/// One of the three copies of the value space killed at no cost.
+///
+/// `contest.hbs` carries the platform's defaults and this module carries the
+/// plan's; they have to be the same, or a plan that says nothing about a policy
+/// would compile to something other than the template's default.
+#[test]
+fn the_template_defaults_and_the_plan_defaults_agree() {
+    let template: serde_json::Value = {
+        let source = include_str!("templates/contest.hbs");
+        // Past the handlebars comment, whose `{{!--` would otherwise look like
+        // the start of the object.
+        let body = source
+            .split_once("--}}")
+            .map(|(_, rest)| rest)
+            .unwrap_or(source);
+        serde_json::from_str(body.trim())
+            .expect("contest.hbs is JSON once its comment is gone")
+    };
+    let presentation = &template["presentation"];
+
+    let defaults = Policies::default();
+    for (column, cell) in defaults.columns() {
+        let key = column
+            .strip_prefix("presentation.")
+            .expect("every policy is a presentation column");
+        let ours = match cell {
+            Cell::Text(text) => text,
+            other => panic!("a policy should render as text, got {other:?}"),
+        };
+        assert_eq!(
+            presentation[key],
+            serde_json::json!(ours),
+            "contest.hbs and Policies::default() disagree about {key}"
+        );
+    }
+}
+
+// -- resolving ---------------------------------------------------------------
+
+#[test]
+fn an_empty_patch_changes_nothing() {
+    let base = Policies::strict();
+    assert_eq!(base.apply(&PolicyPatch::default()), base);
+    assert!(PolicyPatch::default().is_empty());
+}
+
+#[test]
+fn a_patch_replaces_only_what_it_names() {
+    let patched = Policies::standard().apply(&PolicyPatch {
+        over_vote: Some(OverVote::Allowed),
+        ..Default::default()
+    });
+
+    assert_eq!(patched.over_vote, OverVote::Allowed);
+    assert_eq!(
+        patched.blank_vote,
+        Policies::standard().blank_vote,
+        "everything the patch did not name is untouched"
+    );
+}
+
+#[test]
+fn the_presets_differ_where_they_should() {
+    assert_eq!(Policies::permissive().over_vote, OverVote::Allowed);
+    assert_eq!(
+        Policies::strict().over_vote,
+        OverVote::NotAllowedWithMsgAndDisable
+    );
+    assert_eq!(Policies::standard(), Policies::default());
+}
+
+/// The one place a "strict" reading has to bend, and it bends toward a value
+/// that exists rather than toward one that would be rejected.
+#[test]
+fn strict_under_voting_warns_loudly_because_it_cannot_refuse() {
+    assert_eq!(Policies::strict().under_vote, UnderVote::WarnAndAlert);
+}
+
+// -- what it writes ----------------------------------------------------------
+
+#[test]
+fn every_policy_writes_the_column_the_builder_reads() {
+    let columns: Vec<&str> = Policies::default()
+        .columns()
+        .into_iter()
+        .map(|(column, _)| column)
+        .collect();
+
+    assert_eq!(
+        columns,
+        vec![
+            "presentation.over_vote_policy",
+            "presentation.blank_vote_policy",
+            "presentation.under_vote_policy",
+            "presentation.invalid_vote_policy",
+            "presentation.duplicated_rank_policy",
+            "presentation.preference_gaps_policy",
+            "presentation.candidates_order",
+        ]
+    );
+}
+
+/// A patch is what a level says; the resolved set is what a contest gets. The
+/// macro generates both from one declaration so a new policy cannot be added to
+/// one and forgotten in the other — this asserts they stayed the same size.
+#[test]
+fn the_patch_covers_exactly_the_policies_that_exist() {
+    let resolved = serde_json::to_value(Policies::default()).unwrap();
+    let full = PolicyPatch {
+        over_vote: Some(OverVote::Allowed),
+        blank_vote: Some(BlankVote::Allowed),
+        under_vote: Some(UnderVote::Allowed),
+        invalid_vote: Some(InvalidVote::Allowed),
+        duplicated_rank: Some(DuplicatedRank::AllowedWarnAndDialog),
+        preference_gaps: Some(PreferenceGaps::AllowedWarnAndDialog),
+        candidates_order: Some(CandidatesOrder::Random),
+    };
+    let patch = serde_json::to_value(full).unwrap();
+
+    assert_eq!(
+        resolved.as_object().unwrap().len(),
+        patch.as_object().unwrap().len()
+    );
+}

--- a/packages/sequent-core/src/election_config/policy_tests.rs
+++ b/packages/sequent-core/src/election_config/policy_tests.rs
@@ -201,10 +201,46 @@ fn the_patch_covers_exactly_the_policies_that_exist() {
     };
     let patch = serde_json::to_value(full).unwrap();
 
-    assert_eq!(
-        resolved.as_object().unwrap().len(),
-        patch.as_object().unwrap().len()
-    );
+    // Key sets, not lengths. Lengths agree by construction — both come from one
+    // macro invocation over one field list — so comparing them asserts nothing,
+    // and would still pass if the two sides used different *names*.
+    let names = |value: &serde_json::Value| -> Vec<String> {
+        value.as_object().unwrap().keys().cloned().collect()
+    };
+    assert_eq!(names(&resolved), names(&patch));
+}
+
+/// The catalog hand-writes each plan field name — `kind::<OverVote>("over_vote")`
+/// — and nothing else checks them against serde's.
+///
+/// A typo there makes the picker write `{overvot: "allowed"}`, which `Policies`
+/// silently discards: every field is `#[serde(default)]` and unknown keys are
+/// ignored. The choice vanishes between the dropdown and the bundle, with no
+/// error anywhere.
+#[test]
+fn the_catalog_names_the_fields_serde_actually_reads() {
+    // Sorted, because a `serde_json::Map`'s order is an implementation detail
+    // and what is being checked is the *names*.
+    let serialised = serde_json::to_value(Policies::default()).unwrap();
+    let mut from_serde: Vec<String> =
+        serialised.as_object().unwrap().keys().cloned().collect();
+    from_serde.sort();
+
+    // The same list `policy_catalog()` builds, in the same order. Kept here
+    // rather than imported because `wasm.rs` is behind a feature `cargo test`
+    // does not enable, so the catalog itself is never compiled by this suite.
+    let mut from_catalog = vec![
+        "over_vote".to_string(),
+        "blank_vote".to_string(),
+        "under_vote".to_string(),
+        "invalid_vote".to_string(),
+        "duplicated_rank".to_string(),
+        "preference_gaps".to_string(),
+        "candidates_order".to_string(),
+    ];
+    from_catalog.sort();
+
+    assert_eq!(from_serde, from_catalog);
 }
 
 /// The catalog is what stops the value space acquiring a fourth copy, so it has

--- a/packages/sequent-core/src/election_config/profile.rs
+++ b/packages/sequent-core/src/election_config/profile.rs
@@ -1,0 +1,488 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What a client's build of the wizard may say.
+//!
+//! A profile is how one customer's Election Architect differs from another's:
+//! values they never choose, screens they never see, and fields they must fill
+//! in. It is a build-time document, not a runtime permission — see below.
+//!
+//! # Paths, not top-level keys
+//!
+//! The TypeScript version could lock any top-level key of its config and nothing
+//! deeper (`LockableConfigKey = Exclude<keyof ElectionConfig, 'elections'>`,
+//! with `elections` carved out because ballot structure has to stay editable).
+//!
+//! That is not enough for what clients actually ask. `clients/smart-td.json`
+//! locks `defaultCountingAlgorithm`, but what SMART TD wants is "every contest is
+//! plurality-at-large" — and locking the event-wide default leaves every
+//! per-contest override wide open, which defeats the lock entirely.
+//!
+//! So a profile speaks in paths, with `[]` for "every element of this list":
+//!
+//! ```text
+//! trustee_threshold
+//! schedule.voting_opens
+//! elections[].contests[].overrides.tally.counting_algorithm
+//! ```
+//!
+//! The range is deliberately tiny — literal segments and `[]`, nothing else. No
+//! globs, because nobody can predict what one does; no indices, because a profile
+//! that can say `elections[2]` breaks when somebody reorders their ballot.
+//!
+//! # A profile is not a security boundary
+//!
+//! `hidden` decides what the wizard draws. It is not access control, and anyone
+//! who edits the saved plan can write whatever they like into a hidden field.
+//! What makes a locked value stick is [`apply_profile`], which runs in Rust
+//! before validation — so the locked value is the one that gets checked and the
+//! one that gets built, whatever the document said.
+//!
+//! The TypeScript version guarded this twice, in `stripLockedUpdates` on write
+//! and `reapplyLockedFields` on import, and both were bypassable by editing the
+//! JSON. One enforcement point, on the path everything takes, is the whole idea.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use super::architect::Blueprint;
+use super::problem::{Code, Problem, Report};
+
+/// One step along a path into a plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Segment {
+    Field(String),
+    /// `[]` — every element of the list this lands on.
+    EveryElement,
+}
+
+/// A place in a plan a profile can speak about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanPath {
+    text: String,
+    segments: Vec<Segment>,
+}
+
+impl PlanPath {
+    /// Read a path, refusing the shapes that would be a trap.
+    pub fn parse(text: &str) -> Result<PlanPath, String> {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return Err("a path cannot be empty".to_string());
+        }
+
+        let mut segments = Vec::new();
+        for part in trimmed.split('.') {
+            let (name, brackets) = match part.find('[') {
+                Some(at) => (&part[..at], &part[at..]),
+                None => (part, ""),
+            };
+
+            if name.trim().is_empty() {
+                return Err(format!(
+                    "'{trimmed}' has an empty segment; paths look like \
+                     elections[].contests[].max_votes"
+                ));
+            }
+            segments.push(Segment::Field(name.trim().to_string()));
+
+            match brackets {
+                "" => {}
+                "[]" => segments.push(Segment::EveryElement),
+                other => return Err(only_every_element(trimmed, other)),
+            }
+        }
+
+        Ok(PlanPath {
+            text: trimmed.to_string(),
+            segments,
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    /// Every place in `value` this path reaches, as a mutable reference.
+    ///
+    /// A path over a list that is empty reaches nothing, which is not an error —
+    /// a profile locking every contest's counting algorithm is still correct for
+    /// a plan with no contests yet.
+    fn resolve<'a>(&self, value: &'a mut Value) -> Vec<&'a mut Value> {
+        let mut here: Vec<&mut Value> = vec![value];
+
+        for (index, segment) in self.segments.iter().enumerate() {
+            let last = index == self.segments.len() - 1;
+            let mut next: Vec<&mut Value> = Vec::new();
+
+            for current in here {
+                match segment {
+                    Segment::Field(name) => {
+                        let Some(object) = current.as_object_mut() else {
+                            continue;
+                        };
+                        // The final field is created when absent, so a profile
+                        // can supply a default the plan has not got. An
+                        // intermediate one is not: inventing `schedule` to hold
+                        // a `voting_opens` would build a shape the plan's own
+                        // type does not have.
+                        if last && !object.contains_key(name) {
+                            object.insert(name.clone(), Value::Null);
+                        }
+                        if let Some(found) = object.get_mut(name) {
+                            next.push(found);
+                        }
+                    }
+                    Segment::EveryElement => {
+                        if let Some(list) = current.as_array_mut() {
+                            next.extend(list.iter_mut());
+                        }
+                    }
+                }
+            }
+            here = next;
+        }
+
+        here
+    }
+}
+
+/// Why a subscript other than `[]` is refused.
+fn only_every_element(path: &str, subscript: &str) -> String {
+    format!(
+        "'{path}' uses '{subscript}'. Only '[]' — every element — is \
+         understood: an index breaks as soon as somebody reorders their \
+         ballot, and a pattern is something nobody can predict the effect of."
+    )
+}
+
+impl fmt::Display for PlanPath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.text)
+    }
+}
+
+/// Build-time configuration of one client's wizard.
+///
+/// Paths are strings here because that is what JSON has; they are parsed and
+/// checked by [`ClientProfile::read`], which is the only way to get one.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClientProfile {
+    pub id: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+
+    /// Values a new plan starts with, and what a locked or hidden path is forced
+    /// back to whatever the plan says.
+    #[serde(default)]
+    pub defaults: BTreeMap<String, Value>,
+
+    /// Shown, but not editable.
+    #[serde(default)]
+    pub locked: Vec<String>,
+
+    /// Not shown at all. Enforced exactly like `locked` — see the module docs on
+    /// why this is not a permission.
+    #[serde(default)]
+    pub hidden: Vec<String>,
+
+    /// Must be filled in. Additive: the baseline every build enforces is in
+    /// [`validate_plan`](super::architect::validate_plan) and is not listed here.
+    #[serde(default)]
+    pub required: Vec<String>,
+}
+
+/// A profile with every path parsed and checked.
+#[derive(Debug, Clone)]
+pub struct Profile {
+    pub id: String,
+    pub display_name: Option<String>,
+
+    /// What is odd about this profile without being wrong with it. Carried
+    /// rather than discarded, so [`compile_plan`](super::architect::compile_plan)
+    /// can fold it into the report somebody actually reads.
+    pub warnings: Report,
+    defaults: Vec<(PlanPath, Value)>,
+    locked: Vec<PlanPath>,
+    hidden: Vec<PlanPath>,
+    required: Vec<PlanPath>,
+}
+
+impl Profile {
+    /// Read a profile document, refusing one that cannot mean what it says.
+    ///
+    /// A path naming a field no plan has is refused here rather than ignored. A
+    /// profile with a typo in it silently configures nothing, which is the
+    /// failure nobody notices until a client asks why their build looks like
+    /// everybody else's.
+    pub fn read(document: &ClientProfile) -> Result<Profile, Report> {
+        let mut report = Report::default();
+        let shape = shape_of_a_plan();
+
+        let mut parse_all = |paths: &[String], field: &str| -> Vec<PlanPath> {
+            let mut parsed = Vec::new();
+            for (index, text) in paths.iter().enumerate() {
+                match PlanPath::parse(text) {
+                    Ok(path) => {
+                        if !reaches_anything(&path, &shape) {
+                            report.push(Problem::error(
+                                Code::DanglingReference,
+                                format!("{field}[{index}]"),
+                                format!(
+                                    "'{path}' names nothing a plan has. A path \
+                                     that reaches nothing configures nothing, \
+                                     silently."
+                                ),
+                            ));
+                        }
+                        parsed.push(path);
+                    }
+                    Err(why) => report.push(Problem::error(
+                        Code::InvalidValue,
+                        format!("{field}[{index}]"),
+                        why,
+                    )),
+                }
+            }
+            parsed
+        };
+
+        let locked = parse_all(&document.locked, "locked");
+        let hidden = parse_all(&document.hidden, "hidden");
+        let required = parse_all(&document.required, "required");
+
+        let mut defaults = Vec::new();
+        for (index, (text, value)) in document.defaults.iter().enumerate() {
+            match PlanPath::parse(text) {
+                Ok(path) => {
+                    if !reaches_anything(&path, &shape) {
+                        report.push(Problem::error(
+                            Code::DanglingReference,
+                            format!("defaults[{index}]"),
+                            format!("'{path}' names nothing a plan has"),
+                        ));
+                    }
+                    defaults.push((path, value.clone()));
+                }
+                Err(why) => report.push(Problem::error(
+                    Code::InvalidValue,
+                    format!("defaults[{index}]"),
+                    why,
+                )),
+            }
+        }
+
+        if document.id.trim().is_empty() {
+            report.push(Problem::error(
+                Code::MissingField,
+                "id",
+                "a profile needs an id; it names the file and the build",
+            ));
+        }
+
+        for path in locked.iter().chain(hidden.iter()) {
+            if !defaults.iter().any(|(each, _)| each == path) {
+                report.push(Problem::warning(
+                    Code::MissingField,
+                    "defaults",
+                    format!(
+                        "'{path}' is locked or hidden but has no default, so it \
+                         is fixed at whatever the plan happens to say — which is \
+                         nothing, for a new one"
+                    ),
+                ));
+            }
+        }
+
+        if report.has_errors() {
+            return Err(report);
+        }
+
+        Ok(Profile {
+            id: document.id.clone(),
+            display_name: document.display_name.clone(),
+            warnings: report,
+            defaults,
+            locked,
+            hidden,
+            required,
+        })
+    }
+
+    /// The paths the wizard should not draw, for the front end to act on.
+    ///
+    /// Rust decides *which paths*, because that is a statement about the plan.
+    /// Which screens that empties is a question about screens, and belongs to
+    /// whoever draws them.
+    pub fn hidden_paths(&self) -> Vec<&str> {
+        self.hidden.iter().map(PlanPath::as_str).collect()
+    }
+
+    pub fn locked_paths(&self) -> Vec<&str> {
+        self.locked.iter().map(PlanPath::as_str).collect()
+    }
+
+    /// Whether a path is fixed by this profile, hidden or merely shown as read
+    /// only. Both are enforced the same way; only the drawing differs.
+    fn is_fixed(&self, path: &PlanPath) -> bool {
+        self.locked.contains(path) || self.hidden.contains(path)
+    }
+}
+
+/// Fill a plan's defaults and force what the profile fixes.
+///
+/// Two different things, and the difference is the whole of it:
+///
+/// * a **fixed** path — locked or hidden — is written unconditionally. That is
+///   what makes the lock hold against a hand-edited plan.
+/// * any other default is written only where the plan says nothing, so it seeds
+///   a new plan without overwriting an answer somebody gave.
+///
+/// Works over the plan as JSON and deserializes back, so it needs no knowledge
+/// of the plan's shape and cannot fall out of step with it.
+pub fn apply_profile(
+    plan: &Blueprint,
+    profile: &Profile,
+) -> Result<Blueprint, Report> {
+    let mut document = serde_json::to_value(plan).map_err(|error| {
+        one(Problem::error(
+            Code::InvalidValue,
+            "plan",
+            format!(
+                "this plan cannot be read as JSON, which is a bug: {error}"
+            ),
+        ))
+    })?;
+
+    for (path, value) in &profile.defaults {
+        let fixed = profile.is_fixed(path);
+        for target in path.resolve(&mut document) {
+            if fixed || is_unset(target) {
+                *target = value.clone();
+            }
+        }
+    }
+
+    serde_json::from_value(document).map_err(|error| {
+        one(Problem::error(
+            Code::InvalidValue,
+            "profile.defaults",
+            format!(
+                "applying this profile produced something that is not a plan, so \
+                 one of its defaults is the wrong shape for where it was put: \
+                 {error}"
+            ),
+        ))
+    })
+}
+
+/// The profile's own required fields, as problems on the paths that own them.
+///
+/// Deliberately not a boolean. Validation already returns a report whose paths
+/// the wizard routes to the step that can fix each one, so a required field
+/// lands on the right screen for free. The TypeScript version needed
+/// `FIELD_WIZARD_STEP`, a hand-maintained map of thirty keys to steps, and
+/// `isFieldFilled`, a thirty-arm switch — both only because its paths were flat.
+pub fn check_required(
+    plan: &Blueprint,
+    profile: &Profile,
+    report: &mut Report,
+) {
+    let Ok(mut document) = serde_json::to_value(plan) else {
+        return;
+    };
+
+    for path in &profile.required {
+        let targets = path.resolve(&mut document);
+        // A path over an empty list reaches nothing. That is itself the thing
+        // being complained about when the list is what was required.
+        if targets.is_empty() || targets.iter().any(|target| is_unset(target)) {
+            report.push(Problem::error(
+                Code::MissingField,
+                path.as_str(),
+                "this build requires this to be filled in".to_string(),
+            ));
+        }
+    }
+}
+
+/// Whether a value counts as "nobody has said".
+///
+/// Null, empty text, an empty list and an empty object all do. Zero and `false`
+/// do not — they are answers, and a threshold of 0 being treated as unset is how
+/// a default quietly overwrites a deliberate choice.
+fn is_unset(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::String(text) => text.trim().is_empty(),
+        Value::Array(list) => list.is_empty(),
+        Value::Object(object) => object.is_empty(),
+        _ => false,
+    }
+}
+
+fn one(problem: Problem) -> Report {
+    let mut report = Report::default();
+    report.push(problem);
+    report
+}
+
+/// A plan with one of everything, for checking that a path reaches something.
+///
+/// Serializing [`Blueprint::default`] would give empty lists, and a path through
+/// `elections[]` would reach nothing and look like a typo. This has one element
+/// in each list so the shape is walkable all the way down.
+fn shape_of_a_plan() -> Value {
+    let mut plan = Blueprint {
+        version: super::architect::BLUEPRINT_VERSION,
+        ..Default::default()
+    };
+    plan.contacts.push(Default::default());
+    plan.trustees.push(Default::default());
+    plan.areas.push(Default::default());
+    plan.schedule.milestones.push(Default::default());
+
+    let mut election = super::architect::PlannedElection::default();
+    let mut contest = super::architect::PlannedContest::default();
+    contest.candidates.push(Default::default());
+    election.contests.push(contest);
+    plan.elections.push(election);
+
+    serde_json::to_value(&plan).unwrap_or(Value::Object(Map::new()))
+}
+
+/// Whether the path lands on something in a plan-shaped document.
+fn reaches_anything(path: &PlanPath, shape: &Value) -> bool {
+    let mut copy = shape.clone();
+    // `resolve` creates a missing final field, so asking it directly would
+    // always say yes. Walk the parent instead and look for the name.
+    match path.segments.split_last() {
+        Some((Segment::Field(name), parents)) => {
+            let parent = PlanPath {
+                text: String::new(),
+                segments: parents.to_vec(),
+            };
+            if parents.is_empty() {
+                return copy
+                    .as_object()
+                    .is_some_and(|object| object.contains_key(name));
+            }
+            parent.resolve(&mut copy).into_iter().any(|value| {
+                value
+                    .as_object()
+                    .is_some_and(|object| object.contains_key(name))
+            })
+        }
+        // Ends in `[]`: the list itself has to exist.
+        _ => !path.resolve(&mut copy).is_empty(),
+    }
+}
+
+#[cfg(test)]
+#[path = "profile_tests.rs"]
+mod profile_tests;

--- a/packages/sequent-core/src/election_config/profile.rs
+++ b/packages/sequent-core/src/election_config/profile.rs
@@ -332,6 +332,15 @@ impl Profile {
         self.locked.iter().map(PlanPath::as_str).collect()
     }
 
+    /// The paths this build additionally insists on.
+    ///
+    /// Enforcing them is [`check_required`]'s job, in Rust. This is so a form
+    /// can mark them — a required field with no asterisk is a form somebody
+    /// fills in twice.
+    pub fn required_paths(&self) -> Vec<&str> {
+        self.required.iter().map(PlanPath::as_str).collect()
+    }
+
     /// Whether a path is fixed by this profile, hidden or merely shown as read
     /// only. Both are enforced the same way; only the drawing differs.
     fn is_fixed(&self, path: &PlanPath) -> bool {

--- a/packages/sequent-core/src/election_config/profile.rs
+++ b/packages/sequent-core/src/election_config/profile.rs
@@ -257,13 +257,13 @@ impl Profile {
         let required = parse_all(&document.required, "required");
 
         let mut defaults = Vec::new();
-        for (index, (text, value)) in document.defaults.iter().enumerate() {
+        for (text, value) in document.defaults.iter() {
             match PlanPath::parse(text) {
                 Ok(path) => {
                     if !reaches_anything(&path, &shape) {
                         report.push(Problem::error(
                             Code::DanglingReference,
-                            format!("defaults[{index}]"),
+                            format!("defaults.{text}"),
                             format!("'{path}' names nothing a plan has"),
                         ));
                     }
@@ -271,7 +271,7 @@ impl Profile {
                 }
                 Err(why) => report.push(Problem::error(
                     Code::InvalidValue,
-                    format!("defaults[{index}]"),
+                    format!("defaults.{text}"),
                     why,
                 )),
             }
@@ -287,13 +287,18 @@ impl Profile {
 
         for path in locked.iter().chain(hidden.iter()) {
             if !defaults.iter().any(|(each, _)| each == path) {
-                report.push(Problem::warning(
+                // An error, not a warning. `apply_profile` writes only what
+                // `defaults` names, so a lock with nothing to lock *to* fixes
+                // the field at whatever the plan happens to say — which for a
+                // new plan is nothing. There is no case where that is useful,
+                // and a profile that quietly enforces none of what it claims is
+                // worse than one that will not load.
+                report.push(Problem::error(
                     Code::MissingField,
                     "defaults",
                     format!(
-                        "'{path}' is locked or hidden but has no default, so it \
-                         is fixed at whatever the plan happens to say — which is \
-                         nothing, for a new one"
+                        "'{path}' is locked or hidden but has no default, so \
+                         nothing would be enforced. Give it a value."
                     ),
                 ));
             }
@@ -438,6 +443,8 @@ fn one(problem: Problem) -> Report {
 /// `elections[]` would reach nothing and look like a typo. This has one element
 /// in each list so the shape is walkable all the way down.
 fn shape_of_a_plan() -> Value {
+    use super::policy::{Overrides, PolicyPatch, TallyPatch};
+
     let mut plan = Blueprint {
         version: super::architect::BLUEPRINT_VERSION,
         ..Default::default()
@@ -446,10 +453,49 @@ fn shape_of_a_plan() -> Value {
     plan.trustees.push(Default::default());
     plan.areas.push(Default::default());
     plan.schedule.milestones.push(Default::default());
+    // Every moment, filled in. `Option` serialises as `null`, which has no keys
+    // to walk into, and `zone` is skipped while empty — so a shape built from
+    // defaults makes `schedule.voting_opens.zone` look like a typo.
+    let moment =
+        Some(super::time::Timestamp::new("2027-01-01T00:00", "UTC", 0));
+    plan.schedule.key_ceremony = moment.clone();
+    plan.schedule.voting_opens = moment.clone();
+    plan.schedule.voting_closes = moment.clone();
+    plan.schedule.tally_ceremony = moment;
 
-    let mut election = super::architect::PlannedElection::default();
-    let mut contest = super::architect::PlannedContest::default();
+    // Filled rather than defaulted, because `Overrides` and `Option<Overrides>`
+    // both carry `skip_serializing_if`. Left empty they vanish from the shape,
+    // and every path through them — including
+    // `elections[].contests[].overrides.tally.counting_algorithm`, the example
+    // this whole design exists for — is refused as naming nothing.
+    let filled = Overrides {
+        policies: PolicyPatch {
+            over_vote: Some(Default::default()),
+            blank_vote: Some(Default::default()),
+            under_vote: Some(Default::default()),
+            invalid_vote: Some(Default::default()),
+            duplicated_rank: Some(Default::default()),
+            preference_gaps: Some(Default::default()),
+            candidates_order: Some(Default::default()),
+        },
+        tally: TallyPatch {
+            voting_type: Some(String::new()),
+            counting_algorithm: Some(String::new()),
+            min_votes: Some(0),
+            is_encrypted: Some(true),
+        },
+    };
+
+    let mut contest = super::architect::PlannedContest {
+        overrides: filled.clone(),
+        ..Default::default()
+    };
     contest.candidates.push(Default::default());
+
+    let mut election = super::architect::PlannedElection {
+        shared: Some(filled),
+        ..Default::default()
+    };
     election.contests.push(contest);
     plan.elections.push(election);
 

--- a/packages/sequent-core/src/election_config/profile_tests.rs
+++ b/packages/sequent-core/src/election_config/profile_tests.rs
@@ -1,0 +1,478 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`].
+
+use super::*;
+use crate::election_config::architect::{
+    PlannedCandidate, PlannedContest, PlannedElection, Translated, Trustee,
+    BLUEPRINT_VERSION,
+};
+use crate::election_config::problem::Severity;
+
+fn plan() -> Blueprint {
+    Blueprint {
+        version: BLUEPRINT_VERSION,
+        external_id: "union-2027".to_string(),
+        name: Translated::new("Union Election 2027"),
+        trustees: vec![
+            Trustee {
+                name: "A".to_string(),
+                email: "a@example.org".to_string(),
+            },
+            Trustee {
+                name: "B".to_string(),
+                email: "b@example.org".to_string(),
+            },
+        ],
+        trustee_threshold: 2,
+        elections: vec![PlannedElection {
+            external_id: "officers".to_string(),
+            name: Translated::new("Officers"),
+            contests: vec![
+                PlannedContest {
+                    external_id: "president".to_string(),
+                    name: Translated::new("President"),
+                    max_votes: 1,
+                    winners: 1,
+                    candidates: vec![PlannedCandidate {
+                        external_id: "alice".to_string(),
+                        name: Translated::new("Alice"),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                PlannedContest {
+                    external_id: "board".to_string(),
+                    name: Translated::new("Board"),
+                    max_votes: 3,
+                    winners: 3,
+                    ..Default::default()
+                },
+            ],
+        }],
+        ..Default::default()
+    }
+}
+
+fn profile_of(document: ClientProfile) -> Profile {
+    match Profile::read(&document) {
+        Ok(profile) => profile,
+        Err(report) => panic!("expected a readable profile, got:\n{report}"),
+    }
+}
+
+fn refused(document: ClientProfile) -> Report {
+    Profile::read(&document).expect_err("this profile should be refused")
+}
+
+fn says(report: &Report, needle: &str) -> bool {
+    report
+        .problems
+        .iter()
+        .any(|problem| problem.message.contains(needle))
+}
+
+fn defaults(pairs: &[(&str, Value)]) -> BTreeMap<String, Value> {
+    pairs
+        .iter()
+        .map(|(path, value)| (path.to_string(), value.clone()))
+        .collect()
+}
+
+// -- reading a path --------------------------------------------------------
+
+#[test]
+fn a_path_may_name_a_field_a_list_and_a_field_inside_it() {
+    let path = PlanPath::parse("elections[].contests[].max_votes")
+        .expect("this is the shape the whole design rests on");
+    assert_eq!(path.as_str(), "elections[].contests[].max_votes");
+}
+
+#[test]
+fn an_index_is_refused_because_reordering_a_ballot_would_break_it() {
+    let why = PlanPath::parse("elections[0].contests[].max_votes")
+        .expect_err("an index should be refused");
+    assert!(why.contains("reorders their ballot"), "{why}");
+}
+
+#[test]
+fn a_pattern_is_refused() {
+    assert!(PlanPath::parse("elections[*].max_votes").is_err());
+}
+
+#[test]
+fn an_empty_segment_is_refused() {
+    assert!(PlanPath::parse("elections..max_votes").is_err());
+    assert!(PlanPath::parse("").is_err());
+}
+
+/// The failure worth catching: a profile with a typo configures nothing at all,
+/// and does it silently.
+#[test]
+fn a_path_naming_a_field_no_plan_has_is_refused() {
+    let report = refused(ClientProfile {
+        id: "acme".to_string(),
+        locked: vec!["trustee_threshhold".to_string()],
+        ..Default::default()
+    });
+    assert!(says(&report, "names nothing a plan has"));
+}
+
+#[test]
+fn a_path_reaching_into_a_contest_is_accepted() {
+    profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[(
+            "elections[].contests[].max_votes",
+            Value::from(1),
+        )]),
+        locked: vec!["elections[].contests[].max_votes".to_string()],
+        ..Default::default()
+    });
+}
+
+#[test]
+fn a_profile_needs_an_id() {
+    let report = refused(ClientProfile::default());
+    assert!(says(&report, "a profile needs an id"));
+}
+
+/// Locking a path with nothing to lock it *to* fixes it at whatever the plan
+/// happens to say — which for a new plan is nothing. Odd rather than wrong, so
+/// the profile still reads, and the warning travels with it.
+#[test]
+fn locking_something_with_no_default_is_a_warning_that_survives() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        locked: vec!["trustee_threshold".to_string()],
+        ..Default::default()
+    });
+
+    assert!(!profile.warnings.has_errors());
+    assert!(
+        says(&profile.warnings, "has no default"),
+        "the warning must reach whoever reads the report, not be computed and \
+         dropped: {}",
+        profile.warnings
+    );
+}
+
+// -- applying one ----------------------------------------------------------
+
+#[test]
+fn a_locked_value_survives_a_plan_that_disagrees() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[("trustee_threshold", Value::from(3))]),
+        locked: vec!["trustee_threshold".to_string()],
+        ..Default::default()
+    });
+
+    let mut disagrees = plan();
+    disagrees.trustee_threshold = 1;
+
+    let applied = apply_profile(&disagrees, &profile).expect("applies");
+    assert_eq!(applied.trustee_threshold, 3, "the lock has to hold");
+}
+
+#[test]
+fn a_hidden_value_is_forced_exactly_like_a_locked_one() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[("notes", Value::from("set by the profile"))]),
+        hidden: vec!["notes".to_string()],
+        ..Default::default()
+    });
+
+    let mut disagrees = plan();
+    disagrees.notes = "typed by hand into the saved file".to_string();
+
+    let applied = apply_profile(&disagrees, &profile).expect("applies");
+    assert_eq!(applied.notes, "set by the profile");
+}
+
+/// The reason paths are worth having. One entry reaches every contest, however
+/// many there are and whatever they are called.
+#[test]
+fn one_path_with_every_element_reaches_every_contest() {
+    let profile = profile_of(ClientProfile {
+        id: "smart-td".to_string(),
+        defaults: defaults(&[(
+            "elections[].contests[].description",
+            Value::from("Set for every contest"),
+        )]),
+        locked: vec!["elections[].contests[].description".to_string()],
+        ..Default::default()
+    });
+
+    let applied = apply_profile(&plan(), &profile).expect("applies");
+    let descriptions: Vec<&str> = applied.elections[0]
+        .contests
+        .iter()
+        .map(|contest| contest.description.as_str())
+        .collect();
+
+    assert_eq!(
+        descriptions,
+        vec!["Set for every contest", "Set for every contest"]
+    );
+}
+
+/// A default is a starting point, not an override — otherwise opening a saved
+/// plan would quietly discard the answers somebody gave.
+#[test]
+fn an_unlocked_default_seeds_an_empty_field_and_leaves_an_answered_one() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[
+            ("notes", Value::from("a starting note")),
+            ("external_id", Value::from("should-not-win")),
+        ]),
+        ..Default::default()
+    });
+
+    let applied = apply_profile(&plan(), &profile).expect("applies");
+
+    assert_eq!(applied.notes, "a starting note", "was empty, so seeded");
+    assert_eq!(
+        applied.external_id, "union-2027",
+        "was answered, so left alone"
+    );
+}
+
+/// Zero and false are answers. Treating them as unset is how a default quietly
+/// overwrites a deliberate choice.
+#[test]
+fn a_zero_counts_as_an_answer_not_as_an_empty_field() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[("trustee_threshold", Value::from(5))]),
+        ..Default::default()
+    });
+
+    let mut chose_zero = plan();
+    chose_zero.trustee_threshold = 0;
+
+    let applied = apply_profile(&chose_zero, &profile).expect("applies");
+    assert_eq!(applied.trustee_threshold, 0);
+}
+
+#[test]
+fn a_profile_with_nothing_in_it_changes_nothing() {
+    let profile = profile_of(ClientProfile {
+        id: "default".to_string(),
+        ..Default::default()
+    });
+    assert_eq!(apply_profile(&plan(), &profile).expect("applies"), plan());
+}
+
+/// A plan with no contests yet is not a plan the profile is wrong about.
+#[test]
+fn a_path_over_an_empty_list_reaches_nothing_and_says_nothing() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[(
+            "elections[].contests[].max_votes",
+            Value::from(1),
+        )]),
+        locked: vec!["elections[].contests[].max_votes".to_string()],
+        ..Default::default()
+    });
+
+    let empty = Blueprint {
+        version: BLUEPRINT_VERSION,
+        ..Default::default()
+    };
+    assert!(apply_profile(&empty, &profile).is_ok());
+}
+
+#[test]
+fn a_default_of_the_wrong_shape_is_reported_rather_than_panicking() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[(
+            "trustee_threshold",
+            Value::from("not a number"),
+        )]),
+        locked: vec!["trustee_threshold".to_string()],
+        ..Default::default()
+    });
+
+    let report = apply_profile(&plan(), &profile)
+        .expect_err("a string is not a threshold");
+    assert!(says(&report, "the wrong shape for where it was put"));
+}
+
+// -- required --------------------------------------------------------------
+
+/// The path is the point: the wizard routes a problem to the step that owns its
+/// path, so a required field lands on the right screen with no extra table.
+#[test]
+fn a_required_field_left_empty_is_an_error_on_the_path_that_owns_it() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        required: vec!["logo_url".to_string()],
+        ..Default::default()
+    });
+
+    let mut report = Report::default();
+    check_required(&plan(), &profile, &mut report);
+
+    assert_eq!(report.problems.len(), 1);
+    assert_eq!(report.problems[0].path, "logo_url");
+    assert_eq!(report.problems[0].severity, Severity::Error);
+}
+
+#[test]
+fn a_required_field_that_is_filled_in_says_nothing() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        required: vec!["external_id".to_string()],
+        ..Default::default()
+    });
+
+    let mut report = Report::default();
+    check_required(&plan(), &profile, &mut report);
+    assert!(report.problems.is_empty());
+}
+
+#[test]
+fn requiring_a_list_that_is_empty_is_an_error() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        required: vec!["contacts".to_string()],
+        ..Default::default()
+    });
+
+    let mut report = Report::default();
+    check_required(&plan(), &profile, &mut report);
+    assert_eq!(report.problems.len(), 1, "no contacts were named");
+}
+
+#[test]
+fn requiring_something_of_every_contest_checks_every_contest() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        required: vec!["elections[].contests[].description".to_string()],
+        ..Default::default()
+    });
+
+    let mut report = Report::default();
+    check_required(&plan(), &profile, &mut report);
+    assert_eq!(report.problems.len(), 1, "neither contest has one");
+}
+
+// -- what the front end is told --------------------------------------------
+
+#[test]
+fn the_hidden_and_locked_paths_are_handed_over_as_they_were_written() {
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[
+            ("notes", Value::from("x")),
+            ("logo_url", Value::from("y")),
+        ]),
+        hidden: vec!["notes".to_string()],
+        locked: vec!["logo_url".to_string()],
+        ..Default::default()
+    });
+
+    assert_eq!(profile.hidden_paths(), vec!["notes"]);
+    assert_eq!(profile.locked_paths(), vec!["logo_url"]);
+}
+
+// -- through the whole compile ---------------------------------------------
+
+/// The end-to-end property. A locked value has to reach the *bundle*, not just
+/// the plan — anything less and the lock is decoration.
+#[test]
+fn a_locked_value_reaches_the_built_bundle() {
+    use crate::election_config::architect::compile_plan;
+    use crate::election_config::{BuildOptions, TemplateSet};
+
+    let profile = profile_of(ClientProfile {
+        id: "smart-td".to_string(),
+        defaults: defaults(&[(
+            "elections[].contests[].description",
+            Value::from("Locked by the build"),
+        )]),
+        locked: vec!["elections[].contests[].description".to_string()],
+        ..Default::default()
+    });
+
+    let mut disagrees = plan();
+    disagrees.elections[0].contests[0].description =
+        "typed by hand".to_string();
+
+    let templates = TemplateSet::builtin().unwrap();
+    let compiled = compile_plan(
+        &disagrees,
+        &templates,
+        &BuildOptions::default(),
+        Some(&profile),
+    )
+    .expect("compiles");
+
+    let descriptions: Vec<&str> = compiled.bundle.export["contests"]
+        .as_array()
+        .expect("contests")
+        .iter()
+        .map(|contest| contest["description"].as_str().unwrap_or_default())
+        .collect();
+
+    assert!(
+        descriptions
+            .iter()
+            .all(|each| *each == "Locked by the build"),
+        "the lock has to survive all the way into the bundle: {descriptions:?}"
+    );
+}
+
+/// A required field the profile adds stops the build, in the plan's own
+/// vocabulary, on the path the wizard routes by.
+#[test]
+fn a_profiles_required_field_stops_the_build() {
+    use crate::election_config::architect::compile_plan;
+    use crate::election_config::{BuildOptions, TemplateSet};
+
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        required: vec!["logo_url".to_string()],
+        ..Default::default()
+    });
+
+    let templates = TemplateSet::builtin().unwrap();
+    let report = compile_plan(
+        &plan(),
+        &templates,
+        &BuildOptions::default(),
+        Some(&profile),
+    )
+    .expect_err("this build requires a logo");
+
+    assert!(report
+        .problems
+        .iter()
+        .any(|problem| problem.path == "logo_url"));
+}
+
+#[test]
+fn a_profile_document_round_trips_through_json() {
+    let document = ClientProfile {
+        id: "smart-td".to_string(),
+        display_name: Some("SMART TD Locals".to_string()),
+        defaults: defaults(&[("trustee_threshold", Value::from(3))]),
+        locked: vec!["trustee_threshold".to_string()],
+        hidden: vec!["notes".to_string()],
+        required: vec!["logo_url".to_string()],
+    };
+
+    let text = serde_json::to_string(&document).unwrap();
+    let read: ClientProfile = serde_json::from_str(&text).unwrap();
+
+    assert_eq!(read.id, "smart-td");
+    assert_eq!(read.locked, vec!["trustee_threshold".to_string()]);
+    assert_eq!(read.defaults["trustee_threshold"], Value::from(3));
+}

--- a/packages/sequent-core/src/election_config/profile_tests.rs
+++ b/packages/sequent-core/src/election_config/profile_tests.rs
@@ -28,6 +28,7 @@ fn plan() -> Blueprint {
         ],
         trustee_threshold: 2,
         elections: vec![PlannedElection {
+            shared: None,
             external_id: "officers".to_string(),
             name: Translated::new("Officers"),
             contests: vec![

--- a/packages/sequent-core/src/election_config/profile_tests.rs
+++ b/packages/sequent-core/src/election_config/profile_tests.rs
@@ -121,6 +121,34 @@ fn a_path_naming_a_field_no_plan_has_is_refused() {
     assert!(says(&report, "names nothing a plan has"));
 }
 
+/// The paths the module docs and the delivery docs both print as the reason
+/// this design exists. They were **refused**: `Overrides` and `shared` carry
+/// `skip_serializing_if`, so the shape a path is checked against had no such
+/// keys, and the motivating example was unimplementable.
+#[test]
+fn the_paths_the_docs_advertise_are_accepted() {
+    for path in [
+        "elections[].contests[].overrides.tally.counting_algorithm",
+        "elections[].contests[].overrides.policies.over_vote",
+        "elections[].shared.tally.counting_algorithm",
+        "elections[].shared.policies.over_vote",
+        "schedule.voting_opens",
+        "schedule.voting_opens.zone",
+        "trustee_threshold",
+    ] {
+        let document = ClientProfile {
+            id: "acme".to_string(),
+            defaults: defaults(&[(path, Value::from("x"))]),
+            locked: vec![path.to_string()],
+            ..Default::default()
+        };
+        assert!(
+            Profile::read(&document).is_ok(),
+            "'{path}' is printed in the docs and must be usable"
+        );
+    }
+}
+
 #[test]
 fn a_path_reaching_into_a_contest_is_accepted() {
     profile_of(ClientProfile {
@@ -140,23 +168,40 @@ fn a_profile_needs_an_id() {
     assert!(says(&report, "a profile needs an id"));
 }
 
-/// Locking a path with nothing to lock it *to* fixes it at whatever the plan
-/// happens to say — which for a new plan is nothing. Odd rather than wrong, so
-/// the profile still reads, and the warning travels with it.
+/// A lock with nothing to lock *to* enforces nothing: `apply_profile` writes
+/// only what `defaults` names. It used to be a warning, which meant a profile
+/// could load, claim to fix a field, and fix nothing.
 #[test]
-fn locking_something_with_no_default_is_a_warning_that_survives() {
-    let profile = profile_of(ClientProfile {
+fn locking_something_with_no_default_is_refused() {
+    let report = refused(ClientProfile {
         id: "acme".to_string(),
         locked: vec!["trustee_threshold".to_string()],
         ..Default::default()
     });
 
-    assert!(!profile.warnings.has_errors());
-    assert!(
-        says(&profile.warnings, "has no default"),
-        "the warning must reach whoever reads the report, not be computed and \
-         dropped: {}",
-        profile.warnings
+    assert!(report.has_errors());
+    assert!(says(&report, "nothing would be enforced"));
+}
+
+/// Proof of the above, at the level that matters: with the lock unenforced, a
+/// hand-edited plan simply keeps its own value.
+#[test]
+fn a_lock_without_a_default_would_have_enforced_nothing() {
+    // Constructed directly, since `Profile::read` now refuses this shape.
+    let profile = profile_of(ClientProfile {
+        id: "acme".to_string(),
+        defaults: defaults(&[("trustee_threshold", Value::from(3))]),
+        locked: vec!["trustee_threshold".to_string()],
+        ..Default::default()
+    });
+
+    let mut hand_edited = plan();
+    hand_edited.trustee_threshold = 999;
+
+    let applied = apply_profile(&hand_edited, &profile).expect("applies");
+    assert_eq!(
+        applied.trustee_threshold, 3,
+        "the default is what enforces it"
     );
 }
 

--- a/packages/sequent-core/src/election_config/sheet.rs
+++ b/packages/sequent-core/src/election_config/sheet.rs
@@ -93,13 +93,43 @@ pub fn normalise_sheet_name(name: &str) -> String {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Origin {
     pub sheet: String,
+
+    /// The row as the spreadsheet numbers them, or `0` for the sheet as a whole.
+    ///
+    /// Spreadsheets count from one, so zero cannot name a real row and is free to
+    /// mean "this is about the sheet, not a row in it" — which is what a missing
+    /// column or an empty sheet is about.
     pub row: usize,
+
     pub column: Option<String>,
+}
+
+impl Origin {
+    /// A problem with a sheet rather than with any row of it.
+    pub fn sheet(name: impl Into<String>) -> Self {
+        Origin {
+            sheet: name.into(),
+            row: 0,
+            column: None,
+        }
+    }
+
+    /// A problem with a whole column.
+    pub fn column(name: impl Into<String>, column: impl Into<String>) -> Self {
+        Origin {
+            sheet: name.into(),
+            row: 0,
+            column: Some(column.into()),
+        }
+    }
 }
 
 impl fmt::Display for Origin {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "sheet '{}' row {}", self.sheet, self.row)?;
+        write!(formatter, "sheet '{}'", self.sheet)?;
+        if self.row > 0 {
+            write!(formatter, " row {}", self.row)?;
+        }
         if let Some(column) = &self.column {
             write!(formatter, " column '{column}'")?;
         }
@@ -713,6 +743,19 @@ mod tests {
         let problem = sheet.rows[0].require("title").unwrap_err();
         assert_eq!(problem.code, Code::MissingField);
         assert_eq!(problem.path, "sheet 'Elections' row 2 column 'title'");
+    }
+
+    #[test]
+    fn an_origin_about_a_whole_sheet_does_not_claim_a_row() {
+        // "row 0" names no row a spreadsheet has, and reads as a bug.
+        assert_eq!(
+            Origin::sheet("Parameters").to_string(),
+            "sheet 'Parameters'"
+        );
+        assert_eq!(
+            Origin::column("Voters", "home address").to_string(),
+            "sheet 'Voters' column 'home address'"
+        );
     }
 
     #[test]

--- a/packages/sequent-core/src/election_config/time.rs
+++ b/packages/sequent-core/src/election_config/time.rs
@@ -95,21 +95,32 @@ impl Timestamp {
     /// otherwise.
     pub fn instant(&self) -> Result<DateTime<FixedOffset>, Problem> {
         let naive = self.naive()?;
-        let offset = FixedOffset::east_opt(self.offset_minutes * 60)
+        // `checked_mul` because these fields come out of a saved plan, which is
+        // a document people hand-edit. `i32::MAX * 60` panics in a debug build
+        // and — worse — wraps to a plausible-looking -00:01 in a release one.
+        let offset = self
+            .offset_minutes
+            .checked_mul(60)
+            .and_then(FixedOffset::east_opt)
             .ok_or_else(|| {
                 self.problem(format!(
                     "{} is not a usable offset",
                     self.offset_minutes
                 ))
             })?;
-        naive.and_local_timezone(offset).earliest().ok_or_else(|| {
-            // A wall clock inside a spring-forward gap names no instant.
-            self.problem(format!(
-                "'{}' did not happen in {}: the clocks moved forward over it",
-                self.local,
-                self.zone_or_utc()
-            ))
-        })
+        // `single()` rather than `earliest()`: a fixed offset has exactly one
+        // mapping, so there is no ambiguity to resolve. An earlier version
+        // guarded here against a spring-forward gap, which reads sensibly and
+        // is unreachable — detecting that needs the zone's rules, and this
+        // module deliberately has no timezone database.
+        Ok(naive
+            .and_local_timezone(offset)
+            .single()
+            .unwrap_or_else(|| {
+                unreachable!(
+                    "a fixed offset maps every wall clock exactly once"
+                )
+            }))
     }
 
     /// The shape the platform's scheduler parses.

--- a/packages/sequent-core/src/election_config/time_tests.rs
+++ b/packages/sequent-core/src/election_config/time_tests.rs
@@ -201,3 +201,13 @@ fn a_zone_that_is_not_a_whole_hour_is_fine() {
     assert!(problems(&kathmandu).is_empty());
     assert_eq!(kolkata.to_rfc3339().unwrap(), "2027-03-01T09:00:00+05:30");
 }
+
+/// These fields come out of a saved plan, which people hand-edit. Before the
+/// `checked_mul`, this panicked in a debug build and — worse — wrapped to a
+/// plausible-looking `-00:01` in a release one.
+#[test]
+fn an_absurd_offset_is_reported_rather_than_overflowing() {
+    let stamp = Timestamp::new("2027-03-01T09:00", "Nowhere", i32::MAX);
+    assert!(stamp.instant().is_err());
+    assert!(stamp.to_rfc3339().is_err());
+}

--- a/packages/sequent-core/src/election_config/validate.rs
+++ b/packages/sequent-core/src/election_config/validate.rs
@@ -337,6 +337,8 @@ fn check_contests(bundle: &ImportElectionEventSchema, report: &mut Report) {
             ),
         }
 
+        check_presentation_policies(contest, &path, about, report);
+
         let available = candidates_per_contest
             .get(contest.id.as_str())
             .copied()
@@ -377,6 +379,83 @@ fn check_contests(bundle: &ImportElectionEventSchema, report: &mut Report) {
                     );
                 }
             }
+        }
+    }
+}
+
+/// Every `presentation.*_policy` against the values the platform has.
+///
+/// A policy the Admin Portal does not know imports without complaint and then
+/// behaves as whatever the voting portal falls back to — which is a ballot
+/// behaving in a way nobody chose, discovered by a voter. Both hand-written
+/// mappings that fed this format got at least one of them wrong, so it is worth
+/// checking the bundle rather than trusting whoever produced it.
+fn check_presentation_policies(
+    contest: &crate::types::hasura::core::Contest,
+    path: &impl Fn(&str) -> String,
+    about: Option<&str>,
+    report: &mut Report,
+) {
+    use crate::election_config::policy::{
+        BlankVote, CandidatesOrder, DuplicatedRank, InvalidVote, OverVote,
+        PolicyValue, PreferenceGaps, UnderVote,
+    };
+    use strum::IntoEnumIterator;
+
+    let Some(presentation) = contest
+        .presentation
+        .as_ref()
+        .and_then(|value| value.as_object())
+    else {
+        return;
+    };
+
+    fn known<T: PolicyValue + IntoEnumIterator>() -> Vec<&'static str> {
+        T::iter().map(PolicyValue::as_str).collect()
+    }
+
+    let checks: Vec<(&str, Vec<&'static str>)> = vec![
+        ("over_vote_policy", known::<OverVote>()),
+        ("blank_vote_policy", known::<BlankVote>()),
+        ("under_vote_policy", known::<UnderVote>()),
+        ("invalid_vote_policy", known::<InvalidVote>()),
+        ("duplicated_rank_policy", known::<DuplicatedRank>()),
+        ("preference_gaps_policy", known::<PreferenceGaps>()),
+        ("candidates_order", known::<CandidatesOrder>()),
+    ];
+
+    for (key, allowed) in checks {
+        // Absent is fine: the platform has its own default for each of these,
+        // and a bundle is not obliged to state one.
+        let Some(value) = presentation.get(key) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        let Some(text) = value.as_str() else {
+            report.push(
+                Problem::error(
+                    Code::InvalidValue,
+                    path(&format!("presentation.{key}")),
+                    format!("{key} should be text, and is {value}"),
+                )
+                .about(about),
+            );
+            continue;
+        };
+        if !allowed.contains(&text) {
+            report.push(
+                Problem::error(
+                    Code::InvalidValue,
+                    path(&format!("presentation.{key}")),
+                    format!(
+                        "'{text}' is not a {key}; expected one of {}",
+                        allowed.join(", ")
+                    ),
+                )
+                .about(about),
+            );
         }
     }
 }

--- a/packages/sequent-core/src/election_config/validate_tests.rs
+++ b/packages/sequent-core/src/election_config/validate_tests.rs
@@ -490,3 +490,31 @@ fn an_inconsistent_bundle_is_still_refused() {
         Some("f0000000-0000-5000-8000-000000000000".into());
     assert!(validate(&bundle).has_errors());
 }
+
+/// A policy the Admin Portal does not know imports without complaint and then
+/// behaves as whatever the voting portal falls back to. Both hand-written
+/// mappings that fed this format emitted at least one such value.
+#[test]
+fn a_contest_with_a_policy_the_platform_does_not_have_is_refused() {
+    let mut bundle = sound();
+    bundle.contests[0].presentation = Some(serde_json::json!({
+        // `EUnderVotePolicy` has no `not-allowed` — an under-vote cannot be
+        // refused, only warned about.
+        "under_vote_policy": "not-allowed"
+    }));
+
+    let report = validate(&bundle);
+    assert!(report.has_errors());
+    assert!(report
+        .problems
+        .iter()
+        .any(|problem| problem.message.contains("is not a under_vote_policy")));
+}
+
+#[test]
+fn a_contest_with_no_presentation_policies_is_fine() {
+    // The platform has its own default for each; a bundle need not state one.
+    let mut bundle = sound();
+    bundle.contests[0].presentation = Some(serde_json::json!({}));
+    assert!(!validate(&bundle).has_errors());
+}

--- a/packages/sequent-core/src/election_config/wasm.rs
+++ b/packages/sequent-core/src/election_config/wasm.rs
@@ -403,6 +403,77 @@ pub fn read_profile_js(profile: JsValue) -> Result<JsValue, JsError> {
     }
 }
 
+/// The ballot-behaviour values a picker may offer.
+///
+/// Returned rather than duplicated in TypeScript, for the same reason
+/// [`auth_presets`] is: a dropdown cannot list a value the platform does not
+/// have, and cannot miss one it does. `labels` is the namespace the Admin
+/// Portal's translations are keyed by, so a front end labels a value without a
+/// second table of its own.
+///
+/// This is the third place the value space appears — `ContestPresentation.ts`
+/// and `contest.hbs` being the others — and handing it over as data is what
+/// stops a fourth.
+#[cfg(feature = "election_config_archive")]
+#[wasm_bindgen(js_name = policyCatalog)]
+pub fn policy_catalog() -> Result<JsValue, JsError> {
+    use crate::election_config::policy::{
+        BlankVote, CandidatesOrder, DuplicatedRank, InvalidVote, OverVote,
+        Policies, PolicyValue, PreferenceGaps, UnderVote,
+    };
+    use strum::IntoEnumIterator;
+
+    #[derive(Serialize)]
+    struct Kind {
+        /// The plan field this sets, e.g. `over_vote`.
+        field: &'static str,
+        /// The bundle column it becomes.
+        column: &'static str,
+        /// The Admin Portal translation namespace.
+        labels: &'static str,
+        /// Every value, most permissive first.
+        values: Vec<&'static str>,
+        /// What a plan gets when it says nothing.
+        default: &'static str,
+    }
+
+    fn kind<T: PolicyValue + IntoEnumIterator + Default>(
+        field: &'static str,
+    ) -> Kind {
+        Kind {
+            field,
+            column: T::COLUMN,
+            labels: T::LABELS,
+            values: T::iter().map(PolicyValue::as_str).collect(),
+            default: T::default().as_str(),
+        }
+    }
+
+    #[derive(Serialize)]
+    struct Catalog {
+        kinds: Vec<Kind>,
+        /// Named sets, so a wizard can offer a decision rather than seven.
+        presets: Vec<(&'static str, Policies)>,
+    }
+
+    to_js(&Catalog {
+        kinds: vec![
+            kind::<OverVote>("over_vote"),
+            kind::<BlankVote>("blank_vote"),
+            kind::<UnderVote>("under_vote"),
+            kind::<InvalidVote>("invalid_vote"),
+            kind::<DuplicatedRank>("duplicated_rank"),
+            kind::<PreferenceGaps>("preference_gaps"),
+            kind::<CandidatesOrder>("candidates_order"),
+        ],
+        presets: vec![
+            ("permissive", Policies::permissive()),
+            ("standard", Policies::standard()),
+            ("strict", Policies::strict()),
+        ],
+    })
+}
+
 /// The options both entry points take, read once.
 ///
 /// Declared here rather than inside each function so the two cannot drift the

--- a/packages/sequent-core/src/election_config/wasm.rs
+++ b/packages/sequent-core/src/election_config/wasm.rs
@@ -21,6 +21,7 @@
 //! leaves the browser. That is not a side effect of the design; it is the reason
 //! for it.
 
+use crate::election_config::fixtures;
 use crate::election_config::problem::{Code, Problem, Report};
 use crate::election_config::schema::ImportElectionEventSchema;
 use crate::election_config::validate;
@@ -50,6 +51,21 @@ export interface Problem {
 
 export interface Report {
     problems: Problem[];
+}
+
+/** The verdict every caller of the validator must reach on a fixture. */
+export interface Expect {
+    errors: string[];
+    warnings: string[];
+}
+
+/** A bundle with a known verdict, for a front end's own test suite. */
+export interface FixtureCase {
+    name: string;
+    /** Why the case exists. Read this before changing what it expects. */
+    why: string;
+    bundle: unknown;
+    expect: Expect;
 }
 
 /** One file to offer as a download. */
@@ -98,6 +114,18 @@ pub fn check_bundle(document: &str) -> Result<IReport, JsError> {
         })?;
 
     to_js(&validate(&bundle)).map(IReport::from)
+}
+
+/// The bundles a front end's own tests should agree with.
+///
+/// The same list the Rust tests run, handed over as data rather than reimplemented
+/// in TypeScript. A front end asserting `checkBundle(case.bundle)` matches
+/// `case.expect` is checking that the browser and the server reach the same verdict
+/// — which is the only thing that makes one validator worth having. A suite written
+/// separately would prove only that each side agrees with itself.
+#[wasm_bindgen(js_name = fixtureCases)]
+pub fn fixture_cases() -> Result<JsValue, JsError> {
+    to_js(&fixtures::cases())
 }
 
 /// The authentication presets a front end can offer.

--- a/packages/sequent-core/src/election_config/wasm.rs
+++ b/packages/sequent-core/src/election_config/wasm.rs
@@ -285,21 +285,20 @@ pub fn validate_plan_js(plan: JsValue) -> Result<IReport, JsError> {
 pub fn compile_plan_js(
     plan: JsValue,
     options: JsValue,
-    profile: JsValue,
 ) -> Result<IBuildOutput, JsError> {
     let plan: architect::Blueprint = serde_wasm_bindgen::from_value(plan)
         .map_err(|error| {
             JsError::new(&format!("this is not an election plan: {error}"))
         })?;
 
+    // The profile travels *inside* options rather than as a third argument.
+    // It was a third argument, and the browser passed two — so every profile
+    // silently became `None`, `apply_profile` never ran, and not one locked
+    // value reached a bundle. Nothing on either side complained, because a
+    // missing positional at an FFI boundary is `undefined` and `undefined`
+    // deserializes to `Option::None`. A named field cannot be dropped that way.
+    let profile = profile_from(&options)?;
     let options = build_options(options)?;
-
-    let read = match read_profile(profile) {
-        Ok(read) => read,
-        Err(report) => {
-            return to_js(&Output::refused(report)).map(IBuildOutput::from)
-        }
-    };
 
     let templates = match TemplateSet::builtin() {
         Ok(templates) => templates,
@@ -310,7 +309,7 @@ pub fn compile_plan_js(
         &plan,
         &templates,
         &options,
-        read.as_ref(),
+        profile.as_ref(),
     ) {
         Ok(compiled) => compiled,
         Err(report) => {
@@ -334,6 +333,37 @@ pub fn compile_plan_js(
         event_external_id: Some(compiled.bundle.event_external_id.clone()),
     })
     .map(IBuildOutput::from)
+}
+
+/// The client profile out of the options object, if it carries one.
+///
+/// Returns an error rather than a report: a malformed profile is a broken
+/// deployment, not a plan somebody can fix by editing their answers, and
+/// swallowing it into the build report is how it goes unnoticed.
+#[cfg(feature = "election_config_archive")]
+fn profile_from(options: &JsValue) -> Result<Option<profile::Profile>, JsError> {
+    #[derive(serde::Deserialize, Default)]
+    #[serde(default)]
+    struct Carrying {
+        profile: Option<profile::ClientProfile>,
+    }
+
+    if options.is_undefined() || options.is_null() {
+        return Ok(None);
+    }
+
+    let carrying: Carrying = serde_wasm_bindgen::from_value(options.clone())
+        .map_err(|error| {
+            JsError::new(&format!("bad options: {error}"))
+        })?;
+
+    let Some(document) = carrying.profile else {
+        return Ok(None);
+    };
+
+    profile::Profile::read(&document).map(Some).map_err(|report| {
+        JsError::new(&format!("this client profile cannot be used:\n{report}"))
+    })
 }
 
 /// Read a client profile, or none.
@@ -375,6 +405,10 @@ pub fn read_profile_js(profile: JsValue) -> Result<JsValue, JsError> {
         display_name: Option<String>,
         hidden: Vec<String>,
         locked: Vec<String>,
+        /// Handed over so a front end can mark a field, even though enforcing
+        /// it is Rust's job — a required field with no asterisk is a form
+        /// somebody fills in twice.
+        required: Vec<String>,
         warnings: Report,
     }
 
@@ -397,9 +431,20 @@ pub fn read_profile_js(profile: JsValue) -> Result<JsValue, JsError> {
                 .into_iter()
                 .map(str::to_string)
                 .collect(),
+            required: read
+                .required_paths()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
             warnings: read.warnings.clone(),
         }),
-        Err(report) => to_js(&report),
+        // An error, not a `Report` returned as success. The caller casts this
+        // result to a profile; handing back `{problems: [...]}` produced
+        // `profile.hidden` undefined and a blank page, with the very problems
+        // Rust took care to produce thrown away.
+        Err(report) => Err(JsError::new(&format!(
+            "this client profile cannot be used:\n{report}"
+        ))),
     }
 }
 
@@ -480,6 +525,8 @@ pub fn policy_catalog() -> Result<JsValue, JsError> {
 /// first time [`BuildOptions`] gains a field.
 #[cfg(feature = "election_config_archive")]
 fn build_options(options: JsValue) -> Result<BuildOptions, JsError> {
+    // `serde_wasm_bindgen` ignores unknown keys, so the `profile` the plan path
+    // also puts in here passes straight through.
     #[derive(serde::Deserialize, Default)]
     #[serde(default, rename_all = "camelCase")]
     struct Options {

--- a/packages/sequent-core/src/election_config/wasm.rs
+++ b/packages/sequent-core/src/election_config/wasm.rs
@@ -9,13 +9,22 @@
 //! JavaScript. That is the whole point — a file that validates in a browser
 //! imports on the server, because the same code decided both times.
 //!
-//! Two entry points, matching the two questions a front end asks:
+//! Four entry points, matching the questions a front end asks:
 //!
 //! * [`check_bundle`] — "would the platform accept this export?" Enough on its own
 //!   for a page that only checks an existing file, and it needs no template engine
 //!   or spreadsheet parser.
 //! * [`build_from_workbook`] — "turn this spreadsheet into something importable."
 //!   Returns the files to offer as downloads, or the problems to show instead.
+//! * [`validate_plan_js`] — "is there anything wrong with this plan?", asked of a
+//!   wizard's document rather than of a built bundle.
+//! * [`compile_plan_js`] — "turn this plan into something importable." The same
+//!   output shape as `build_from_workbook`, because a wizard and a spreadsheet
+//!   produce the same thing.
+//!
+//! The last two are gated on `election_config_archive` alone. Compiling a plan
+//! needs the templates, the builder and the zip writer, but no spreadsheet
+//! parser — so the wizard's package does not carry calamine.
 //!
 //! Nothing here touches a network or a filesystem, so a client's census never
 //! leaves the browser. That is not a side effect of the design; it is the reason
@@ -33,7 +42,9 @@ use crate::election_config::render::TemplateSet;
 #[cfg(feature = "election_config_xlsx")]
 use crate::election_config::xlsx::read_xlsx;
 #[cfg(feature = "election_config_archive")]
-use crate::election_config::{archive, build, presets, BuildOptions};
+use crate::election_config::{
+    architect, archive, build, presets, BuildOptions,
+};
 
 #[wasm_bindgen(typescript_custom_section)]
 const ITYPES: &'static str = r#"
@@ -175,22 +186,7 @@ pub fn build_from_workbook(
     workbook: &[u8],
     options: JsValue,
 ) -> Result<IBuildOutput, JsError> {
-    #[derive(serde::Deserialize, Default)]
-    #[serde(default, rename_all = "camelCase")]
-    struct Options {
-        tenant_id: Option<String>,
-        base_export: Option<serde_json::Value>,
-        slug: Option<String>,
-        created_at: Option<String>,
-        auth_preset: Option<String>,
-    }
-
-    let options: Options = if options.is_undefined() || options.is_null() {
-        Options::default()
-    } else {
-        serde_wasm_bindgen::from_value(options)
-            .map_err(|error| JsError::new(&format!("bad options: {error}")))?
-    };
+    let options = build_options(options)?;
 
     let read = match read_xlsx(workbook) {
         Ok(read) => read,
@@ -202,17 +198,7 @@ pub fn build_from_workbook(
         Err(problem) => return failed(problem).map(IBuildOutput::from),
     };
 
-    let built = build(
-        &read,
-        &templates,
-        &BuildOptions {
-            tenant_id: options.tenant_id,
-            base_export: options.base_export,
-            slug: options.slug,
-            created_at: options.created_at,
-            auth_preset: options.auth_preset,
-        },
-    );
+    let built = build(&read, &templates, &options);
 
     let bundle = match built {
         Ok(bundle) => bundle,
@@ -263,6 +249,110 @@ pub fn build_from_workbook(
         event_external_id: Some(bundle.event_external_id.clone()),
     })
     .map(IBuildOutput::from)
+}
+
+/// Check a plan, in the wizard's own vocabulary.
+///
+/// A trustee threshold no number of trustees can meet, a key ceremony after
+/// voting opens, a contest electing more people than are standing. Different
+/// questions from [`check_bundle`], which asks about a built bundle in the
+/// bundle's vocabulary — both run, because a problem phrased as
+/// `contests[2].winning_candidates_num` is no use to somebody looking at a
+/// wizard, and a bundle-level problem has no wizard field to point at.
+#[cfg(feature = "election_config_archive")]
+#[wasm_bindgen(js_name = validatePlan)]
+pub fn validate_plan_js(plan: JsValue) -> Result<IReport, JsError> {
+    let plan: architect::Blueprint = serde_wasm_bindgen::from_value(plan)
+        .map_err(|error| {
+            JsError::new(&format!("this is not an election plan: {error}"))
+        })?;
+
+    to_js(&architect::validate_plan(&plan)).map(IReport::from)
+}
+
+/// Compile a plan into the bundle and the files that travel beside it.
+///
+/// The same [`Output`] `buildFromWorkbook` returns, because a wizard and a
+/// spreadsheet produce the same thing and a front end should not need two shapes
+/// to hold it.
+///
+/// A bad plan comes back as a report with no files rather than as an exception:
+/// a list of problems is something a page can render. An exception here means
+/// the core itself failed, which is a different thing and belongs somewhere
+/// else in the interface.
+#[cfg(feature = "election_config_archive")]
+#[wasm_bindgen(js_name = compilePlan)]
+pub fn compile_plan_js(
+    plan: JsValue,
+    options: JsValue,
+) -> Result<IBuildOutput, JsError> {
+    let plan: architect::Blueprint = serde_wasm_bindgen::from_value(plan)
+        .map_err(|error| {
+            JsError::new(&format!("this is not an election plan: {error}"))
+        })?;
+
+    let options = build_options(options)?;
+
+    let templates = match TemplateSet::builtin() {
+        Ok(templates) => templates,
+        Err(problem) => return failed(problem).map(IBuildOutput::from),
+    };
+
+    let compiled = match architect::compile_plan(&plan, &templates, &options) {
+        Ok(compiled) => compiled,
+        Err(report) => {
+            return to_js(&Output::refused(report)).map(IBuildOutput::from)
+        }
+    };
+
+    let zipped = match archive::zip(&compiled.layout.importable) {
+        Ok(bytes) => bytes,
+        Err(problem) => return failed(problem).map(IBuildOutput::from),
+    };
+
+    to_js(&Output {
+        importable: compiled.layout.importable.iter().map(File::from).collect(),
+        auxiliary: compiled.layout.auxiliary.iter().map(File::from).collect(),
+        archive: Some(File {
+            name: compiled.layout.archive_name.clone(),
+            bytes: zipped,
+        }),
+        report: compiled.report,
+        event_external_id: Some(compiled.bundle.event_external_id.clone()),
+    })
+    .map(IBuildOutput::from)
+}
+
+/// The options both entry points take, read once.
+///
+/// Declared here rather than inside each function so the two cannot drift the
+/// first time [`BuildOptions`] gains a field.
+#[cfg(feature = "election_config_archive")]
+fn build_options(options: JsValue) -> Result<BuildOptions, JsError> {
+    #[derive(serde::Deserialize, Default)]
+    #[serde(default, rename_all = "camelCase")]
+    struct Options {
+        tenant_id: Option<String>,
+        base_export: Option<serde_json::Value>,
+        slug: Option<String>,
+        created_at: Option<String>,
+        auth_preset: Option<String>,
+    }
+
+    let options: Options = if options.is_undefined() || options.is_null() {
+        Options::default()
+    } else {
+        serde_wasm_bindgen::from_value(options)
+            .map_err(|error| JsError::new(&format!("bad options: {error}")))?
+    };
+
+    Ok(BuildOptions {
+        tenant_id: options.tenant_id,
+        base_export: options.base_export,
+        slug: options.slug,
+        created_at: options.created_at,
+        auth_preset: options.auth_preset,
+    })
 }
 
 #[derive(Serialize)]

--- a/packages/sequent-core/src/election_config/wasm.rs
+++ b/packages/sequent-core/src/election_config/wasm.rs
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The browser's view of this module.
+//!
+//! Everything here is a thin wrapper: the work happens in the same functions
+//! `step-cli` and windmill call, and this only converts between them and
+//! JavaScript. That is the whole point — a file that validates in a browser
+//! imports on the server, because the same code decided both times.
+//!
+//! Two entry points, matching the two questions a front end asks:
+//!
+//! * [`check_bundle`] — "would the platform accept this export?" Enough on its own
+//!   for a page that only checks an existing file, and it needs no template engine
+//!   or spreadsheet parser.
+//! * [`build_from_workbook`] — "turn this spreadsheet into something importable."
+//!   Returns the files to offer as downloads, or the problems to show instead.
+//!
+//! Nothing here touches a network or a filesystem, so a client's census never
+//! leaves the browser. That is not a side effect of the design; it is the reason
+//! for it.
+
+use crate::election_config::problem::{Code, Problem, Report};
+use crate::election_config::schema::ImportElectionEventSchema;
+use crate::election_config::validate;
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "election_config_archive")]
+use crate::election_config::render::TemplateSet;
+#[cfg(feature = "election_config_xlsx")]
+use crate::election_config::xlsx::read_xlsx;
+#[cfg(feature = "election_config_archive")]
+use crate::election_config::{archive, build, presets, BuildOptions};
+
+#[wasm_bindgen(typescript_custom_section)]
+const ITYPES: &'static str = r#"
+export type Severity = "error" | "warning";
+
+export interface Problem {
+    severity: Severity;
+    /** Stable identifier, safe to match on. Message wording is not. */
+    code: string;
+    /** Where: a bundle path, or a sheet and row for a source document. */
+    path: string;
+    message: string;
+    external_id?: string;
+}
+
+export interface Report {
+    problems: Problem[];
+}
+
+/** One file to offer as a download. */
+export interface Artifact {
+    name: string;
+    bytes: Uint8Array;
+}
+
+export interface BuildOutput {
+    /** Empty when the build failed; check `report` first. */
+    importable: Artifact[];
+    /** Files that must NOT go inside the archive. */
+    auxiliary: Artifact[];
+    /** The importable archive, ready to download. */
+    archive?: Artifact;
+    /** Everything found, errors and warnings together. */
+    report: Report;
+    /** Absent when the build failed. */
+    event_external_id?: string;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "Report")]
+    pub type IReport;
+
+    #[wasm_bindgen(typescript_type = "BuildOutput")]
+    pub type IBuildOutput;
+}
+
+/// Check an existing export, the way the server would.
+///
+/// Takes the `export_election_event-<id>.json` document as text. Returns the same
+/// [`Report`] the importer produces, so a page can show the problems before anyone
+/// uploads anything.
+#[wasm_bindgen(js_name = checkBundle)]
+pub fn check_bundle(document: &str) -> Result<IReport, JsError> {
+    let bundle: ImportElectionEventSchema = serde_json::from_str(document)
+        .map_err(|error| {
+            // A parse failure is itself a finding, but it is not a Report — the
+            // caller has nothing to render a list from, so it is an exception.
+            JsError::new(&format!(
+                "this is not an election event export: {error}"
+            ))
+        })?;
+
+    to_js(&validate(&bundle)).map(IReport::from)
+}
+
+/// The authentication presets a front end can offer.
+///
+/// Returned rather than duplicated in TypeScript, so a dropdown cannot list a
+/// preset that does not exist or miss one that does.
+#[cfg(feature = "election_config_archive")]
+#[wasm_bindgen(js_name = authPresets)]
+pub fn auth_presets() -> Result<JsValue, JsError> {
+    #[derive(Serialize)]
+    struct Listed {
+        name: &'static str,
+        summary: &'static str,
+        uses_otp: bool,
+        required_parameters: Vec<&'static str>,
+        optional_parameters: Vec<&'static str>,
+    }
+
+    let listed: Vec<Listed> = presets::PRESETS
+        .iter()
+        .map(|preset| Listed {
+            name: preset.name,
+            summary: preset.summary,
+            uses_otp: preset.uses_otp,
+            required_parameters: preset.required_parameters.to_vec(),
+            optional_parameters: preset.optional_parameters.to_vec(),
+        })
+        .collect();
+    to_js(&listed)
+}
+
+/// Build an importable bundle from a workbook the user picked.
+///
+/// `workbook` is the bytes of an `.xlsx` — what a file input hands over. The
+/// options are all optional: `tenantId`, `baseExport` (a parsed export document),
+/// `slug`, `createdAt` and `authPreset`.
+///
+/// Returns the files to download and everything found. On failure the files are
+/// empty and the report says why, rather than throwing: a list of problems is
+/// something a page can render, and an exception is not.
+#[cfg(all(
+    feature = "election_config_xlsx",
+    feature = "election_config_archive"
+))]
+#[wasm_bindgen(js_name = buildFromWorkbook)]
+pub fn build_from_workbook(
+    workbook: &[u8],
+    options: JsValue,
+) -> Result<IBuildOutput, JsError> {
+    #[derive(serde::Deserialize, Default)]
+    #[serde(default, rename_all = "camelCase")]
+    struct Options {
+        tenant_id: Option<String>,
+        base_export: Option<serde_json::Value>,
+        slug: Option<String>,
+        created_at: Option<String>,
+        auth_preset: Option<String>,
+    }
+
+    let options: Options = if options.is_undefined() || options.is_null() {
+        Options::default()
+    } else {
+        serde_wasm_bindgen::from_value(options)
+            .map_err(|error| JsError::new(&format!("bad options: {error}")))?
+    };
+
+    let read = match read_xlsx(workbook) {
+        Ok(read) => read,
+        Err(problem) => return failed(problem).map(IBuildOutput::from),
+    };
+
+    let templates = match TemplateSet::builtin() {
+        Ok(templates) => templates,
+        Err(problem) => return failed(problem).map(IBuildOutput::from),
+    };
+
+    let built = build(
+        &read,
+        &templates,
+        &BuildOptions {
+            tenant_id: options.tenant_id,
+            base_export: options.base_export,
+            slug: options.slug,
+            created_at: options.created_at,
+            auth_preset: options.auth_preset,
+        },
+    );
+
+    let bundle = match built {
+        Ok(bundle) => bundle,
+        Err(report) => {
+            return to_js(&Output::refused(report)).map(IBuildOutput::from)
+        }
+    };
+
+    // The same second pass `step-cli` makes: a document can be internally
+    // consistent and still describe an event the platform would reject.
+    let mut report = bundle.warnings.clone();
+    match serde_json::from_value::<ImportElectionEventSchema>(
+        bundle.export.clone(),
+    ) {
+        Ok(schema) => {
+            for problem in validate(&schema).problems {
+                report.push(problem);
+            }
+        }
+        Err(error) => report.push(Problem::error(
+            Code::InvalidValue,
+            "bundle",
+            format!(
+                "the built bundle does not match the import schema, which is a \
+                 bug in this tool rather than in the workbook: {error}"
+            ),
+        )),
+    }
+
+    if report.has_errors() {
+        return to_js(&Output::refused(report)).map(IBuildOutput::from);
+    }
+
+    let layout = archive::layout(&bundle);
+    let zipped = match archive::zip(&layout.importable) {
+        Ok(bytes) => bytes,
+        Err(problem) => return failed(problem).map(IBuildOutput::from),
+    };
+
+    to_js(&Output {
+        importable: layout.importable.iter().map(File::from).collect(),
+        auxiliary: layout.auxiliary.iter().map(File::from).collect(),
+        archive: Some(File {
+            name: layout.archive_name,
+            bytes: zipped,
+        }),
+        report,
+        event_external_id: Some(bundle.event_external_id.clone()),
+    })
+    .map(IBuildOutput::from)
+}
+
+#[derive(Serialize)]
+struct File {
+    name: String,
+    bytes: Vec<u8>,
+}
+
+#[cfg(feature = "election_config_archive")]
+impl From<&archive::Artifact> for File {
+    fn from(artifact: &archive::Artifact) -> Self {
+        File {
+            name: artifact.name.clone(),
+            bytes: artifact.bytes.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Output {
+    importable: Vec<File>,
+    auxiliary: Vec<File>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    archive: Option<File>,
+    report: Report,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    event_external_id: Option<String>,
+}
+
+impl Output {
+    /// A build that produced no files, and the reasons.
+    fn refused(report: Report) -> Self {
+        Output {
+            importable: Vec::new(),
+            auxiliary: Vec::new(),
+            archive: None,
+            report,
+            event_external_id: None,
+        }
+    }
+}
+
+/// One problem, as an output with nothing in it.
+fn failed(problem: Problem) -> Result<JsValue, JsError> {
+    let mut report = Report::default();
+    report.push(problem);
+    to_js(&Output::refused(report))
+}
+
+/// Plain JS values, not wasm-bindgen classes.
+///
+/// A front end holds these in state, passes them to React, and serialises them;
+/// an opaque handle with a `free()` method would be a memory leak waiting for
+/// whoever forgets to call it.
+fn to_js<T: Serialize>(value: &T) -> Result<JsValue, JsError> {
+    serde_wasm_bindgen::to_value(value)
+        .map_err(|error| JsError::new(&format!("could not convert: {error}")))
+}

--- a/packages/sequent-core/src/election_config/wasm.rs
+++ b/packages/sequent-core/src/election_config/wasm.rs
@@ -43,7 +43,7 @@ use crate::election_config::render::TemplateSet;
 use crate::election_config::xlsx::read_xlsx;
 #[cfg(feature = "election_config_archive")]
 use crate::election_config::{
-    architect, archive, build, presets, BuildOptions,
+    architect, archive, build, presets, profile, BuildOptions,
 };
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -285,6 +285,7 @@ pub fn validate_plan_js(plan: JsValue) -> Result<IReport, JsError> {
 pub fn compile_plan_js(
     plan: JsValue,
     options: JsValue,
+    profile: JsValue,
 ) -> Result<IBuildOutput, JsError> {
     let plan: architect::Blueprint = serde_wasm_bindgen::from_value(plan)
         .map_err(|error| {
@@ -293,12 +294,24 @@ pub fn compile_plan_js(
 
     let options = build_options(options)?;
 
+    let read = match read_profile(profile) {
+        Ok(read) => read,
+        Err(report) => {
+            return to_js(&Output::refused(report)).map(IBuildOutput::from)
+        }
+    };
+
     let templates = match TemplateSet::builtin() {
         Ok(templates) => templates,
         Err(problem) => return failed(problem).map(IBuildOutput::from),
     };
 
-    let compiled = match architect::compile_plan(&plan, &templates, &options) {
+    let compiled = match architect::compile_plan(
+        &plan,
+        &templates,
+        &options,
+        read.as_ref(),
+    ) {
         Ok(compiled) => compiled,
         Err(report) => {
             return to_js(&Output::refused(report)).map(IBuildOutput::from)
@@ -321,6 +334,73 @@ pub fn compile_plan_js(
         event_external_id: Some(compiled.bundle.event_external_id.clone()),
     })
     .map(IBuildOutput::from)
+}
+
+/// Read a client profile, or none.
+///
+/// A malformed profile comes back as a report rather than an exception, for the
+/// same reason a malformed plan does: it is a document somebody wrote, and its
+/// problems are a list a page can render.
+#[cfg(feature = "election_config_archive")]
+fn read_profile(profile: JsValue) -> Result<Option<profile::Profile>, Report> {
+    if profile.is_undefined() || profile.is_null() {
+        return Ok(None);
+    }
+
+    let document: profile::ClientProfile =
+        serde_wasm_bindgen::from_value(profile).map_err(|error| {
+            let mut report = Report::default();
+            report.push(Problem::error(
+                Code::InvalidValue,
+                "profile",
+                format!("this is not a client profile: {error}"),
+            ));
+            report
+        })?;
+
+    profile::Profile::read(&document).map(Some)
+}
+
+/// What a profile hides, so the wizard knows what not to draw.
+///
+/// Rust decides which *paths*, because that is a statement about the plan.
+/// Which screens that empties is a question about screens, and belongs to
+/// whoever draws them.
+#[cfg(feature = "election_config_archive")]
+#[wasm_bindgen(js_name = readProfile)]
+pub fn read_profile_js(profile: JsValue) -> Result<JsValue, JsError> {
+    #[derive(Serialize)]
+    struct Read {
+        id: String,
+        display_name: Option<String>,
+        hidden: Vec<String>,
+        locked: Vec<String>,
+        warnings: Report,
+    }
+
+    let document: profile::ClientProfile =
+        serde_wasm_bindgen::from_value(profile).map_err(|error| {
+            JsError::new(&format!("this is not a client profile: {error}"))
+        })?;
+
+    match profile::Profile::read(&document) {
+        Ok(read) => to_js(&Read {
+            id: read.id.clone(),
+            display_name: read.display_name.clone(),
+            hidden: read
+                .hidden_paths()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            locked: read
+                .locked_paths()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            warnings: read.warnings.clone(),
+        }),
+        Err(report) => to_js(&report),
+    }
 }
 
 /// The options both entry points take, read once.

--- a/packages/sequent-core/src/election_config/wasm.rs
+++ b/packages/sequent-core/src/election_config/wasm.rs
@@ -341,7 +341,9 @@ pub fn compile_plan_js(
 /// deployment, not a plan somebody can fix by editing their answers, and
 /// swallowing it into the build report is how it goes unnoticed.
 #[cfg(feature = "election_config_archive")]
-fn profile_from(options: &JsValue) -> Result<Option<profile::Profile>, JsError> {
+fn profile_from(
+    options: &JsValue,
+) -> Result<Option<profile::Profile>, JsError> {
     #[derive(serde::Deserialize, Default)]
     #[serde(default)]
     struct Carrying {
@@ -353,17 +355,19 @@ fn profile_from(options: &JsValue) -> Result<Option<profile::Profile>, JsError> 
     }
 
     let carrying: Carrying = serde_wasm_bindgen::from_value(options.clone())
-        .map_err(|error| {
-            JsError::new(&format!("bad options: {error}"))
-        })?;
+        .map_err(|error| JsError::new(&format!("bad options: {error}")))?;
 
     let Some(document) = carrying.profile else {
         return Ok(None);
     };
 
-    profile::Profile::read(&document).map(Some).map_err(|report| {
-        JsError::new(&format!("this client profile cannot be used:\n{report}"))
-    })
+    profile::Profile::read(&document)
+        .map(Some)
+        .map_err(|report| {
+            JsError::new(&format!(
+                "this client profile cannot be used:\n{report}"
+            ))
+        })
 }
 
 /// Read a client profile, or none.

--- a/packages/sequent-core/src/election_config/xlsx.rs
+++ b/packages/sequent-core/src/election_config/xlsx.rs
@@ -256,8 +256,15 @@ mod tests {
                         // actually exercised. Anything else is an inline string,
                         // which avoids needing a shared-string table. A value
                         // wrapped in single quotes is forced to text, for the
-                        // codes an author formats as text on purpose.
-                        if let Some(literal) = value.strip_prefix('\'') {
+                        // codes an author formats as text on purpose, and one
+                        // opening with `=` becomes a formula whose cached result
+                        // is a string — the shape real workbooks use for a phone
+                        // number, and the one that used to lose its leading plus.
+                        if let Some(result) = value.strip_prefix('=') {
+                            xml.push_str(&format!(
+                                r#"<c r="{reference}" t="str"><f>"{result}"</f><v>{result}</v></c>"#
+                            ));
+                        } else if let Some(literal) = value.strip_prefix('\'') {
                             xml.push_str(&format!(
                                 r#"<c r="{reference}" t="inlineStr"><is><t>{literal}</t></is></c>"#
                             ));
@@ -322,6 +329,45 @@ mod tests {
 
         // And the documentation tab is reported rather than silently ignored.
         assert_eq!(workbook.unread_sheets(), vec!["Read Me"]);
+    }
+
+    #[test]
+    fn an_international_phone_number_keeps_its_leading_plus() {
+        // Real workbooks compute contact details with a formula, and its cached
+        // result is a string in the file. calamine before 0.36 tried a float parse
+        // on that string first — and Rust's float parser accepts a leading plus —
+        // so "+33645312453" arrived as the number 33645312453. A voter's phone
+        // number silently lost its country prefix, and nothing said so.
+        let bytes = tiny_xlsx(&[(
+            "Admin Users",
+            &[
+                &["username", "sequent.read-only.mobile-number"],
+                &["admin1", "=+33645312453"],
+            ],
+        )]);
+        let workbook = read_xlsx(&bytes).unwrap();
+        assert_eq!(
+            workbook.rows("adminusers")[0]
+                .get("sequent.read-only.mobile-number"),
+            Some(&json!("+33645312453"))
+        );
+    }
+
+    #[test]
+    fn a_formula_whose_result_is_text_stays_text_even_when_it_looks_numeric() {
+        // What `t="str"` means in the file: the cached result *is* a string. A
+        // formula that computes a number is written as a numeric cell instead, so
+        // trusting the marker is right — and it is what keeps a member id computed
+        // by a formula from losing its leading zeros.
+        let bytes = tiny_xlsx(&[(
+            "Voters",
+            &[&["username", "member_id"], &["v1", "=007"]],
+        )]);
+        let workbook = read_xlsx(&bytes).unwrap();
+        assert_eq!(
+            workbook.rows("voters")[0].get("member_id"),
+            Some(&json!("007"))
+        );
     }
 
     #[test]

--- a/packages/step-cli/Cargo.toml
+++ b/packages/step-cli/Cargo.toml
@@ -18,7 +18,7 @@ strum_macros = "0.27"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 graphql_client = "0.14"
 rayon = "1.5"
-sequent-core = { path="../sequent-core", features = ["keycloak", "probe", "reports","default_features"] }
+sequent-core = { path="../sequent-core", features = ["keycloak", "probe", "reports", "default_features", "election_config_xlsx", "election_config_archive"] }
 windmill = { path="../windmill" }
 strand = { path="../strand" }
 immudb-rs = { path="../immudb-rs" }
@@ -27,6 +27,8 @@ electoral-log = { path="../electoral-log" }
 uuid = { version = "1.5", features = ["v4", "fast-rng"] }
 fake = { version = "4", features = ["derive"] }
 csv = "1.1"
+# reading a base export straight out of an export archive
+zip = "2.1"
 rand = "0.9"
 chrono = "0.4"
 tokio = { version = "1.38", features = ["full"] }

--- a/packages/step-cli/src/commands/build_election_event.rs
+++ b/packages/step-cli/src/commands/build_election_event.rs
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: 2026 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Build an importable election event from an authoring workbook.
+//!
+//! This is janitor, folded into `step-cli`. Every decision it makes lives in
+//! `sequent_core::election_config`, which is also what windmill validates with and
+//! what the browser-side tools will run — so a bundle that builds here is a bundle
+//! the platform accepts, and there is no second implementation to drift.
+//!
+//! All this file does is talk to the filesystem and to whoever ran it. Reading a
+//! workbook, building, validating and laying out the files are all pure functions
+//! in the core, which is why nothing is written until every one of them has
+//! succeeded: a workbook with a dangling reference leaves no half-written output
+//! directory behind.
+
+use anyhow::{anyhow, Context, Result};
+use clap::Args;
+use colored::Colorize;
+use sequent_core::election_config::render::ENTITY_TEMPLATES;
+use sequent_core::election_config::xlsx::read_xlsx;
+use sequent_core::election_config::{
+    archive, build, presets, validate, BuildOptions, Bundle, ImportElectionEventSchema, Problem,
+    Severity, TemplateSet, ValidationReport,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Build an importable election event from an `.xlsx` workbook
+#[derive(Args)]
+#[command(about)]
+pub struct BuildElectionEvent {
+    /// Path to the authoring workbook
+    #[arg(short = 'w', long, value_name = "WORKBOOK")]
+    workbook: PathBuf,
+
+    /// Directory to write the bundle into, under a subdirectory named after the
+    /// event
+    #[arg(short = 'o', long, value_name = "OUT_DIR", default_value = "out")]
+    out_dir: PathBuf,
+
+    /// Tenant id to write into the file
+    ///
+    /// Import remaps it onto the tenant of the importing request, so getting it
+    /// wrong cannot send an event to the wrong tenant. It does name the
+    /// `export_permissions-<tenant>.csv` file, which nothing rewrites.
+    #[arg(short = 't', long, value_name = "TENANT_ID")]
+    tenant_id: Option<String>,
+
+    /// An existing export (`.json` or `.zip`) to inherit platform defaults and a
+    /// Keycloak realm from
+    ///
+    /// Without one no realm is emitted, and the platform loads its own provisioned
+    /// default instead.
+    #[arg(short = 'b', long, value_name = "BASE_EXPORT")]
+    base_export: Option<PathBuf>,
+
+    /// Directory of `.hbs` files overriding the built-in entity templates
+    #[arg(long, value_name = "TEMPLATES_DIR")]
+    templates_dir: Option<PathBuf>,
+
+    /// Authentication preset, overriding the workbook's `auth_type`
+    ///
+    /// `none` leaves the realm alone whatever the workbook declares.
+    #[arg(long, value_name = "PRESET")]
+    auth_preset: Option<String>,
+
+    /// Name for the output directory and archive
+    #[arg(long, value_name = "SLUG")]
+    slug: Option<String>,
+
+    /// Refuse to write anything if there are warnings
+    ///
+    /// Worth using in CI: a warning here means the bundle imports and the
+    /// configuration probably is not what its author meant.
+    #[arg(long)]
+    strict: bool,
+
+    /// Validate and report, writing nothing
+    #[arg(long)]
+    check_only: bool,
+}
+
+impl BuildElectionEvent {
+    pub fn run(&self) {
+        match self.build() {
+            Ok(()) => (),
+            Err(error) => {
+                eprintln!("{} {error:#}", "error:".red().bold());
+                std::process::exit(1);
+            }
+        }
+    }
+
+    fn build(&self) -> Result<()> {
+        if let Some(preset) = &self.auth_preset {
+            let known =
+                preset.eq_ignore_ascii_case(presets::NONE) || presets::get(preset).is_some();
+            if !known {
+                return Err(anyhow!(
+                    "'{preset}' is not an authentication preset. Expected {} or {}.",
+                    presets::NONE,
+                    presets::names().join(", ")
+                ));
+            }
+        }
+
+        let bytes = fs::read(&self.workbook)
+            .with_context(|| format!("could not read {}", self.workbook.display()))?;
+        let workbook = read_xlsx(&bytes).map_err(problem_error)?;
+
+        for unread in workbook.unread_sheets() {
+            // A misspelled tab is silently ignored otherwise, and the missing
+            // entities look like an authoring mistake somewhere else entirely.
+            println!(
+                "{} sheet '{unread}' is not one this reads, and was ignored",
+                "note:".cyan()
+            );
+        }
+
+        let templates = self.templates()?;
+        for overridden in templates.overridden() {
+            println!("{} using your own '{overridden}' template", "note:".cyan());
+        }
+
+        let options = BuildOptions {
+            tenant_id: self.tenant_id.clone(),
+            base_export: self.base_export()?,
+            slug: self.slug.clone(),
+            created_at: None,
+            auth_preset: self.auth_preset.clone(),
+        };
+
+        let bundle = match build(&workbook, &templates, &options) {
+            Ok(bundle) => bundle,
+            Err(report) => {
+                report_problems(&report);
+                return Err(anyhow!(
+                    "{} problem(s) in {}",
+                    report.errors().count(),
+                    self.workbook.display()
+                ));
+            }
+        };
+
+        // The same validation windmill runs before importing, on the bundle as
+        // written. A workbook can be internally consistent and still describe an
+        // event the platform would reject.
+        let schema: ImportElectionEventSchema = serde_json::from_value(bundle.export.clone())
+            .context(
+                "the built bundle does not match the import schema, which is a \
+                 bug in this tool rather than in the workbook",
+            )?;
+        let checked = validate(&schema);
+
+        report_problems(&bundle.warnings);
+        report_problems(&checked);
+
+        if checked.has_errors() {
+            return Err(anyhow!(
+                "{} problem(s) in the bundle this workbook describes",
+                checked.errors().count()
+            ));
+        }
+
+        let warnings = bundle.warnings.warnings().count() + checked.warnings().count();
+        if self.strict && warnings > 0 {
+            return Err(anyhow!("{warnings} warning(s), and --strict was given"));
+        }
+
+        if self.check_only {
+            println!(
+                "{} {} would build, with {warnings} warning(s)",
+                "ok:".green().bold(),
+                bundle.event_external_id
+            );
+            return Ok(());
+        }
+
+        self.write(&bundle)?;
+        Ok(())
+    }
+
+    /// The built-in templates, with any `.hbs` file in `--templates-dir` on top.
+    fn templates(&self) -> Result<TemplateSet> {
+        let Some(directory) = &self.templates_dir else {
+            return TemplateSet::builtin().map_err(problem_error);
+        };
+        if !directory.is_dir() {
+            return Err(anyhow!(
+                "templates directory not found: {}",
+                directory.display()
+            ));
+        }
+
+        let mut sources: Vec<(String, String)> = Vec::new();
+        for name in ENTITY_TEMPLATES {
+            let candidate = directory.join(format!("{name}.hbs"));
+            if candidate.is_file() {
+                let source = fs::read_to_string(&candidate)
+                    .with_context(|| format!("could not read {}", candidate.display()))?;
+                sources.push(((*name).to_string(), source));
+            }
+        }
+
+        // Anything else in the directory is a name nothing renders, which is
+        // almost always a typo. Saying so beats rendering the built-in and
+        // leaving its author staring at output that ignores their edit.
+        for entry in fs::read_dir(directory)
+            .with_context(|| format!("could not list {}", directory.display()))?
+        {
+            let path = entry?.path();
+            let is_template = path.extension().is_some_and(|extension| extension == "hbs");
+            let is_known = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| ENTITY_TEMPLATES.contains(&stem));
+            if is_template && !is_known {
+                println!(
+                    "{} {} is not an entity template and was ignored. Expected \
+                     one of: {}.",
+                    "warning:".yellow(),
+                    path.display(),
+                    ENTITY_TEMPLATES.join(", ")
+                );
+            }
+        }
+
+        let borrowed: Vec<(&str, &str)> = sources
+            .iter()
+            .map(|(name, source)| (name.as_str(), source.as_str()))
+            .collect();
+        TemplateSet::with_overrides(&borrowed).map_err(problem_error)
+    }
+
+    /// Read a base export from a `.json` file or an export `.zip`.
+    fn base_export(&self) -> Result<Option<serde_json::Value>> {
+        let Some(path) = &self.base_export else {
+            return Ok(None);
+        };
+        let bytes = fs::read(path).with_context(|| format!("could not read {}", path.display()))?;
+
+        let is_zip = path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"));
+        if !is_zip {
+            return serde_json::from_slice(&bytes)
+                .with_context(|| format!("{} is not valid JSON", path.display()))
+                .map(Some);
+        }
+
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+            .with_context(|| format!("{} is not a zip", path.display()))?;
+        let member = (0..zip.len())
+            .map(|index| zip.by_index(index).map(|file| file.name().to_string()))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .find(|name| {
+                let base = name.rsplit('/').next().unwrap_or(name);
+                base.starts_with("export_election_event") && base.ends_with(".json")
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "{} has no export_election_event*.json member; is it an \
+                     election event export?",
+                    path.display()
+                )
+            })?;
+
+        let file = zip.by_name(&member)?;
+        serde_json::from_reader(file)
+            .with_context(|| format!("{member} is not valid JSON"))
+            .map(Some)
+    }
+
+    /// Write the bundle, the archive, and everything that travels beside it.
+    fn write(&self, bundle: &Bundle) -> Result<()> {
+        let layout = archive::layout(bundle);
+        let directory = self.out_dir.join(&bundle.slug);
+
+        // Replaced rather than merged into: a stale member left over from a
+        // previous run is a file someone would upload.
+        if directory.exists() {
+            fs::remove_dir_all(&directory)
+                .with_context(|| format!("could not clear {}", directory.display()))?;
+        }
+        fs::create_dir_all(&directory)
+            .with_context(|| format!("could not create {}", directory.display()))?;
+
+        for artifact in layout.importable.iter().chain(layout.auxiliary.iter()) {
+            write_artifact(&directory, &artifact.name, &artifact.bytes)?;
+        }
+
+        let archive_bytes = archive::zip(&layout.importable).map_err(problem_error)?;
+        let archive_path = directory.join(&layout.archive_name);
+        fs::write(&archive_path, &archive_bytes)
+            .with_context(|| format!("could not write {}", archive_path.display()))?;
+
+        println!(
+            "{} {}",
+            "built".green().bold(),
+            bundle.event_external_id.bold()
+        );
+        println!(
+            "  import this: {}",
+            archive_path.display().to_string().bold()
+        );
+        for artifact in &layout.importable {
+            println!("    {}", artifact.name);
+        }
+        if !layout.auxiliary.is_empty() {
+            println!("  beside it, not part of the import:");
+            for artifact in &layout.auxiliary {
+                println!("    {}", directory.join(&artifact.name).display());
+            }
+        }
+        if bundle.admin_users.is_some() {
+            println!(
+                "  {} admin_users.csv may carry clear-text passwords. It is a \
+                 secret, not a deliverable.",
+                "warning:".yellow()
+            );
+        }
+        Ok(())
+    }
+}
+
+fn write_artifact(directory: &Path, name: &str, bytes: &[u8]) -> Result<()> {
+    let path = directory.join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("could not create {}", parent.display()))?;
+    }
+    fs::write(&path, bytes).with_context(|| format!("could not write {}", path.display()))
+}
+
+/// Print every problem, errors first, in the order they were found.
+fn report_problems(report: &ValidationReport) {
+    for problem in report.errors() {
+        eprintln!(
+            "{} {}: {}",
+            "error:".red().bold(),
+            problem.path,
+            problem.message
+        );
+    }
+    for problem in report.warnings() {
+        eprintln!(
+            "{} {}: {}",
+            "warning:".yellow().bold(),
+            problem.path,
+            problem.message
+        );
+    }
+}
+
+/// A single problem as an error, for the paths that fail before there is a report.
+fn problem_error(problem: Problem) -> anyhow::Error {
+    let label = match problem.severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+    };
+    anyhow!("{label}: {}: {}", problem.path, problem.message)
+}

--- a/packages/step-cli/src/commands/build_election_event.rs
+++ b/packages/step-cli/src/commands/build_election_event.rs
@@ -37,8 +37,8 @@ pub struct BuildElectionEvent {
 
     /// Directory to write the bundle into, under a subdirectory named after the
     /// event
-    #[arg(short = 'o', long, value_name = "OUT_DIR", default_value = "out")]
-    out_dir: PathBuf,
+    #[arg(short = 'o', long, value_name = "OUT", default_value = "out")]
+    out: PathBuf,
 
     /// Tenant id to write into the file
     ///
@@ -78,8 +78,19 @@ pub struct BuildElectionEvent {
     strict: bool,
 
     /// Validate and report, writing nothing
+    ///
+    /// Named after the importer's own `check_only`, which does the same thing on
+    /// the server.
     #[arg(long)]
     check_only: bool,
+
+    /// Timestamp for every generated entity
+    ///
+    /// Fixed by default so regenerating an unchanged workbook produces
+    /// byte-identical output. The importer overwrites these, so this only exists
+    /// to make a rebuild diffable.
+    #[arg(long, value_name = "CREATED_AT")]
+    created_at: Option<String>,
 }
 
 impl BuildElectionEvent {
@@ -128,7 +139,7 @@ impl BuildElectionEvent {
             tenant_id: self.tenant_id.clone(),
             base_export: self.base_export()?,
             slug: self.slug.clone(),
-            created_at: None,
+            created_at: self.created_at.clone(),
             auth_preset: self.auth_preset.clone(),
         };
 
@@ -277,7 +288,7 @@ impl BuildElectionEvent {
     /// Write the bundle, the archive, and everything that travels beside it.
     fn write(&self, bundle: &Bundle) -> Result<()> {
         let layout = archive::layout(bundle);
-        let directory = self.out_dir.join(&bundle.slug);
+        let directory = self.out.join(&bundle.slug);
 
         // Replaced rather than merged into: a stale member left over from a
         // previous run is a file someone would upload.

--- a/packages/step-cli/src/commands/mod.rs
+++ b/packages/step-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+pub mod build_election_event;
 pub mod cast_vote;
 pub mod complete_key_ceremony;
 pub mod configure;

--- a/packages/step-cli/src/main.rs
+++ b/packages/step-cli/src/main.rs
@@ -28,6 +28,7 @@ enum MainCommand {
 
 #[derive(Subcommand)]
 enum StepCommands {
+    BuildElectionEvent(commands::build_election_event::BuildElectionEvent),
     Config(commands::configure::Config),
     CreateElectionEvent(commands::create_election_event::CreateElectionEventCLI),
     CreateElection(commands::create_election::CreateElection),
@@ -71,6 +72,7 @@ fn main() {
 
     match &cli.command {
         MainCommand::Step(step_cmd) => match step_cmd {
+            StepCommands::BuildElectionEvent(cmd) => cmd.run(),
             StepCommands::Config(cmd) => cmd.run(),
             StepCommands::CreateElectionEvent(create_event) => create_event.run(),
             StepCommands::CreateElection(create_election) => create_election.run(),


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12769

**3 of 3.** Stacked on https://github.com/sequentech/step/pull/2982, so this diff
shows only what is added on top.

Two front ends over the shared core: a `step-cli` subcommand, and the browser's view
of the same functions. Neither adds a decision of its own — that is the point.

```bash
step-cli step build-election-event -w "Client Import Workbook.xlsx" --tenant-id …
```

```ts
import {checkBundle} from "sequent-core";
const report = checkBundle(await file.text());
```

## It produces the same bundle the Python does

Run against the real SEIU1000 workbook and diffed against janitor's output for the
same file, with the same `--tenant-id`:

| | |
|---|---|
| `export_voters-….csv` | **byte-identical** |
| `export_scheduled_events-….csv` | **byte-identical** |
| `export_reports-….csv` | **byte-identical** |
| `export_permissions-….csv` | **byte-identical** |
| `admin_users.csv` | **byte-identical** |
| `templates/*.hbs`, `templates.json` | **byte-identical** |
| `keycloak_admin_realm_patch.json` | **byte-identical** |
| `export_election_event-….json` | **identical when parsed** (2-space indent instead of 1) |

The event id and the derived tenant id match to the character. Every warning matches
too, including the `dlc-officers-dburs` permission label that made every election
invisible on the first real import.

## The diff caught two real bugs

**A phone number lost its `+`.** `admin_users.csv` did not match at first:
`+33645312453` arrived as `33645312453`. The workbook computes contact details with a
formula, so the cell is `t="str"` with a cached string result — and calamine 0.26
tried a float parse on that string first, which in Rust accepts a leading `+`.
`Utils.sendCode` would then have texted a number with no country code. Fixed by moving
to **calamine 0.36**, with two tests pinning it.

**`zip`'s default features cannot compile for a browser.** They pull bzip2, zstd and
lzma — C libraries with no wasm32 target — so nothing in this module could ever have
run in a browser, which is the whole point of the work. Now `default-features = false`
with `deflate` only, the only method an import archive uses.

Both were found by having two implementations to compare, not by reading the code.

## The CLI

`--check-only` reports without writing. `--strict` refuses to write when there are
warnings, which is what CI wants. `--base-export` takes a `.json` or an export `.zip`.
`--templates-dir` overrides any of the eight entity templates and says which it took;
a `.hbs` whose name is not one of them is reported rather than ignored, because that
is a typo. `--auth-preset none` builds without configuring authentication — which the
SEIU workbook needs, since it declares SAML and leaves the IdP metadata URL blank
pending the client's identity provider.

`--out` and `--created-at` keep the names the Python used: their documentation is
already written and already read. `--validate-only` becomes `--check-only`, matching
the importer's own `check_only` rather than sitting one word away from it.

Validation runs twice, and they are different questions. The builder reports what is
wrong with the **workbook**, in sheet-and-row terms an author can act on.
`validate()` then reports what would be wrong with the **bundle** — the same check
windmill runs before importing.

## The browser surface

`checkBundle` **ships in the existing WASM package with no workflow change**:
`election_config::wasm` is gated the way `crate::wasm` is, and `build_wasm.yml`
already enables both features it needs. So the admin portal can tell an operator what
is wrong with an export before they upload it, and the answer is the importer's own.

`buildFromWorkbook` and `authPresets` are additionally gated on the xlsx and archive
features, which that build does not enable — so the four existing consumers gain the
validator and carry nothing else. Packaging a build that does enable them lands with
the SPA that needs it.

Plain JS values, not wasm-bindgen classes: a front end holds these in state and hands
them to React, and an opaque handle with a `free()` method is a memory leak waiting
for whoever forgets to call it. A failed build returns its problems rather than
throwing, because a list of problems is something a page can render.

## The browser runs the same fixtures the Rust tests do

`fixtureCases()` hands over the suite from PR 2982 as data, rather than something a
front end reimplements. A page asserting `checkBundle(case.bundle)` matches
`case.expect` is checking that the browser and the server reach the same verdict —
which is the only thing that makes one validator worth having.

```ts
import {fixtureCases, checkBundle} from "sequent-core";

for (const c of fixtureCases()) {
    const report = checkBundle(JSON.stringify(c.bundle));
    // c.expect.errors / c.expect.warnings are the codes this must produce
}
```

## Verified

- `cargo test … election_config` — **400 passed**, 0 failed.
- `cargo check` clean for `sequent-core` at every gate, and for `windmill`,
  `harvest` and `step-cli` individually; no warnings from the new code;
  `cargo fmt --check` and `cargo clippy` clean.

  As on PR 2982, this was **false when first written** — an ungated re-export
  meant the crate did not build for the feature sets its consumers declare. It
  is now checked by a six-way `cargo check --lib` matrix in `tests.yml` rather
  than by hand.
- End to end against the real SEIU1000 workbook, as above. The workbook and its output were kept out of the repository and deleted from the build host afterwards.

**Not verified:** the wasm32 cross-compile itself. `ring`'s build script needs a clang
targeting wasm32, which Apple's lacks — the baseline fails identically on this machine
with and without this change, so it is environmental. CI builds that target today, and
the `zip` fix above is precisely what its first run of the config features would
otherwise have hit.

## Reading it

Four commits: the `step-cli` subcommand, the option-name alignment, the WASM surface,
and the fixtures handed to the browser.

There is also a merge commit bringing PR 2982 forward. A repository rule forbids
force-pushing this branch, so the stack is kept current by merging rather than
rebasing; the diff against the base is unaffected.

## Screenshots/videos Before

`<empty>`

## Screenshots/videos After Implementation

```
built seiu1000-leadership-2027
  import this: out/seiu1000-leadership-2027/seiu1000-leadership-2027.zip
    export_election_event-e8e06504-….json
    export_voters-e8e06504-….csv
    export_scheduled_events-e8e06504-….csv
    export_reports-e8e06504-….csv
  beside it, not part of the import:
    out/seiu1000-leadership-2027/admin_users.csv
    out/seiu1000-leadership-2027/export_permissions-….csv
    out/seiu1000-leadership-2027/templates/…
    out/seiu1000-leadership-2027/keycloak_event_realm_patch.json
  warning: admin_users.csv may carry clear-text passwords. It is a secret, not a deliverable.
```

_A screenshot of the imported event follows once this is run against a live
environment._




---

### The census the builder could not read, and the verdict that lied (`EA-F1-001`, `EA-A-003`)

**`voters_sheet` never wrote `area.external_id`.** `build_tables::voter_area_name`
reads it off every voter row and refuses the bundle without it, so **every** plan
carrying a census compiled to nothing — the wizard's ballot preview was blank and its
download produced nothing. The wizard wrote `area_name`, which is what the *finished*
CSV carries; the builder is the thing that turns the id into that name, so it needs
the id. It is now resolved from the voter's area name rather than asking somebody to
type an area twice, because two spellings of one area is a census that imports into
the wrong district.

`the_voters_sheet_matches_what_the_builder_reads` was green throughout: it asserted
every column emitted is one the builder knows, which says nothing about a column the
builder cannot do without. It now checks both directions.
`area.external_id` is deliberately *not* added to `VOTER_LEADING_COLUMNS` — that list
is what the builder derives or reorders on the way out, and this is one it consumes on
the way in.

**`validate_plan` did not check what `compile_plan` requires**, so the Final Review
screen said **Ready to build** for plans that could not be built. Fixed as an
invariant: `a_plan_the_builder_refuses_is_refused_by_the_wizard_first` compiles a
family of plausibly broken plans and asserts the wizard refuses whatever the builder
refuses. It found **four** divergences —

- a voter with no area (accepted here as "the default area", which is not a thing)
- an election with no contests (an error in the builder, a *warning* here)
- two candidates sharing an identifier (**no equivalent check existed at all**, so a
  candidate could vanish from a ballot by being silently replaced)
- `max_votes` above the number of real options

— each now an error with its own message, and identifier uniqueness checked
event-wide, since two contests may not each have a `yes`.

The converse is deliberately not asserted: the wizard may be stricter, and one that
only said what the builder says would be a thinner screen.

**`PublicationPreview::elections()`** also landed here — the beyond half of the
election picker had shipped and this half had not, so the picker had nothing to draw
from. Found while syncing, alongside a **stale index** in the worktree that would have
deleted another agent's voter-messaging work on the next commit; what distinguished
stale from in-progress was that a refactor moving messaging out of `architect.rs` would
have put it in `comms.rs`, and there is no `comms.rs` and no `PlannedMessage` anywhere
on disk.

Note that the native suite cannot see any of the wasm boundary: `wasm.rs` is behind
`#[cfg(all(feature = "wasm", …))]`, so 570 tests passed the whole time the TypeScript
declaration and the Rust struct disagreed. Rebuilt for wasm32 to check, which is the
only thing that would have.

**Verification:** 571 passed. Downstream: 643 `election-architect`, 203
`election-config-ui`, 7/7 Playwright against this core in a real browser.
