### PR TITLE
🐞 Voting Portal: remove the duplicate audit trigger

### DIFF
--- a/packages/voting-portal/src/routes/ReviewScreen.tsx
+++ b/packages/voting-portal/src/routes/ReviewScreen.tsx
@@ -615,18 +615,12 @@ export const ReviewScreen: React.FC = () => {
         }
     }
 
-    function handleCloseDialogIdHelp(val: boolean) {
+    // Dismiss only. Auditing is reached from AuditButton, which confirms through
+    // AuditBallotHelpDialog first; this dialog used to navigate there too, which
+    // is the duplicate audit trigger reported in META-12776. Matches how
+    // AuditScreen renders the same dialog.
+    function handleCloseDialogIdHelp() {
         setOpenBallotIdHelp(false)
-
-        if (val) {
-            if (ballotStyle && tenantId && eventId) {
-                navigate(
-                    `/tenant/${tenantId}/event/${eventId}/election/${ballotStyle.election_id}/audit`
-                )
-            } else {
-                navigate(`/tenant/${tenantId}/event/${eventId}/election-chooser`)
-            }
-        }
     }
 
     const getBallotDataFromSessionStorage = () => {
@@ -779,7 +773,10 @@ export const ReviewScreen: React.FC = () => {
                         ? [
                               <AuditButton
                                   key={"audit-button"}
-                                  onClick={() => setAuditBallotHelp(true)}
+                                  onClick={() => {
+                                      setOpenBallotIdHelp(false)
+                                      setAuditBallotHelp(true)
+                                  }}
                               />,
                           ]
                         : []


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12776

## The duplication

Under `audit_button_cfg = SHOW_IN_HELP`, opening the Ballot Tracker ID help dialog produced one action row with **two** controls that both jumped to `/audit`:

- the red/white `AuditButton` in `middleActions` (`variant="warning"` → white background, `#DC2626` border and text)
- the blue OK button, "I accept my vote has NOT been cast" (Dialog `variant="info"` → `okVariant="primary"`, which is not a registered variant so it falls through to `MuiButton` root styling, `brandColor` `#0F054C`)

That maps exactly onto the report: remove the blue one, keep the red and white one.

It was also wrong under the default `SHOW` config, where the blue OK jumped straight to `/audit` — **skipping the "Yes, I want to DISCARD my ballot to audit it" confirmation** and dropping `location.search`, which both other audit navigations preserve. So a button labelled "I accept my vote has NOT been cast" silently voided the ballot.

Introduced by #701, which added `AuditButton` to this dialog's `middleActions` and renamed the handler while leaving the old navigation in place.

## Change

- `handleCloseDialogIdHelp` now only dismisses. Auditing is reached solely from `AuditButton`, which confirms through `AuditBallotHelpDialog` first.
- `AuditButton` in `middleActions` closes the ballot-id dialog before opening the confirmation, so the two no longer stack. Under `SHOW_IN_HELP` this is now the only route into the audit flow, so the stacking would otherwise be on the happy path.

The removed `else` branch navigated to `election-chooser` when `ballotStyle`/`tenantId`/`eventId` were missing. It was unreachable — the component early-returns above when `!ballotStyle || !auditableBallot`, and the route guarantees the params — and would have produced `/tenant/undefined/event/undefined/election-chooser` if it had run.

## One decision for the reporter

This removes the blue button's *behaviour*, not the button. It now dismisses, the same as Cancel.

I did not delete it, because `AuditScreen.tsx:161-168` renders this identical dialog with the same blue OK as a pure dismiss already, so removing the navigation makes ReviewScreen consistent with its sibling rather than diverging from it. Deleting the button would mean making `ok` optional on the shared `Dialog` component, which has 104 call sites.

If you want the button gone rather than inert, say so and I'll make `ok` optional and guard the render.

## Verification

`prettier --check` clean, `tsc --noEmit` reports zero errors in `ReviewScreen.tsx`. Two independent hostile reviews confirmed the diagnosis, the colour mapping, the absence of any other audit-triggering control in the portal, and that no audit entry point is lost under any config. No test in the repo exercises this dialog, so nothing breaks and nothing verifies it.

## Pre-existing, out of scope

- `Dialog.tsx:125` — `className={middleActions ? "has-middle" : "no-middle"}`; ReviewScreen passes `[]`, which is truthy, so `has-middle` applies in every config.
- `Dialog.tsx:19-29` — `StyledDialogActions` has an unbalanced brace: the `@media` block is never closed, so the mobile column layout for middle-action dialogs does not apply.
