### PR TITLE
hasura: add Total Blank Ballots columns migration and wire windmill's Postgres path

### DIFF
--- a/hasura/metadata/databases/backend-db/tables/sequent_backend_results_election.yaml
+++ b/hasura/metadata/databases/backend-db/tables/sequent_backend_results_election.yaml
@@ -14,6 +14,8 @@ insert_permissions:
               - documents
               - labels
               - total_voters_percent
+              - blank_ballots
+              - blank_ballots_percent
               - name
               - created_at
               - last_updated_at
@@ -33,6 +35,8 @@ insert_permissions:
               - documents
               - labels
               - total_voters_percent
+              - blank_ballots
+              - blank_ballots_percent
               - name
               - created_at
               - last_updated_at
@@ -53,6 +57,8 @@ select_permissions:
               - documents
               - labels
               - total_voters_percent
+              - blank_ballots
+              - blank_ballots_percent
               - name
               - created_at
               - last_updated_at
@@ -75,6 +81,8 @@ select_permissions:
               - documents
               - labels
               - total_voters_percent
+              - blank_ballots
+              - blank_ballots_percent
               - name
               - created_at
               - last_updated_at
@@ -95,6 +103,8 @@ select_permissions:
               - documents
               - labels
               - total_voters_percent
+              - blank_ballots
+              - blank_ballots_percent
               - name
               - created_at
               - last_updated_at
@@ -120,6 +130,8 @@ update_permissions:
               - documents
               - labels
               - total_voters_percent
+              - blank_ballots
+              - blank_ballots_percent
               - name
               - created_at
               - last_updated_at
@@ -142,6 +154,8 @@ update_permissions:
               - documents
               - labels
               - total_voters_percent
+              - blank_ballots
+              - blank_ballots_percent
               - name
               - created_at
               - last_updated_at

--- a/hasura/metadata/databases/backend-db/tables/sequent_backend_results_election_area.yaml
+++ b/hasura/metadata/databases/backend-db/tables/sequent_backend_results_election_area.yaml
@@ -9,6 +9,8 @@ insert_permissions:
                   _eq: X-Hasura-Tenant-Id
           columns:
               - area_id
+              - blank_ballots
+              - blank_ballots_percent
               - created_at
               - documents
               - election_event_id
@@ -24,6 +26,8 @@ insert_permissions:
           check: {}
           columns:
               - area_id
+              - blank_ballots
+              - blank_ballots_percent
               - created_at
               - documents
               - election_event_id
@@ -40,6 +44,8 @@ select_permissions:
           allow_aggregations: true
           columns:
               - area_id
+              - blank_ballots
+              - blank_ballots_percent
               - created_at
               - documents
               - election_event_id
@@ -58,6 +64,8 @@ select_permissions:
           allow_aggregations: true
           columns:
               - area_id
+              - blank_ballots
+              - blank_ballots_percent
               - created_at
               - documents
               - election_event_id
@@ -74,6 +82,8 @@ select_permissions:
           allow_aggregations: true
           columns:
               - area_id
+              - blank_ballots
+              - blank_ballots_percent
               - created_at
               - documents
               - election_event_id
@@ -95,6 +105,8 @@ update_permissions:
                   _eq: X-Hasura-Tenant-Id
           columns:
               - area_id
+              - blank_ballots
+              - blank_ballots_percent
               - created_at
               - documents
               - election_event_id
@@ -117,6 +129,8 @@ update_permissions:
               - created_at
               - last_updated_at
               - area_id
+              - blank_ballots
+              - blank_ballots_percent
               - election_event_id
               - election_id
               - id

--- a/hasura/migrations/backend-db/1786200256750_add_blank_ballots_to_results_election_tables/down.sql
+++ b/hasura/migrations/backend-db/1786200256750_add_blank_ballots_to_results_election_tables/down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "sequent_backend"."results_election_area"
+    DROP COLUMN "blank_ballots",
+    DROP COLUMN "blank_ballots_percent";
+
+ALTER TABLE "sequent_backend"."results_election"
+    DROP COLUMN "blank_ballots",
+    DROP COLUMN "blank_ballots_percent";

--- a/hasura/migrations/backend-db/1786200256750_add_blank_ballots_to_results_election_tables/up.sql
+++ b/hasura/migrations/backend-db/1786200256750_add_blank_ballots_to_results_election_tables/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "sequent_backend"."results_election"
+    ADD COLUMN "blank_ballots" integer,
+    ADD COLUMN "blank_ballots_percent" numeric;
+
+ALTER TABLE "sequent_backend"."results_election_area"
+    ADD COLUMN "blank_ballots" integer,
+    ADD COLUMN "blank_ballots_percent" numeric;

