### PR TITLE
Blank ballots: voting-portal review/confirmation UI and ballot-verifier rendering

### DIFF
--- a/packages/ballot-verifier/src/fixtures/confirmation_ballot.json
+++ b/packages/ballot-verifier/src/fixtures/confirmation_ballot.json
@@ -229,6 +229,7 @@
           "contest_id":"fae0b09e-1b78-4118-b99c-7955f8ef2a52",
           "is_explicit_invalid":false,
           "is_decline_to_vote":false,
+          "is_blank_ballot":false,
           "choices":[
              {
                 "id":"0",
@@ -258,6 +259,7 @@
           "contest_id":"837993a6-1d7d-473c-82b7-5fc5a128f0a4",
           "is_explicit_invalid":false,
           "is_decline_to_vote":false,
+          "is_blank_ballot":false,
           "choices":[
              {
                 "id":"0",

--- a/packages/ballot-verifier/src/screens/ConfirmationScreen.tsx
+++ b/packages/ballot-verifier/src/screens/ConfirmationScreen.tsx
@@ -32,7 +32,11 @@ import {sortContestList} from "@sequentech/ui-core"
 import {keyBy} from "lodash"
 import {useElectionClassName} from "./hooks/useElectionClassName"
 import {SettingsContext} from "../providers/SettingsContextProvider"
-import {EDeclineToVotePolicy, EElectionEventContestEncryptionPolicy} from "@sequentech/ui-core"
+import {
+    EDeclineToVotePolicy,
+    EElectionEventContestEncryptionPolicy,
+    EBlankBallotsPolicy,
+} from "@sequentech/ui-core"
 
 const StyledLink = styled(RouterLink)`
     margin: auto 0;
@@ -280,6 +284,12 @@ const VerifySelectionsSection: React.FC<VerifySelectionsSectionProps> = ({
         confirmationBallot?.election_config?.election_event_presentation
             ?.contest_encryption_policy === EElectionEventContestEncryptionPolicy.MULTIPLE_CONTESTS
 
+    const isBlankBallotsPolicyEnabled =
+        confirmationBallot?.election_config?.election_presentation?.blank_ballots_policy ===
+            EBlankBallotsPolicy.ENABLED &&
+        confirmationBallot?.election_config?.election_event_presentation
+            ?.contest_encryption_policy === EElectionEventContestEncryptionPolicy.MULTIPLE_CONTESTS
+
     return (
         <>
             <HorizontalWrap marginTop="26px">
@@ -346,6 +356,8 @@ const VerifySelectionsSection: React.FC<VerifySelectionsSectionProps> = ({
                             pointsLabel={(points) => t("confirmationScreen.points", {points})}
                             isDeclineToVotePolicyEnabled={isDeclineToVotePolicyEnabled}
                             declineToVoteLabel={t("confirmationScreen.declineToVote")}
+                            isBlankBallotsPolicyEnabled={isBlankBallotsPolicyEnabled}
+                            blankBallotLabel={t("confirmationScreen.blankBallot")}
                         />
                     ))}
                 </>

--- a/packages/ballot-verifier/src/translations/cat.ts
+++ b/packages/ballot-verifier/src/translations/cat.ts
@@ -76,6 +76,7 @@ const catalanTranslation: TranslationType = {
             points: "({{points}} Punts)",
             contestNotFound: "Pregunta no trobada: {{contestId}}",
             declineToVote: "Vot no emès",
+            blankBallot: "Papereta en blanc",
         },
         "errors": {
             encoding: {

--- a/packages/ballot-verifier/src/translations/en.ts
+++ b/packages/ballot-verifier/src/translations/en.ts
@@ -72,6 +72,7 @@ const englishTranslation = {
             points: "({{points}} Points)",
             contestNotFound: "Contest not found: {{contestId}}",
             declineToVote: "Declined to vote",
+            blankBallot: "Blank ballot",
         },
         footer: {
             poweredBy: "Powered by <1></1>",

--- a/packages/ballot-verifier/src/translations/es.ts
+++ b/packages/ballot-verifier/src/translations/es.ts
@@ -76,6 +76,7 @@ const spanishTranslation: TranslationType = {
             points: "({{points}} Puntos)",
             contestNotFound: "Pregunta no encontrada: {{contestId}}",
             declineToVote: "Se abstuvo de votar",
+            blankBallot: "Papeleta en blanco",
         },
         footer: {
             poweredBy: "Funciona con <1></1>",

--- a/packages/ballot-verifier/src/translations/fr.ts
+++ b/packages/ballot-verifier/src/translations/fr.ts
@@ -74,6 +74,7 @@ const frenchTranslation: TranslationType = {
             points: "({{points}} Points)",
             contestNotFound: "Question non trouvée : {{contestId}}",
             declineToVote: "A choisi de ne pas voter",
+            blankBallot: "Bulletin blanc",
         },
         "footer": {
             poweredBy: "Propulsé par <1></1>",

--- a/packages/ballot-verifier/src/translations/gl.ts
+++ b/packages/ballot-verifier/src/translations/gl.ts
@@ -75,6 +75,7 @@ const galegoTranslation: TranslationType = {
             points: "({{points}} Puntos)",
             contestNotFound: "Concurso non atopado: {{contestId}}",
             declineToVote: "Decidiu non votar",
+            blankBallot: "Papeleta en branco",
         },
         footer: {
             poweredBy: "Impulsado por <1></1>",

--- a/packages/ballot-verifier/src/translations/tl.ts
+++ b/packages/ballot-verifier/src/translations/tl.ts
@@ -72,6 +72,7 @@ const tagalogTranslation = {
             points: "({{points}} Mga Punto)",
             contestNotFound: "Paligsahan hindi natagpuan: {{contestId}}",
             declineToVote: "Hindi bumoto",
+            blankBallot: "Blangkong balota",
         },
         footer: {
             poweredBy: "Pinapagana ng <1></1>",

--- a/packages/ui-essentials/src/components/PlaintextVoteContest/PlaintextVoteContest.tsx
+++ b/packages/ui-essentials/src/components/PlaintextVoteContest/PlaintextVoteContest.tsx
@@ -235,6 +235,8 @@ export interface PlaintextVoteContestProps {
     pointsLabel: (points: number) => string
     isDeclineToVotePolicyEnabled: boolean
     declineToVoteLabel?: string
+    isBlankBallotsPolicyEnabled?: boolean
+    blankBallotLabel?: string
 }
 
 export const PlaintextVoteContest: React.FC<PlaintextVoteContestProps> = ({
@@ -246,6 +248,8 @@ export const PlaintextVoteContest: React.FC<PlaintextVoteContestProps> = ({
     pointsLabel,
     isDeclineToVotePolicyEnabled,
     declineToVoteLabel,
+    isBlankBallotsPolicyEnabled,
+    blankBallotLabel,
 }) => {
     const {t, i18n} = useTranslation()
 
@@ -266,6 +270,10 @@ export const PlaintextVoteContest: React.FC<PlaintextVoteContestProps> = ({
 
     const isBallotDeclineToVote =
         isDeclineToVotePolicyEnabled && questionPlaintext.is_decline_to_vote
+
+    const isWholeBallotBlank = Boolean(
+        isBlankBallotsPolicyEnabled && questionPlaintext.is_blank_ballot
+    )
 
     const {noCategoryCandidates, categoriesMap} = categorizeCandidates(question)
     const sortedCategoryEntries = sortCategoryEntries(
@@ -292,10 +300,12 @@ export const PlaintextVoteContest: React.FC<PlaintextVoteContestProps> = ({
             <Typography variant="body2" fontWeight={"bold"}>
                 {translate(question, "name", i18n.language) || ""}
             </Typography>
-            {isBlank || isBallotDeclineToVote ? (
+            {isWholeBallotBlank ? (
+                <BlankAnswer title={blankBallotLabel} />
+            ) : isBlank || isBallotDeclineToVote ? (
                 <BlankAnswer title={isBallotDeclineToVote ? declineToVoteLabel : undefined} />
             ) : null}
-            {!isBallotDeclineToVote && (
+            {!isBallotDeclineToVote && !isWholeBallotBlank && (
                 <>
                     {questionPlaintext.invalid_errors.map((error, index) => (
                         <WarnBox

--- a/packages/ui-essentials/src/components/PlaintextVoteContest/__stories__/PlaintextVoteContest.stories.tsx
+++ b/packages/ui-essentials/src/components/PlaintextVoteContest/__stories__/PlaintextVoteContest.stories.tsx
@@ -410,3 +410,27 @@ export const DeclineToVote: Story = {
     ),
     parameters: commonParameters,
 }
+
+export const BlankBallot: Story = {
+    render: () => (
+        <PlaintextVoteContest
+            question={makeContest()}
+            questionPlaintext={makePlaintext({
+                is_blank_ballot: true,
+                choices: [
+                    {id: "1", selected: -1},
+                    {id: "2", selected: -1},
+                    {id: "3", selected: -1},
+                ],
+            })}
+            publicBucketUrl=""
+            contestNotFoundLabel="Contest not found"
+            markedInvalidLabel="Ballot explicitly marked invalid"
+            pointsLabel={() => ""}
+            isDeclineToVotePolicyEnabled={false}
+            isBlankBallotsPolicyEnabled={true}
+            blankBallotLabel="Blank ballot"
+        />
+    ),
+    parameters: commonParameters,
+}

--- a/packages/voting-portal/src/components/Question/Question.tsx
+++ b/packages/voting-portal/src/components/Question/Question.tsx
@@ -123,6 +123,7 @@ export interface IQuestionProps {
     setDecodedContests: (input: IDecodedVoteContest) => void
     errorSelectionState: BallotSelection
     isDeclineToVote?: boolean
+    isBlankBallot?: boolean
 }
 
 export const Question: React.FC<IQuestionProps> = ({
@@ -133,6 +134,7 @@ export const Question: React.FC<IQuestionProps> = ({
     setDecodedContests,
     errorSelectionState,
     isDeclineToVote,
+    isBlankBallot,
 }) => {
     // THIS IS A CONTEST COMPONENT
     const {i18n, t} = useTranslation()
@@ -328,6 +330,10 @@ export const Question: React.FC<IQuestionProps> = ({
             {isDeclineToVote ? (
                 <InvalidBlankWrapper className="candidates-review-decline" columnCount={1}>
                     <BlankAnswer title={t("reviewScreen.declineToVote")} />
+                </InvalidBlankWrapper>
+            ) : isBlankBallot ? (
+                <InvalidBlankWrapper className="candidates-review-blank-ballot" columnCount={1}>
+                    <BlankAnswer title={t("reviewScreen.blankBallot")} />
                 </InvalidBlankWrapper>
             ) : (
                 <>

--- a/packages/voting-portal/src/hooks/useEncryptBallotForReview.ts
+++ b/packages/voting-portal/src/hooks/useEncryptBallotForReview.ts
@@ -64,16 +64,22 @@ export const useEncryptBallotForReview = () => {
                     auditableBallot.voter_ballot_signature = signedContent?.signature
                 }
 
+                let decodedSelectionState = isMultiContest
+                    ? decodeAuditableMultiBallot(auditableBallot as IAuditableMultiBallot)
+                    : decodeAuditableBallot(auditableBallot as IAuditableSingleBallot)
+
+                const isBlankBallot = Boolean(
+                    decodedSelectionState?.length &&
+                    decodedSelectionState.every((contest) => contest.is_blank_ballot)
+                )
+
                 dispatch(
                     setAuditableBallot({
                         electionId: ballotStyle.election_id,
                         auditableBallot,
+                        isBlankBallot,
                     })
                 )
-
-                let decodedSelectionState = isMultiContest
-                    ? decodeAuditableMultiBallot(auditableBallot as IAuditableMultiBallot)
-                    : decodeAuditableBallot(auditableBallot as IAuditableSingleBallot)
 
                 if (!isUndefined(decodedSelectionState) && decodedSelectionState !== null) {
                     dispatch(

--- a/packages/voting-portal/src/routes/ConfirmationScreen.tsx
+++ b/packages/voting-portal/src/routes/ConfirmationScreen.tsx
@@ -28,7 +28,10 @@ import {faPrint, faCircleQuestion, faCheck} from "@fortawesome/free-solid-svg-ic
 import {useLocation, useNavigate, useParams} from "react-router-dom"
 import Link from "@mui/material/Link"
 import {useAppDispatch, useAppSelector} from "../store/hooks"
-import {selectAuditableBallot} from "../store/auditableBallots/auditableBallotsSlice"
+import {
+    selectAuditableBallot,
+    selectIsBlankBallot,
+} from "../store/auditableBallots/auditableBallotsSlice"
 import {canVoteSomeElection, CastVoteStatus} from "../store/castVotes/castVotesSlice"
 import {selectElectionEventById} from "../store/electionEvents/electionEventsSlice"
 import {IElectionExtended} from "../store/elections/electionsSlice"
@@ -334,6 +337,7 @@ const ConfirmationScreen: React.FC = () => {
     const {tenantId, eventId} = useParams<TenantEventType>()
     const {electionId} = useParams<{electionId?: string}>()
     const auditableBallot = useAppSelector(selectAuditableBallot(String(electionId)))
+    const isBlankBallot = useAppSelector(selectIsBlankBallot(String(electionId)))
     const confirmationScreenData = useAppSelector(selectConfirmationScreenData(String(electionId)))
     const {t} = useTranslation()
     const [openBallotIdHelp, setOpenBallotIdHelp] = useState(false)
@@ -438,6 +442,11 @@ const ConfirmationScreen: React.FC = () => {
             <Typography variant="body2" sx={{color: theme.palette.customGrey.main}}>
                 {stringToHtml(t("confirmationScreen.description"))}
             </Typography>
+            {isBlankBallot ? (
+                <Typography variant="body2" sx={{color: theme.palette.customGrey.main}}>
+                    {stringToHtml(t("confirmationScreen.blankBallot.description"))}
+                </Typography>
+            ) : null}
             <BallotIdContainer>
                 <Typography
                     variant="h5"

--- a/packages/voting-portal/src/routes/ReviewScreen.tsx
+++ b/packages/voting-portal/src/routes/ReviewScreen.tsx
@@ -307,6 +307,7 @@ interface ActionButtonProps {
     isGoldenPolicy: boolean
     isMultiContest: boolean
     isDeclineToVote: boolean
+    isBlankBallot: boolean
 }
 
 const ActionButtons: React.FC<ActionButtonProps> = ({
@@ -319,6 +320,7 @@ const ActionButtons: React.FC<ActionButtonProps> = ({
     isGoldenPolicy,
     isMultiContest,
     isDeclineToVote,
+    isBlankBallot,
 }) => {
     const {t} = useTranslation()
     const navigate = useNavigate()
@@ -491,12 +493,30 @@ const ActionButtons: React.FC<ActionButtonProps> = ({
             <Dialog
                 handleClose={handleCloseCastVoteDialog}
                 open={isConfirmCastVoteModal}
-                title={t("reviewScreen.confirmCastVoteDialog.title")}
-                ok={t("reviewScreen.confirmCastVoteDialog.ok")}
-                cancel={t("reviewScreen.confirmCastVoteDialog.cancel")}
+                title={t(
+                    isBlankBallot
+                        ? "reviewScreen.confirmCastBlankBallotDialog.title"
+                        : "reviewScreen.confirmCastVoteDialog.title"
+                )}
+                ok={t(
+                    isBlankBallot
+                        ? "reviewScreen.confirmCastBlankBallotDialog.ok"
+                        : "reviewScreen.confirmCastVoteDialog.ok"
+                )}
+                cancel={t(
+                    isBlankBallot
+                        ? "reviewScreen.confirmCastBlankBallotDialog.cancel"
+                        : "reviewScreen.confirmCastVoteDialog.cancel"
+                )}
                 variant="info"
             >
-                {stringToHtml(t("reviewScreen.confirmCastVoteDialog.content"))}
+                {stringToHtml(
+                    t(
+                        isBlankBallot
+                            ? "reviewScreen.confirmCastBlankBallotDialog.content"
+                            : "reviewScreen.confirmCastVoteDialog.content"
+                    )
+                )}
             </Dialog>
         </Box>
     )
@@ -586,6 +606,10 @@ export const ReviewScreen: React.FC = () => {
 
     const selectionState = useAppSelector(
         selectBallotSelectionByElectionId(ballotStyle?.election_id ?? "")
+    )
+
+    const isBlankBallot = Boolean(
+        selectionState?.length && selectionState.every((contest) => contest.is_blank_ballot)
     )
 
     const errorSelectionState = useMemo(() => {
@@ -834,6 +858,7 @@ export const ReviewScreen: React.FC = () => {
                         setDecodedContests={() => undefined}
                         errorSelectionState={errorSelectionState}
                         isDeclineToVote={isDeclineToVote}
+                        isBlankBallot={isBlankBallot}
                     />
                 </Box>
             ))}
@@ -848,6 +873,7 @@ export const ReviewScreen: React.FC = () => {
                     isGoldenPolicy={isGoldenPolicy ?? false}
                     isMultiContest={isMultiContest}
                     isDeclineToVote={isDeclineToVote}
+                    isBlankBallot={isBlankBallot}
                 />
             )}
         </PageLimit>

--- a/packages/voting-portal/src/routes/VotingScreen.tsx
+++ b/packages/voting-portal/src/routes/VotingScreen.tsx
@@ -10,11 +10,13 @@ import {PageLimit, Icon, IconButton, theme, Dialog} from "@sequentech/ui-essenti
 import {
     check_voting_error_dialog_bool,
     check_voting_not_allowed_next_bool,
+    checkIsBlank,
     stringToHtml,
     isUndefined,
     translateFromPresentation,
     IContest,
     EElectionEventContestEncryptionPolicy,
+    EBlankBallotsPolicy,
     BallotSelection,
     getDefaultVotingScreenBackPolicy,
 } from "@sequentech/ui-core"
@@ -34,6 +36,7 @@ import {
 import {
     selectBallotSelectionByElectionId,
     resetBallotSelection,
+    setAllBallotSelectionsBlankBallot,
 } from "../store/ballotSelections/ballotSelectionsSlice"
 import {clearDeclinedToVoteForElection, clearIsVoted, setIsVoted} from "../store/extra/extraSlice"
 import {TenantEventType} from ".."
@@ -355,6 +358,30 @@ const VotingScreen: React.FC = () => {
         return check_voting_error_dialog_bool(ballotStyle?.ballot_eml.contests, decodedContests)
     }
 
+    // whole-ballot blank ballots are only meaningful for MULTIPLE_CONTESTS
+    // elections, and only when the admin has opted into the policy - this is
+    // distinct from each contest's own (pre-existing) blank_vote_policy
+    const isBlankBallotsPolicyEnabled = (): boolean => {
+        const isMultiContest =
+            ballotStyle?.ballot_eml.election_event_presentation?.contest_encryption_policy ==
+            EElectionEventContestEncryptionPolicy.MULTIPLE_CONTESTS
+        return (
+            election?.presentation?.blank_ballots_policy === EBlankBallotsPolicy.ENABLED &&
+            isMultiContest
+        )
+    }
+
+    const isWholeBallotBlank = (): boolean => {
+        const contests = ballotStyle?.ballot_eml.contests ?? []
+        if (contests.length === 0 || !isBlankBallotsPolicyEnabled()) {
+            return false
+        }
+        return contests.every((contest) => {
+            const decoded = decodedContests[contest.id]
+            return Boolean(decoded && checkIsBlank(decoded))
+        })
+    }
+
     const encryptAndReview = () => {
         if (isUndefined(selectionState) || !ballotStyle) {
             return
@@ -377,6 +404,10 @@ const VotingScreen: React.FC = () => {
         }
 
         dispatch(clearDeclinedToVoteForElection(ballotStyle.election_id))
+
+        if (isWholeBallotBlank()) {
+            dispatch(setAllBallotSelectionsBlankBallot({ballotStyle}))
+        }
 
         const isMultiContest =
             ballotStyle?.ballot_eml.election_event_presentation?.contest_encryption_policy ==
@@ -522,17 +553,23 @@ const VotingScreen: React.FC = () => {
                     title={t(
                         hasInvalidErrors
                             ? "votingScreen.nonVotedDialog.title"
-                            : "votingScreen.warningDialog.title"
+                            : isWholeBallotBlank()
+                              ? "votingScreen.blankBallotDialog.title"
+                              : "votingScreen.warningDialog.title"
                     )}
                     ok={t(
                         hasInvalidErrors
                             ? "votingScreen.nonVotedDialog.continue"
-                            : "votingScreen.warningDialog.continue"
+                            : isWholeBallotBlank()
+                              ? "votingScreen.blankBallotDialog.continue"
+                              : "votingScreen.warningDialog.continue"
                     )}
                     cancel={t(
                         hasInvalidErrors
                             ? "votingScreen.nonVotedDialog.cancel"
-                            : "votingScreen.warningDialog.cancel"
+                            : isWholeBallotBlank()
+                              ? "votingScreen.blankBallotDialog.cancel"
+                              : "votingScreen.warningDialog.cancel"
                     )}
                     variant="action"
                 >
@@ -540,7 +577,9 @@ const VotingScreen: React.FC = () => {
                         t(
                             hasInvalidErrors
                                 ? "votingScreen.nonVotedDialog.content"
-                                : "votingScreen.warningDialog.content"
+                                : isWholeBallotBlank()
+                                  ? "votingScreen.blankBallotDialog.content"
+                                  : "votingScreen.warningDialog.content"
                         )
                     )}
                 </Dialog>

--- a/packages/voting-portal/src/store/auditableBallots/auditableBallotsSlice.ts
+++ b/packages/voting-portal/src/store/auditableBallots/auditableBallotsSlice.ts
@@ -5,8 +5,13 @@ import {createSlice, PayloadAction} from "@reduxjs/toolkit"
 import {RootState} from "../store"
 import {IAuditableBallot} from "@sequentech/ui-core"
 
+export interface AuditableBallotEntry {
+    auditableBallot: IAuditableBallot
+    isBlankBallot: boolean
+}
+
 export interface AuditableBallotsState {
-    [ballotStyleId: string]: IAuditableBallot | undefined
+    [ballotStyleId: string]: AuditableBallotEntry | undefined
 }
 
 const initialState: AuditableBallotsState = {}
@@ -20,9 +25,13 @@ export const auditableBallotsSlice = createSlice({
             action: PayloadAction<{
                 electionId: string
                 auditableBallot: IAuditableBallot
+                isBlankBallot: boolean
             }>
         ): AuditableBallotsState => {
-            state[action.payload.electionId] = action.payload.auditableBallot
+            state[action.payload.electionId] = {
+                auditableBallot: action.payload.auditableBallot,
+                isBlankBallot: action.payload.isBlankBallot,
+            }
 
             return state
         },
@@ -32,6 +41,9 @@ export const auditableBallotsSlice = createSlice({
 export const {setAuditableBallot} = auditableBallotsSlice.actions
 
 export const selectAuditableBallot = (electionId: string) => (state: RootState) =>
-    state.auditableBallots[electionId]
+    state.auditableBallots[electionId]?.auditableBallot
+
+export const selectIsBlankBallot = (electionId: string) => (state: RootState) =>
+    state.auditableBallots[electionId]?.isBlankBallot ?? false
 
 export default auditableBallotsSlice.reducer

--- a/packages/voting-portal/src/store/ballotSelections/ballotSelectionsSlice.test.ts
+++ b/packages/voting-portal/src/store/ballotSelections/ballotSelectionsSlice.test.ts
@@ -22,6 +22,7 @@ jest.mock(
 
 import ballotSelectionsReducer, {
     resetBallotSelection,
+    setAllBallotSelectionsBlankBallot,
     setAllBallotSelectionsDeclineToVote,
     setBallotSelectionBlankVote,
     setBallotSelectionInvalidVote,
@@ -168,5 +169,21 @@ describe("ballotSelectionsSlice is_blank_ballot consistency", () => {
 
         const election = state[ELECTION_ID]
         expect(election?.every((contest) => contest.is_blank_ballot === false)).toBe(true)
+    })
+
+    it("sets is_blank_ballot and clears is_decline_to_vote on every contest, even from a declined state", () => {
+        const ballotStyle = makeBallotStyle()
+        const declinedState = ballotSelectionsReducer(
+            makeState(),
+            setAllBallotSelectionsDeclineToVote({ballotStyle})
+        )
+        const state = ballotSelectionsReducer(
+            declinedState,
+            setAllBallotSelectionsBlankBallot({ballotStyle})
+        )
+
+        const election = state[ELECTION_ID]
+        expect(election?.every((contest) => contest.is_blank_ballot === true)).toBe(true)
+        expect(election?.every((contest) => contest.is_decline_to_vote === false)).toBe(true)
     })
 })

--- a/packages/voting-portal/src/store/ballotSelections/ballotSelectionsSlice.ts
+++ b/packages/voting-portal/src/store/ballotSelections/ballotSelectionsSlice.ts
@@ -264,6 +264,23 @@ export const ballotSelectionsSlice = createSlice({
             }
             return state
         },
+        setAllBallotSelectionsBlankBallot: (
+            state,
+            action: PayloadAction<{
+                ballotStyle: IBallotStyle
+            }>
+        ): BallotSelectionsState => {
+            let currentElection = state[action.payload.ballotStyle.election_id]
+
+            if (!isUndefined(currentElection)) {
+                currentElection.forEach((currentQuestion) => {
+                    currentQuestion.is_blank_ballot = true
+                    // A ballot cannot be both blank and declined.
+                    currentQuestion.is_decline_to_vote = false
+                })
+            }
+            return state
+        },
     },
     /*extraReducers: (builder) => {
         builder.addCase(fetchElectionByIdAsync.fulfilled, (state, action) => {
@@ -289,6 +306,7 @@ export const {
     setBallotSelectionBlankVote,
     setBallotSelectionVoteChoice,
     setAllBallotSelectionsDeclineToVote,
+    setAllBallotSelectionsBlankBallot,
 } = ballotSelectionsSlice.actions
 
 export const selectBallotSelectionVoteChoice =

--- a/packages/voting-portal/src/translations/cat.ts
+++ b/packages/voting-portal/src/translations/cat.ts
@@ -55,6 +55,13 @@ const catalanTranslation: TranslationType = {
                 continue: "Continua",
                 cancel: "Cancel·la",
             },
+            blankBallotDialog: {
+                title: "No heu seleccionat cap candidat",
+                content:
+                    "No heu fet cap selecció. La vostra papereta s'emetrà com a papereta en blanc, que és una elecció vàlida i deliberada i es comptabilitzarà com a tal.",
+                continue: "Continua",
+                cancel: "Cancel·la",
+            },
         },
         startScreen: {
             startButton: "Començar a votar",
@@ -111,6 +118,13 @@ const catalanTranslation: TranslationType = {
                 title: "Esteu segur que voleu emetre el vostre vot?",
                 content: "Un cop confirmeu, el vostre vot serà emès.",
                 ok: "Sí, vull emetre el meu vot",
+                cancel: "Cancel·lar",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "Esteu segur que voleu emetre una papereta en blanc?",
+                content:
+                    "No heu seleccionat cap candidat. Un cop confirmeu, la vostra papereta s'emetrà en blanc.",
+                ok: "Sí, vull emetre la meva papereta en blanc",
                 cancel: "Cancel·lar",
             },
             error: {
@@ -206,11 +220,16 @@ const catalanTranslation: TranslationType = {
                     "S'ha produït un error intern en emetre el vot. Si us plau, torneu-ho a provar més tard o contacteu amb el suport per rebre assistència.",
             },
             declineToVote: "Declinar votar",
+            blankBallot: "Papereta en blanc",
         },
         confirmationScreen: {
             title: "El seu vot ha estat emès",
             description:
                 "La seva papereta va ser emesa correctament. Usi el codi a continuació per verificar que va ser comptabilitzada",
+            blankBallot: {
+                description:
+                    "La vostra papereta s'ha emès en blanc, que és una elecció vàlida i deliberada.",
+            },
             ballotId: "Localitzador del Vot",
             printButton: "Imprimir",
             finishButton: "Finalitzar",

--- a/packages/voting-portal/src/translations/en.ts
+++ b/packages/voting-portal/src/translations/en.ts
@@ -53,6 +53,13 @@ const englishTranslation = {
                 continue: "Continue",
                 cancel: "Cancel",
             },
+            blankBallotDialog: {
+                title: "You have not selected any candidates",
+                content:
+                    "You have not made any selections. Your ballot will be cast as a blank ballot, which is a valid, deliberate choice and will be counted as such.",
+                continue: "Continue",
+                cancel: "Cancel",
+            },
         },
         startScreen: {
             startButton: "Start Voting",
@@ -108,6 +115,13 @@ const englishTranslation = {
                 title: "Are you sure you want to cast your vote?",
                 content: "After you confirm, your vote will be cast.",
                 ok: "Yes, I want to cast my vote",
+                cancel: "Cancel",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "Are you sure you want to cast a blank ballot?",
+                content:
+                    "You have not selected any candidates. After you confirm, your ballot will be cast as blank.",
+                ok: "Yes, cast my blank ballot",
                 cancel: "Cancel",
             },
             error: {
@@ -196,11 +210,15 @@ const englishTranslation = {
                     "There was an internal error while casting the vote. Please try again later or contact support for assistance.",
             },
             declineToVote: "Decline to vote",
+            blankBallot: "Blank ballot",
         },
         confirmationScreen: {
             title: "Your vote has been cast",
             description:
                 "Your ballot was cast successfully. Use the code below to verify that it was counted",
+            blankBallot: {
+                description: "Your ballot was cast blank, which is a valid, deliberate choice.",
+            },
             ballotId: "Ballot ID",
             printButton: "Print",
             finishButton: "Finish",

--- a/packages/voting-portal/src/translations/es.ts
+++ b/packages/voting-portal/src/translations/es.ts
@@ -55,6 +55,13 @@ const spanishTranslation: TranslationType = {
                 continue: "Continuar",
                 cancel: "Cancelar",
             },
+            blankBallotDialog: {
+                title: "No ha seleccionado ningún candidato",
+                content:
+                    "No ha realizado ninguna selección. Su papeleta se emitirá como papeleta en blanco, lo cual es una elección válida y deliberada y se contabilizará como tal.",
+                continue: "Continuar",
+                cancel: "Cancelar",
+            },
         },
         startScreen: {
             startButton: "Empezar a votar",
@@ -110,6 +117,13 @@ const spanishTranslation: TranslationType = {
                 title: "¿Está seguro de que quiere emitir su voto?",
                 content: "Una vez que confirmes, tu voto será emitido.",
                 ok: "Sí, quiero emitir mi voto",
+                cancel: "Cancelar",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "¿Está seguro de que desea emitir una papeleta en blanco?",
+                content:
+                    "No ha seleccionado ningún candidato. Una vez confirme, su papeleta se emitirá en blanco.",
+                ok: "Sí, quiero emitir mi papeleta en blanco",
                 cancel: "Cancelar",
             },
             error: {
@@ -205,11 +219,16 @@ const spanishTranslation: TranslationType = {
                     "Hubo un error interno al emitir el voto. Por favor, inténtelo de nuevo más tarde o contacte con soporte para obtener ayuda.",
             },
             declineToVote: "Declinar votar",
+            blankBallot: "Papeleta en blanco",
         },
         confirmationScreen: {
             title: "Su voto ha sido emitido",
             description:
                 "Su papeleta fue emitida correctamente. Use el código a continuación para verificar que fue contabilizada",
+            blankBallot: {
+                description:
+                    "Su papeleta se emitió en blanco, lo cual es una elección válida y deliberada.",
+            },
             ballotId: "Localizador del Voto",
             printButton: "Imprimir",
             finishButton: "Finalizar",

--- a/packages/voting-portal/src/translations/eu.ts
+++ b/packages/voting-portal/src/translations/eu.ts
@@ -55,6 +55,13 @@ const basqueTranslation: TranslationType = {
                 continue: "Jarraitu",
                 cancel: "Utzi",
             },
+            blankBallotDialog: {
+                title: "Ez duzu hautagairik hautatu",
+                content:
+                    "Ez duzu inolako hautaketarik egin. Zure boto-txartela zuri gisa aurkeztuko da, aukera baliozko eta nahitakoa da eta horrela zenbatuko da.",
+                continue: "Jarraitu",
+                cancel: "Utzi",
+            },
         },
         startScreen: {
             startButton: "Hasi Bozketa",
@@ -111,6 +118,13 @@ const basqueTranslation: TranslationType = {
                 title: "Ziur zaude zure botoa eman nahi duzula?",
                 content: "Berretsi ondoren, zure botoa emango da.",
                 ok: "Bai, nire botoa eman nahi dut",
+                cancel: "Ezeztatu",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "Ziur zaude boto-txartel zuria aurkeztu nahi duzula?",
+                content:
+                    "Ez duzu hautagairik hautatu. Berretsi ondoren, zure boto-txartela zuri gisa aurkeztuko da.",
+                ok: "Bai, nire boto-txartel zuria aurkeztu nahi dut",
                 cancel: "Ezeztatu",
             },
             error: {
@@ -204,11 +218,16 @@ const basqueTranslation: TranslationType = {
                     "Barne-errore bat gertatu da botoa ematean. Mesedez, saiatu berriro geroago edo jarri harremanetan laguntza-zerbitzuarekin.",
             },
             declineToVote: "Bozkatzeari uko egin",
+            blankBallot: "Boto-txartel zuria",
         },
         confirmationScreen: {
             title: "Zure botoa eman da",
             description:
                 "Beheko berrespen kodeak egiaztatzen du <b>zure bozketa arrakastaz eman dela</b>. Kode hau erabil dezakezu zure bozketa kontatu dela egiaztatzeko.",
+            blankBallot: {
+                description:
+                    "Zure boto-txartela zuri gisa aurkeztu da, aukera baliozko eta nahitakoa da.",
+            },
             ballotId: "Bozketa IDa",
             printButton: "Inprimatu",
             finishButton: "Amaitu",

--- a/packages/voting-portal/src/translations/fr.ts
+++ b/packages/voting-portal/src/translations/fr.ts
@@ -55,6 +55,13 @@ const frenchTranslation: TranslationType = {
                 continue: "Continuer",
                 cancel: "Annuler",
             },
+            blankBallotDialog: {
+                title: "Vous n'avez sélectionné aucun candidat",
+                content:
+                    "Vous n'avez fait aucune sélection. Votre bulletin sera déposé comme bulletin blanc, un choix valide et délibéré qui sera comptabilisé comme tel.",
+                continue: "Continuer",
+                cancel: "Annuler",
+            },
         },
         startScreen: {
             startButton: "Commencer à voter",
@@ -110,6 +117,13 @@ const frenchTranslation: TranslationType = {
                 title: "Êtes-vous sûr de vouloir voter?",
                 content: "Après confirmation, votre vote sera émis.",
                 ok: "Oui, je veux voter",
+                cancel: "Annuler",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "Êtes-vous sûr de vouloir déposer un bulletin blanc ?",
+                content:
+                    "Vous n'avez sélectionné aucun candidat. Après confirmation, votre bulletin sera déposé blanc.",
+                ok: "Oui, je veux déposer mon bulletin blanc",
                 cancel: "Annuler",
             },
             error: {
@@ -204,11 +218,15 @@ const frenchTranslation: TranslationType = {
                     "Une erreur interne s'est produite lors du vote. Veuillez réessayer ultérieurement ou contacter le support pour obtenir de l'aide.",
             },
             declineToVote: "S’abstenir de voter",
+            blankBallot: "Bulletin blanc",
         },
         confirmationScreen: {
             title: "Votre vote a été émis",
             description:
                 "Le code de confirmation ci-dessous vérifie que <b>votre vote a été émis correctement</b>. Vous pouvez utiliser ce code pour vérifier que votre vote a été comptabilisé.",
+            blankBallot: {
+                description: "Votre bulletin a été déposé blanc, un choix valide et délibéré.",
+            },
             ballotId: "Localisateur de Vote",
             printButton: "Imprimer",
             finishButton: "Terminer",

--- a/packages/voting-portal/src/translations/gl.ts
+++ b/packages/voting-portal/src/translations/gl.ts
@@ -56,6 +56,13 @@ const galegoTranslation: TranslationType = {
                 continue: "Continuar",
                 cancel: "Cancelar",
             },
+            blankBallotDialog: {
+                title: "Non seleccionou ningún candidato",
+                content:
+                    "Non fixo ningunha selección. A súa papeleta emitirase como papeleta en branco, o cal é unha elección válida e deliberada e contabilizarase como tal.",
+                continue: "Continuar",
+                cancel: "Cancelar",
+            },
         },
         startScreen: {
             startButton: "Comezar a votar",
@@ -112,6 +119,13 @@ const galegoTranslation: TranslationType = {
                 title: "Estás seguro de que queres emitir o teu voto?",
                 content: "Tras confirmar, o teu voto será emitido.",
                 ok: "Si, quero emitir o meu voto",
+                cancel: "Cancelar",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "Está seguro de que quere emitir unha papeleta en branco?",
+                content:
+                    "Non seleccionou ningún candidato. Unha vez confirme, a súa papeleta emitirase en branco.",
+                ok: "Si, quero emitir a miña papeleta en branco",
                 cancel: "Cancelar",
             },
             error: {
@@ -204,11 +218,16 @@ const galegoTranslation: TranslationType = {
                     "Houbo un erro interno ao emitir o voto. Por favor, inténteo de novo máis tarde ou contacte co soporte para obter axuda.",
             },
             declineToVote: "Absterse de votar",
+            blankBallot: "Papeleta en branco",
         },
         confirmationScreen: {
             title: "O teu voto foi emitido",
             description:
                 "O código de confirmación abaixo verifica que <b>o teu voto foi emitido correctamente</b>. Podes usar este código para verificar que a túa papeleta foi contada.",
+            blankBallot: {
+                description:
+                    "A súa papeleta emitiuse en branco, o cal é unha elección válida e deliberada.",
+            },
             ballotId: "ID da Papeleta",
             printButton: "Imprimir",
             finishButton: "Rematar",

--- a/packages/voting-portal/src/translations/nl.ts
+++ b/packages/voting-portal/src/translations/nl.ts
@@ -55,6 +55,13 @@ const dutchTranslation: TranslationType = {
                 continue: "Doorgaan",
                 cancel: "Annuleren",
             },
+            blankBallotDialog: {
+                title: "U heeft geen kandidaten geselecteerd",
+                content:
+                    "U heeft geen selecties gemaakt. Uw stembiljet wordt uitgebracht als blanco stembiljet, wat een geldige, weloverwogen keuze is en als zodanig zal worden geteld.",
+                continue: "Doorgaan",
+                cancel: "Annuleren",
+            },
         },
         startScreen: {
             startButton: "Begin met stemmen",
@@ -111,6 +118,13 @@ const dutchTranslation: TranslationType = {
                 title: "Weet u zeker dat u uw stem wilt uitbrengen?",
                 content: "Na bevestiging wordt uw stem uitgebracht.",
                 ok: "Ja, ik wil mijn stem uitbrengen",
+                cancel: "Annuleren",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "Weet u zeker dat u een blanco stembiljet wilt uitbrengen?",
+                content:
+                    "U heeft geen kandidaten geselecteerd. Na bevestiging wordt uw stembiljet blanco uitgebracht.",
+                ok: "Ja, ik wil mijn blanco stembiljet uitbrengen",
                 cancel: "Annuleren",
             },
             error: {
@@ -204,11 +218,16 @@ const dutchTranslation: TranslationType = {
                     "Er is een interne fout opgetreden tijdens het uitbrengen van de stem. Probeer het later opnieuw of neem contact op met de ondersteuning voor hulp.",
             },
             declineToVote: "Afzien van stemmen",
+            blankBallot: "Blanco stembiljet",
         },
         confirmationScreen: {
             title: "Uw stem is uitgebracht",
             description:
                 "De onderstaande bevestigingscode verifieert dat <b>uw stembiljet succesvol is uitgebracht</b>. U kunt deze code gebruiken om te controleren of uw stembiljet is geteld.",
+            blankBallot: {
+                description:
+                    "Uw stembiljet is blanco uitgebracht, wat een geldige, weloverwogen keuze is.",
+            },
             ballotId: "Stembiljet ID",
             printButton: "Afdrukken",
             finishButton: "Voltooien",

--- a/packages/voting-portal/src/translations/tl.ts
+++ b/packages/voting-portal/src/translations/tl.ts
@@ -55,6 +55,13 @@ const tagalogTranslation: TranslationType = {
                 continue: "Magpatuloy",
                 cancel: "Kanselahin",
             },
+            blankBallotDialog: {
+                title: "Wala kang napiling kandidato",
+                content:
+                    "Wala kang ginawang pagpili. Ang iyong balota ay isusumite bilang blangkong balota, na isang wasto at sinasadyang pagpili at ibibilang bilang ganoon.",
+                continue: "Magpatuloy",
+                cancel: "Kanselahin",
+            },
         },
         startScreen: {
             startButton: "Simulan ang Pagboto",
@@ -111,6 +118,13 @@ const tagalogTranslation: TranslationType = {
                 title: "Sigurado ka bang nais mong i-submit ang iyong boto?",
                 content: "Pagkatapos mong kumpirmahin, ang iyong boto ay mai-susubmit.",
                 ok: "Oo, nais kong i-submit ang aking boto",
+                cancel: "Kanselahin",
+            },
+            confirmCastBlankBallotDialog: {
+                title: "Sigurado ka bang nais mong magsumite ng blangkong balota?",
+                content:
+                    "Wala kang napiling kandidato. Pagkatapos mong kumpirmahin, ang iyong balota ay isusumite bilang blangko.",
+                ok: "Oo, nais kong isumite ang aking blangkong balota",
                 cancel: "Kanselahin",
             },
             error: {
@@ -203,11 +217,16 @@ const tagalogTranslation: TranslationType = {
                     "Nagkaroon ng internal error habang nagboboto. Pakisubukang muli mamaya o makipag-ugnayan sa support para sa tulong.",
             },
             declineToVote: "Tumangging bumoto",
+            blankBallot: "Blangkong balota",
         },
         confirmationScreen: {
             title: "Ang iyong boto ay nai-submit na",
             description:
                 "Ang code ng kumpirmasyon sa ibaba ay nagpapatunay na <b>ang iyong balota ay matagumpay na nai-submit</b>. Maaari mong gamitin ang code na ito upang tiyakin na ang iyong balota ay nabilang.",
+            blankBallot: {
+                description:
+                    "Ang iyong balota ay naisumite bilang blangko, na isang wasto at sinasadyang pagpili.",
+            },
             ballotId: "ID ng Balota",
             printButton: "I-print",
             finishButton: "Tapos na",


### PR DESCRIPTION
## Summary
- Sets `is_blank_ballot` on every contest before encryption when a voter leaves the whole ballot empty under an enabled `blank_ballots_policy` (multi-contest elections only), mirroring the existing decline-to-vote flow.
- Adds per-contest "Blank ballot" labels on the review screen, blank-aware copy on the pre-cast warning dialog and the cast-confirmation dialog, and blank-specific receipt copy on the confirmation screen.
- Renders the blank ballot flag in ballot-verifier's `PlaintextVoteContest`, taking priority over the generic per-contest "blank vote" label.
- Adds translations across all 8 voting-portal locales and all 6 ballot-verifier locales.
- Adds a `PlaintextVoteContest` Storybook story and a reducer unit test for the new `setAllBallotSelectionsBlankBallot` action.

Stacked on #2995 (hasura migration + windmill Postgres wiring), the first point in the stack where `EBlankBallotsPolicy`/`is_blank_ballot` are usable end-to-end.

Parent issue: https://github.com/sequentech/meta/issues/12773

## Test plan
- [x] `yarn --cwd ./ui-essentials test` and `yarn --cwd ./voting-portal test` pass, including new `setAllBallotSelectionsBlankBallot` reducer test
- [x] `tsc --noEmit` clean on voting-portal, ui-essentials, ballot-verifier (no new errors introduced)
- [x] `yarn lint` clean across all touched packages
- [x] Manual smoke test: voting-portal boots and renders cleanly with the new code paths
- [ ] Manual walkthrough in devcontainer with a live MULTIPLE_CONTESTS election with `blank_ballots_policy: ENABLED`: cast a blank ballot end-to-end (warning dialog → review screen labels → cast confirmation → receipt copy) and confirm regression-free behavior with the policy disabled and with decline-to-vote

🤖 Generated with [Claude Code](https://claude.com/claude-code)