### PR TITLE
🔥 i18n: delete the "Hello World" scaffolding key

### DIFF
--- a/packages/ballot-verifier/src/translations/cat-tu.ts
+++ b/packages/ballot-verifier/src/translations/cat-tu.ts
@@ -5,7 +5,6 @@ import {TranslationType} from "./en"
 
 const catalanInformalTranslation: TranslationType = {
     translations: {
-        "welcome": "Comencem: Importa la papereta auditable...",
         "404": {
             title: "Pàgina no trobada",
             subtitle: "La pàgina que busques no existeix",

--- a/packages/ballot-verifier/src/translations/cat.ts
+++ b/packages/ballot-verifier/src/translations/cat.ts
@@ -5,7 +5,6 @@ import {TranslationType} from "./en"
 
 const catalanTranslation: TranslationType = {
     translations: {
-        "welcome": "Comencem: Importeu la papereta auditable...",
         "404": {
             title: "Pàgina no trobada",
             subtitle: "La pàgina que busqueu no existeix",

--- a/packages/ballot-verifier/src/translations/en.ts
+++ b/packages/ballot-verifier/src/translations/en.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 const englishTranslation = {
     translations: {
-        welcome: "Hello <br/> <strong>World</strong>",
         404: {
             title: "Page not found",
             subtitle: "The page you are looking for does not exist",

--- a/packages/ballot-verifier/src/translations/es-tu.ts
+++ b/packages/ballot-verifier/src/translations/es-tu.ts
@@ -5,7 +5,6 @@ import {TranslationType} from "./en"
 
 const spanishInformalTranslation: TranslationType = {
     translations: {
-        welcome: "Comencemos: Importa la papeleta auditable...",
         404: {
             title: "Página no encontrada",
             subtitle: "La página que buscas no existe",

--- a/packages/ballot-verifier/src/translations/es.ts
+++ b/packages/ballot-verifier/src/translations/es.ts
@@ -5,7 +5,6 @@ import {TranslationType} from "./en"
 
 const spanishTranslation: TranslationType = {
     translations: {
-        welcome: "Comencemos: Importe la papeleta auditable...",
         404: {
             title: "Página no encontrada",
             subtitle: "La página que busca no existe",

--- a/packages/ballot-verifier/src/translations/fr.ts
+++ b/packages/ballot-verifier/src/translations/fr.ts
@@ -5,7 +5,6 @@ import {TranslationType} from "./en"
 
 const frenchTranslation: TranslationType = {
     translations: {
-        "welcome": "Commençons : Importez le bulletin auditable...",
         "404": {
             title: "Page non trouvée",
             subtitle: "La page que vous cherchez n'existe pas",

--- a/packages/ballot-verifier/src/translations/gl.ts
+++ b/packages/ballot-verifier/src/translations/gl.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 
 const galegoTranslation: TranslationType = {
     translations: {
-        welcome: "Ola <br/> <strong>Mundo</strong>",
         404: {
             title: "Páxina non atopada",
             subtitle: "A páxina que estás buscando non existe",

--- a/packages/ballot-verifier/src/translations/tl.ts
+++ b/packages/ballot-verifier/src/translations/tl.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 const tagalogTranslation = {
     translations: {
-        welcome: "Kamusta <br/> <strong>World</strong>",
         404: {
             title: "Hindi natagpuan ang pahina",
             subtitle: "Ang pahinang hinahanap mo ay wala",

--- a/packages/ui-core/src/translations/cat-tu.ts
+++ b/packages/ui-core/src/translations/cat-tu.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const catalanInformalTranslation: TranslationType = {
     translations: {
         language: "Valencià (tu)",
-        welcome: "Comencem: Importa el vot auditable..",
         breadcrumbSteps: {
             select: "Seleccionar un Verificador",
             import: "Importar Dades",

--- a/packages/ui-core/src/translations/cat.ts
+++ b/packages/ui-core/src/translations/cat.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const catalanTranslation: TranslationType = {
     translations: {
         language: "Valencià",
-        welcome: "Comencem: Importeu el vot auditable..",
         breadcrumbSteps: {
             select: "Seleccionar un Verificador",
             import: "Importar Dades",

--- a/packages/ui-core/src/translations/en.ts
+++ b/packages/ui-core/src/translations/en.ts
@@ -4,7 +4,6 @@
 const englishTranslation = {
     translations: {
         language: "English",
-        welcome: "Hello <br/> <strong>World</strong>",
         breadcrumbSteps: {
             select: "Select a Verifier",
             import: "Import Data",

--- a/packages/ui-core/src/translations/es-tu.ts
+++ b/packages/ui-core/src/translations/es-tu.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const spanishInformalTranslation: TranslationType = {
     translations: {
         language: "Español (tú)",
-        welcome: "Let's start: Import auditable ballot..",
         breadcrumbSteps: {
             select: "Seleccionar un Verificador",
             import: "Importar Datos",

--- a/packages/ui-core/src/translations/es.ts
+++ b/packages/ui-core/src/translations/es.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const spanishTranslation: TranslationType = {
     translations: {
         language: "Español",
-        welcome: "Let's start: Import auditable ballot..",
         breadcrumbSteps: {
             select: "Seleccionar un Verificador",
             import: "Importar Datos",

--- a/packages/ui-core/src/translations/eu.ts
+++ b/packages/ui-core/src/translations/eu.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const basqueTranslation: TranslationType = {
     translations: {
         language: "Euskara",
-        welcome: "Kaixo <br/> <strong>Mundua</strong>",
         breadcrumbSteps: {
             select: "Hautatu egiaztatzaile bat",
             import: "Inportatu datuak",

--- a/packages/ui-core/src/translations/fr.ts
+++ b/packages/ui-core/src/translations/fr.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const frenchTranslation: TranslationType = {
     translations: {
         language: "Français",
-        welcome: "Commençons : Importation de bulletin de vote auditable.",
         breadcrumbSteps: {
             select: "Sélectionner un vérificateur",
             import: "Importer des données",

--- a/packages/ui-core/src/translations/gl.ts
+++ b/packages/ui-core/src/translations/gl.ts
@@ -7,7 +7,6 @@ import {TranslationType} from "./en"
 const galegoTranslation: TranslationType = {
     translations: {
         language: "Galego",
-        welcome: "Ola <br/> <strong>Mundo</strong>",
         breadcrumbSteps: {
             select: "Seleccionar un Verificador",
             import: "Importar Datos",

--- a/packages/ui-core/src/translations/nl.ts
+++ b/packages/ui-core/src/translations/nl.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const dutchTranslation: TranslationType = {
     translations: {
         language: "Nederlands",
-        welcome: "Hello <br/> <strong>World</strong>",
         breadcrumbSteps: {
             select: "Selecteer een verificateur",
             import: "Gegevens importeren",

--- a/packages/ui-core/src/translations/tl.ts
+++ b/packages/ui-core/src/translations/tl.ts
@@ -6,7 +6,6 @@ import {TranslationType} from "./en"
 const tagalogTranslation: TranslationType = {
     translations: {
         language: "Tagalog",
-        welcome: "Simulan natin: I-import ang auditable na balota..",
         breadcrumbSteps: {
             select: "Pumili ng Tagasuri",
             import: "I-import ang Data",


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12764

## What this changes

`translations.welcome` is left over from project setup and nothing reads it. Deleted from all ten `ui-core`
bundles and all eight in `ballot-verifier`, which carries its own copy of the same key.

What it held:

| language | value |
|---|---|
| en, nl | `Hello <br/> <strong>World</strong>` |
| gl, eu, tl | translations of "Hello World" |
| es, es-tu | `Let's start: Import auditable ballot..` — English, in the Spanish bundles |
| cat, cat-tu, fr | translated variants of the ballot-verifier opening line |

Two different keys are called `welcome`, which is most of why this survived:

* **`translations.welcome`** — top level, deleted here.
* **`translations.header.welcome`** (`Welcome,<br><span>{{name}}</span>`) — rendered by `ProfileMenu` through
  `i18nKey="header.welcome"`. **Untouched**, in both `ui-core` and `results-portal`.

## Why it is safe to delete

Nothing reaches the top-level key:

* No `t("welcome")` and no `i18nKey="welcome"` anywhere.
* No dynamic construction can produce it. Every computed key in the codebase carries a static namespace prefix
  — `common.language.${lang}`, `candidateScreen.invalidVotePosition.${value}`, and so on — and none yields a
  bare `welcome`. The `t(variable)` call sites take keys from resource configs and notification helpers; the
  string `"welcome"` is never among them.
* Repo-wide, `welcome` appears outside the translation files only as English prose in `README.md` and the
  docs, as an unrelated IVR phase name, and as the DOM ids `welcome-text-name` in `ProfileMenu.tsx`.

The deletion has to be all-or-nothing per package: the bundles are typed `TranslationType = typeof
englishTranslation`, so removing the key from `en.ts` alone would make every other file in that package fail
to compile.

## Base

Branched off `feat/meta-12771-register-variants/main` rather than `main`, because `es-tu.ts` and `cat-tu.ts`
exist only on that branch and carry the key too. Off `main` this would compile, then break once the i18n stack
merged: the variants would still declare a key `en.ts` no longer has.

## Verification

```
ui-core        tsc --noEmit clean, 66 tests passed
ballot-verifier tsc error count unchanged vs base (36 = 36, all pre-existing module resolution)
prettier       All matched files use Prettier code style! (18 files)
remaining `welcome` keys  20 — the nested header.welcome in ui-core and results-portal, as intended
```