--- a/packages/windmill/src/postgres/results_election.rs
+++ b/packages/windmill/src/postgres/results_election.rs
@@ -51,11 +51,14 @@ impl TryFrom<Row> for ResultsElectionWrapper {
                 .map(NotNan::new)
                 .transpose()?,
             documents,
-            // The results_election.blank_ballots(_percent) columns don't
-            // exist yet; populated by a later PR once the hasura migration
-            // lands.
-            blank_ballots: None,
-            blank_ballots_percent: None,
+            blank_ballots: item
+                .try_get::<_, Option<i32>>("blank_ballots")?
+                .map(|v| v as i64),
+            blank_ballots_percent: item
+                .try_get::<&str, Option<Decimal>>("blank_ballots_percent")?
+                .map(|d| d.to_f64().map(NotNan::new).transpose())
+                .transpose()?
+                .flatten(),
         }))
     }
 }
@@ -150,6 +153,8 @@ pub async fn insert_results_elections(
         pub elegible_census: Option<i64>,
         pub total_voters: Option<i64>,
         pub total_voters_percent: Option<f64>,
+        pub blank_ballots: Option<i64>,
+        pub blank_ballots_percent: Option<f64>,
     }
 
     let tenant_uuid = parse_uuid_v4(tenant_id)?;
@@ -168,6 +173,8 @@ pub async fn insert_results_elections(
                 elegible_census: election.elegible_census,
                 total_voters: election.total_voters,
                 total_voters_percent: election.total_voters_percent.clone().map(|n| n.into()),
+                blank_ballots: election.blank_ballots,
+                blank_ballots_percent: election.blank_ballots_percent.map(|n| n.into()),
             })
         })
         .collect::<Result<Vec<InsertResultsElection>>>()?;
@@ -184,14 +191,16 @@ pub async fn insert_results_elections(
                 name TEXT,
                 elegible_census BIGINT,
                 total_voters BIGINT,
-                total_voters_percent FLOAT8
+                total_voters_percent FLOAT8,
+                blank_ballots BIGINT,
+                blank_ballots_percent FLOAT8
             )
         )
         INSERT INTO sequent_backend.results_election (
-            tenant_id, election_event_id, results_event_id, election_id, name, elegible_census, total_voters, total_voters_percent
+            tenant_id, election_event_id, results_event_id, election_id, name, elegible_census, total_voters, total_voters_percent, blank_ballots, blank_ballots_percent
         )
         SELECT
-            tenant_id, election_event_id, results_event_id, election_id, name, elegible_census, total_voters, total_voters_percent
+            tenant_id, election_event_id, results_event_id, election_id, name, elegible_census, total_voters, total_voters_percent, blank_ballots, blank_ballots_percent
         FROM data
         RETURNING *;";
 
@@ -371,6 +380,8 @@ struct InsertableResultsElection {
     elegible_census: Option<i64>,
     total_voters: Option<i64>,
     total_voters_percent: Option<f64>,
+    blank_ballots: Option<i64>,
+    blank_ballots_percent: Option<f64>,
     created_at: Option<DateTime<Local>>,
     last_updated_at: Option<DateTime<Local>>,
     labels: Option<Value>,
@@ -402,6 +413,8 @@ pub async fn insert_many_results_elections(
                 elegible_census: r.elegible_census,
                 total_voters: r.total_voters,
                 total_voters_percent: r.total_voters_percent.map(|n| n.into_inner()),
+                blank_ballots: r.blank_ballots,
+                blank_ballots_percent: r.blank_ballots_percent.map(|n| n.into_inner()),
                 created_at: r.created_at,
                 last_updated_at: r.last_updated_at,
                 labels: r.labels.clone(),
@@ -425,6 +438,8 @@ pub async fn insert_many_results_elections(
                 elegible_census BIGINT,
                 total_voters BIGINT,
                 total_voters_percent FLOAT8,
+                blank_ballots BIGINT,
+                blank_ballots_percent FLOAT8,
                 created_at TIMESTAMPTZ,
                 last_updated_at TIMESTAMPTZ,
                 labels JSONB,
@@ -435,13 +450,15 @@ pub async fn insert_many_results_elections(
         INSERT INTO sequent_backend.results_election (
             id, tenant_id, election_event_id, election_id,
             results_event_id, name, elegible_census, total_voters,
-            total_voters_percent, created_at, last_updated_at,
+            total_voters_percent, blank_ballots, blank_ballots_percent,
+            created_at, last_updated_at,
             labels, annotations, documents
         )
         SELECT
             id, tenant_id, election_event_id, election_id,
             results_event_id, name, elegible_census, total_voters,
-            total_voters_percent, created_at, last_updated_at,
+            total_voters_percent, blank_ballots, blank_ballots_percent,
+            created_at, last_updated_at,
             labels, annotations, documents
         FROM data
         RETURNING *;

--- a/packages/windmill/src/postgres/results_election_area.rs
+++ b/packages/windmill/src/postgres/results_election_area.rs
@@ -61,7 +61,7 @@ pub async fn insert_results_election_area_documents(
     area_id: &str,
     area_name: &str,
     documents: &ResultDocuments,
-    blank_ballots: Option<i64>,
+    blank_ballots: Option<i32>,
     blank_ballots_percent: Option<f64>,
 ) -> Result<()> {
     let documents_value = serde_json::to_value(documents.clone())?;

--- a/packages/windmill/src/postgres/results_election_area.rs
+++ b/packages/windmill/src/postgres/results_election_area.rs
@@ -75,6 +75,11 @@ pub async fn insert_results_election_area_documents(
         .map_err(|err| anyhow!("Error parsing election_id as UUID: {}", err))?;
     let area_uuid: uuid::Uuid =
         parse_uuid_v4(&area_id).map_err(|err| anyhow!("Error parsing area_id as UUID: {}", err))?;
+    // blank_ballots_percent is a Postgres `numeric` column; tokio-postgres
+    // only maps f64 to `float8`, so bind the value as the same Decimal type
+    // the read path (ResultsElectionAreaWrapper) already uses.
+    let blank_ballots_percent_decimal: Option<Decimal> =
+        blank_ballots_percent.and_then(Decimal::from_f64_retain);
 
     let statement = hasura_transaction
         .prepare(
@@ -107,7 +112,7 @@ pub async fn insert_results_election_area_documents(
                 &area_uuid,
                 &area_name,
                 &blank_ballots,
-                &blank_ballots_percent,
+                &blank_ballots_percent_decimal,
             ],
         )
         .await

--- a/packages/windmill/src/postgres/results_election_area.rs
+++ b/packages/windmill/src/postgres/results_election_area.rs
@@ -61,6 +61,8 @@ pub async fn insert_results_election_area_documents(
     area_id: &str,
     area_name: &str,
     documents: &ResultDocuments,
+    blank_ballots: Option<i64>,
+    blank_ballots_percent: Option<f64>,
 ) -> Result<()> {
     let documents_value = serde_json::to_value(documents.clone())?;
     let tenant_uuid: uuid::Uuid = parse_uuid_v4(&tenant_id)
@@ -78,15 +80,17 @@ pub async fn insert_results_election_area_documents(
         .prepare(
             r#"
                 INSERT INTO sequent_backend.results_election_area (
-                    documents, 
-                    tenant_id, 
-                    results_event_id, 
-                    election_event_id, 
-                    election_id, 
+                    documents,
+                    tenant_id,
+                    results_event_id,
+                    election_event_id,
+                    election_id,
                     area_id,
-                    name
+                    name,
+                    blank_ballots,
+                    blank_ballots_percent
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 RETURNING id;
             "#,
         )
@@ -102,6 +106,8 @@ pub async fn insert_results_election_area_documents(
                 &election_uuid,
                 &area_uuid,
                 &area_name,
+                &blank_ballots,
+                &blank_ballots_percent,
             ],
         )
         .await

--- a/packages/windmill/src/postgres/results_election_area.rs
+++ b/packages/windmill/src/postgres/results_election_area.rs
@@ -4,6 +4,9 @@
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Local};
 use deadpool_postgres::Transaction;
+use ordered_float::NotNan;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 use sequent_core::serialization::deserialize_with_path::deserialize_value;
 use sequent_core::services::uuid_validation::parse_uuid_v4;
 use sequent_core::types::results::{ResultDocuments, ResultsElectionArea};
@@ -36,11 +39,14 @@ impl TryFrom<Row> for ResultsElectionAreaWrapper {
             created_at: item.get("created_at"),
             last_updated_at: item.get("last_updated_at"),
             documents,
-            // The results_election_area.blank_ballots(_percent) columns
-            // don't exist yet; populated by a later PR once the hasura
-            // migration lands.
-            blank_ballots: None,
-            blank_ballots_percent: None,
+            blank_ballots: item
+                .try_get::<_, Option<i32>>("blank_ballots")?
+                .map(|v| v as i64),
+            blank_ballots_percent: item
+                .try_get::<&str, Option<Decimal>>("blank_ballots_percent")?
+                .map(|d| d.to_f64().map(NotNan::new).transpose())
+                .transpose()?
+                .flatten(),
         }))
     }
 }
@@ -158,6 +164,8 @@ struct InsertableResultsElectionArea {
     last_updated_at: Option<DateTime<Local>>,
     documents: Option<Value>,
     name: Option<String>,
+    blank_ballots: Option<i64>,
+    blank_ballots_percent: Option<f64>,
 }
 
 #[instrument(err, skip(hasura_transaction, areas))]
@@ -185,6 +193,8 @@ pub async fn insert_many_results_elections_areas(
                 last_updated_at: a.last_updated_at,
                 documents: documents_json,
                 name: a.name.clone(),
+                blank_ballots: a.blank_ballots,
+                blank_ballots_percent: a.blank_ballots_percent.map(|n| n.into_inner()),
             })
         })
         .collect::<Result<_>>()?;
@@ -203,18 +213,20 @@ pub async fn insert_many_results_elections_areas(
                 created_at TIMESTAMPTZ,
                 last_updated_at TIMESTAMPTZ,
                 documents JSONB,
-                name TEXT
+                name TEXT,
+                blank_ballots BIGINT,
+                blank_ballots_percent FLOAT8
             )
         )
         INSERT INTO sequent_backend.results_election_area (
             id, tenant_id, election_event_id, election_id,
             area_id, results_event_id, created_at, last_updated_at,
-            documents, name
+            documents, name, blank_ballots, blank_ballots_percent
         )
         SELECT
             id, tenant_id, election_event_id, election_id,
             area_id, results_event_id, created_at, last_updated_at,
-            documents, name
+            documents, name, blank_ballots, blank_ballots_percent
         FROM data
         RETURNING *;
     "#;

--- a/packages/windmill/src/services/ceremonies/result_documents.rs
+++ b/packages/windmill/src/services/ceremonies/result_documents.rs
@@ -835,7 +835,7 @@ pub async fn save_result_documents(
                         })
                     })
             });
-            let area_blank_ballots_count = area_blank_ballots.map(|(count, _)| count as i64);
+            let area_blank_ballots_count = area_blank_ballots.map(|(count, _)| count as i32);
             // Percentage over total votes cast, not census: a blank ballot
             // is a valid cast ballot, matching results.rs/generate_db.rs.
             let area_blank_ballots_percent = area_blank_ballots
@@ -911,7 +911,7 @@ async fn save_area_documents(
     area: BasicArea,
     tally_type_enum: TallyType,
     sqlite_transaction_opt: Option<&SqliteTransaction<'_>>,
-    blank_ballots: Option<i64>,
+    blank_ballots: Option<i32>,
     blank_ballots_percent: Option<f64>,
 ) -> Result<ResultDocuments> {
     let documents = generic_save_documents(
@@ -947,7 +947,7 @@ async fn save_area_documents(
             &area.id,
             &area.name,
             &documents,
-            blank_ballots,
+            blank_ballots.map(|v| v as i64),
             blank_ballots_percent
                 .map(ordered_float::NotNan::new)
                 .transpose()?,

--- a/packages/windmill/src/services/ceremonies/result_documents.rs
+++ b/packages/windmill/src/services/ceremonies/result_documents.rs
@@ -37,6 +37,7 @@ use sequent_core::types::hasura::core::Area;
 use sequent_core::types::results::ResultDocuments;
 use sequent_core::util::temp_path::get_file_size;
 use std::{
+    cmp,
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
@@ -813,6 +814,33 @@ pub async fn save_result_documents(
                 base_tally_path,
             );
 
+            // election_report.blank_ballots is None when the policy is
+            // disabled, or Some when enabled (already resolved by
+            // generate_reports.rs against the tally session
+            // configuration) -- reuse that gate rather than re-deriving
+            // the policy check here. Matched by area id, not the first
+            // report found: a MULTIPLE_CONTESTS election's contests can
+            // have non-identical area coverage.
+            let area_blank_ballots = election_report.blank_ballots.and_then(|_| {
+                election_report
+                    .reports
+                    .iter()
+                    .find(|report| {
+                        report.area.as_ref().map(|report_area| &report_area.id) == Some(&area.id)
+                    })
+                    .and_then(|report| report.contest_result.as_ref())
+                    .and_then(|contest_result| {
+                        contest_result.extended_metrics.as_ref().map(|metrics| {
+                            (metrics.total_blank_ballots, contest_result.total_votes)
+                        })
+                    })
+            });
+            let area_blank_ballots_count = area_blank_ballots.map(|(count, _)| count as i64);
+            // Percentage over total votes cast, not census: a blank ballot
+            // is a valid cast ballot, matching results.rs/generate_db.rs.
+            let area_blank_ballots_percent = area_blank_ballots
+                .map(|(count, total_votes)| (count as f64) / (cmp::max(total_votes, 1) as f64));
+
             save_area_documents(
                 hasura_transaction,
                 &report_tenant_id,
@@ -824,6 +852,8 @@ pub async fn save_result_documents(
                 area,
                 tally_type_enum.clone(),
                 sqlite_transaction_opt,
+                area_blank_ballots_count,
+                area_blank_ballots_percent,
             )
             .await?;
         }
@@ -881,6 +911,8 @@ async fn save_area_documents(
     area: BasicArea,
     tally_type_enum: TallyType,
     sqlite_transaction_opt: Option<&SqliteTransaction<'_>>,
+    blank_ballots: Option<i64>,
+    blank_ballots_percent: Option<f64>,
 ) -> Result<ResultDocuments> {
     let documents = generic_save_documents(
         document_paths,
@@ -900,6 +932,8 @@ async fn save_area_documents(
         &area.id,
         &area.name,
         &documents,
+        blank_ballots,
+        blank_ballots_percent,
     )
     .await?;
 
@@ -913,8 +947,10 @@ async fn save_area_documents(
             &area.id,
             &area.name,
             &documents,
-            None,
-            None,
+            blank_ballots,
+            blank_ballots_percent
+                .map(ordered_float::NotNan::new)
+                .transpose()?,
         )
         .await?;
     }


### PR DESCRIPTION
## Summary

Fourth PR in the Total Blank Ballots stack (sequent-core → velvet → windmill CSV pipeline → this one), stacked on #2993.

- Hasura migration `1786200256750_add_blank_ballots_to_results_election_tables`: adds nullable `blank_ballots` (integer) / `blank_ballots_percent` (numeric) columns to `sequent_backend.results_election` and `results_election_area`, matching the existing `total_voters`/`total_voters_percent` column types.
- Metadata permissions extended for `admin-user`, `service-account`, and `tally-results-read` across both tables' insert/select/update permission sets.
- `windmill/src/postgres/results_election.rs` and `results_election_area.rs` stop hardcoding these fields to `None` — those comments said "populated by a later PR once the hasura migration lands"; this is that PR. Read side follows the existing `elegible_census`/`total_voters` pattern (stored as `integer`, widened to `i64` in Rust); write side threads both columns through the JSONB-recordset insert helpers.

## Update: establish blank_ballots per area, not just at election level

Also closes the velvet checklist item "Per-area establishment" (the "unavailability propagated through roll-ups" half of that item is a separate, pre-existing, cross-cutting gap affecting every metric at parent/aggregate areas today, not specific to blank ballots — stays out of scope, not silently claimed as solved).

The data was already computed: `ElectionReportDataComputed.reports` has one entry per area with `contest_result.extended_metrics.total_blank_ballots` populated — the same struct `results.rs` already reads for the election-level value. No velvet-crate changes needed.

- `postgres/results_election_area.rs` — `insert_results_election_area_documents` gains `blank_ballots`/`blank_ballots_percent` parameters and columns, mirroring `insert_many_results_elections_areas` from earlier in this PR.
- `services/ceremonies/result_documents.rs` — before writing each area's documents, look up that area's entry by area id (not `.first()` — a `MULTIPLE_CONTESTS` election's contests can have non-identical area coverage), gated on `election_report.blank_ballots.is_some()` so it stays unavailable rather than a false zero. Percentage computed against the area's own `total_votes`. Threaded into both the Postgres and sqlite write calls, replacing the hardcoded `None, None` the sqlite call has had since PR1.

## Verification

Verified against the live devcontainer's Hasura + Postgres, not just compiled:
- Applied the migration and metadata with the real `hasura` CLI (`hasura migrate apply`, `hasura metadata apply`).
- Confirmed both columns exist with the correct types via `psql \d`.
- Confirmed `hasura metadata ic list` reports metadata consistent.
- Confirmed both columns are queryable over GraphQL under both the `admin-user` and `tally-results-read` roles specifically — proving the hand-written permission entries are actually recognized by Hasura, not just well-formed YAML.
- `cargo check -p windmill` and `cargo fmt -p windmill -- --check` both pass clean.

Parent issue: https://github.com/sequentech/meta/issues/12773
