### PR TITLE
🐞 Voting Portal: only link to results once voting has closed

### DIFF
--- a/packages/voting-portal/src/routes/ElectionSelectionScreen.tsx
+++ b/packages/voting-portal/src/routes/ElectionSelectionScreen.tsx
@@ -21,6 +21,7 @@ import {
     formatVotingPortalDateTime,
 } from "@sequentech/ui-core"
 import {AuthContext} from "../providers/AuthContextProvider"
+import {isElectionEventVotingClosed, isVotingClosedForChannels} from "../utils/votingStatus"
 import {faCircleQuestion} from "@fortawesome/free-solid-svg-icons"
 import {styled} from "@mui/material/styles"
 import {useAppDispatch, useAppSelector} from "../store/hooks"
@@ -169,14 +170,6 @@ const isResultsWebsiteEnabled = (electionEvent?: IElectionEvent): boolean => {
     )
 }
 
-const isElectionEventVotingClosed = (electionEvent?: IElectionEvent): boolean => {
-    return (
-        !isElectionEventOnlineVotingOpen(electionEvent) &&
-        !isElectionEventKioskOpen(electionEvent) &&
-        !isElectionEventEarlyVotingOpen(electionEvent)
-    )
-}
-
 const ElectionWrapper: React.FC<ElectionWrapperProps> = ({
     electionId,
     bypassChooser,
@@ -277,10 +270,20 @@ const ElectionWrapper: React.FC<ElectionWrapperProps> = ({
         navigate(`../election/${electionId}/ballot-locator${location.search}`)
     }
 
+    // Not `!isVotingOpen()`: that is also true before voting starts and while
+    // it is paused.
+    const isVotingClosed = () =>
+        isVotingClosedForChannels([
+            electionStatus?.voting_status,
+            electionStatus?.kiosk_voting_status,
+            electionStatus?.early_voting_status,
+            electionStatus?.telephone_voting_status,
+        ])
+
     const resultsUrl =
         globalSettings.RESULTS_PORTAL_URL &&
         eventId &&
-        !isVotingOpen() &&
+        isVotingClosed() &&
         isResultsWebsiteEnabled(electionEvent)
             ? `${globalSettings.RESULTS_PORTAL_URL.replace(/\/+$/, "")}/${eventId}/elections/${electionId}`
             : undefined

--- a/packages/voting-portal/src/utils/votingStatus.test.ts
+++ b/packages/voting-portal/src/utils/votingStatus.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import {EVotingStatus, IElectionEvent} from "@sequentech/ui-core"
+import {isElectionEventVotingClosed, isVotingClosedForChannels} from "./votingStatus"
+
+const NOT_STARTED = EVotingStatus.NOT_STARTED
+const OPEN = EVotingStatus.OPEN
+const PAUSED = EVotingStatus.PAUSED
+const CLOSED = EVotingStatus.CLOSED
+
+const event = (
+    voting: EVotingStatus,
+    kiosk: EVotingStatus = NOT_STARTED,
+    early: EVotingStatus = NOT_STARTED,
+    telephone: EVotingStatus = NOT_STARTED
+): IElectionEvent =>
+    ({
+        status: {
+            voting_status: voting,
+            kiosk_voting_status: kiosk,
+            early_voting_status: early,
+            telephone_voting_status: telephone,
+        },
+    }) as unknown as IElectionEvent
+
+describe("isVotingClosedForChannels", () => {
+    it("is false when nothing ever ran", () => {
+        expect(isVotingClosedForChannels([NOT_STARTED, NOT_STARTED, NOT_STARTED])).toBe(false)
+        expect(isVotingClosedForChannels([])).toBe(false)
+        expect(isVotingClosedForChannels([undefined, undefined])).toBe(false)
+    })
+
+    it("is false while a channel is open or paused", () => {
+        expect(isVotingClosedForChannels([OPEN])).toBe(false)
+        expect(isVotingClosedForChannels([PAUSED])).toBe(false)
+        expect(isVotingClosedForChannels([CLOSED, OPEN])).toBe(false)
+        expect(isVotingClosedForChannels([CLOSED, PAUSED])).toBe(false)
+    })
+
+    it("ignores channels that never ran", () => {
+        expect(isVotingClosedForChannels([CLOSED, NOT_STARTED, NOT_STARTED])).toBe(true)
+        expect(isVotingClosedForChannels([NOT_STARTED, CLOSED])).toBe(true)
+    })
+
+    it("requires every channel that ran to be closed", () => {
+        expect(isVotingClosedForChannels([CLOSED, CLOSED])).toBe(true)
+        expect(isVotingClosedForChannels([CLOSED, CLOSED, NOT_STARTED])).toBe(true)
+    })
+})
+
+describe("isElectionEventVotingClosed", () => {
+    // The regression this guards: an online-only event created through the admin
+    // UI keeps the other three channels at NOT_STARTED forever, so a predicate
+    // demanding all four be CLOSED would hide the results link permanently.
+    it("is true for a closed online-only event", () => {
+        expect(isElectionEventVotingClosed(event(CLOSED))).toBe(true)
+    })
+
+    it("is false for an event that has not started, which is META-12780", () => {
+        expect(isElectionEventVotingClosed(event(NOT_STARTED))).toBe(false)
+    })
+
+    it("is false while voting is open or paused", () => {
+        expect(isElectionEventVotingClosed(event(OPEN))).toBe(false)
+        expect(isElectionEventVotingClosed(event(PAUSED))).toBe(false)
+    })
+
+    it("is true for a kiosk-only event whose kiosk channel closed", () => {
+        expect(isElectionEventVotingClosed(event(NOT_STARTED, CLOSED))).toBe(true)
+    })
+
+    it("is false when early voting is still open after online closed", () => {
+        expect(isElectionEventVotingClosed(event(CLOSED, NOT_STARTED, OPEN))).toBe(false)
+    })
+
+    it("is true when every channel that ran has closed", () => {
+        expect(isElectionEventVotingClosed(event(CLOSED, CLOSED, CLOSED, CLOSED))).toBe(true)
+    })
+
+    it("is false for a missing event or missing status", () => {
+        expect(isElectionEventVotingClosed(undefined)).toBe(false)
+        expect(isElectionEventVotingClosed({} as IElectionEvent)).toBe(false)
+    })
+})

--- a/packages/voting-portal/src/utils/votingStatus.ts
+++ b/packages/voting-portal/src/utils/votingStatus.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import {EVotingStatus, IElectionEvent, IElectionEventStatus} from "@sequentech/ui-core"
+
+/**
+ * Voting has finished when at least one channel actually ran and every channel
+ * that ran has reached CLOSED.
+ *
+ * Channels still at NOT_STARTED are ignored rather than counted as closed. A
+ * status row always carries all four channels and the backend only ever writes
+ * the ones the event enables, so an online-only event keeps kiosk, early and
+ * telephone at NOT_STARTED for its whole life; requiring all four to be CLOSED
+ * would hide the results link forever.
+ *
+ * Testing for "no channel is OPEN" is equally wrong in the other direction: it
+ * holds before voting starts and while it is paused, which is what put the
+ * results link on events that had not started. See META-12780.
+ */
+export const isVotingClosedForChannels = (statuses: Array<EVotingStatus | undefined>): boolean => {
+    const channelsThatRan = statuses.filter(
+        (status): status is EVotingStatus => Boolean(status) && EVotingStatus.NOT_STARTED !== status
+    )
+    return (
+        channelsThatRan.length > 0 &&
+        channelsThatRan.every((status) => EVotingStatus.CLOSED === status)
+    )
+}
+
+export const isElectionEventVotingClosed = (electionEvent?: IElectionEvent): boolean => {
+    const status = electionEvent?.status as IElectionEventStatus | null
+    return isVotingClosedForChannels([
+        status?.voting_status,
+        status?.kiosk_voting_status,
+        status?.early_voting_status,
+        status?.telephone_voting_status,
+    ])
+}


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12780

## Cause

`EVotingStatus` is `NOT_STARTED | OPEN | PAUSED | CLOSED`, but both results-portal gates tested for the absence of `OPEN`:

- `isElectionEventVotingClosed` was `!onlineOpen && !kioskOpen && !earlyOpen`
- the per-election `resultsUrl` was gated on `!isVotingOpen()`

"Not open" is true before voting starts and while it is paused, so the link showed on events that had never started.

## Fix

Voting counts as closed when **at least one channel actually ran and every channel that ran has reached CLOSED**.

Channels left at `NOT_STARTED` are ignored rather than counted as closed. That distinction is load-bearing: `ElectionEventStatus` in `sequent-core/src/ballot.rs` declares all four channel fields as non-optional with `NOT_STARTED` defaults, and `windmill/src/services/election_event_status.rs` only ever writes the channels the event enables. So a normal online-only event keeps kiosk, early and telephone at `NOT_STARTED` for its entire life. A first version of this fix required all four to be `CLOSED` and would have hidden the results link permanently on every event created through the admin UI — caught in review before it went anywhere.

`telephone_voting_status` is now included; it was declared and maintained but not consulted.

The per-election gate applies the same rule to the election's own channels. It deliberately does **not** also require the event to be closed: `windmill/src/services/voting_status.rs` only ever escalates an event to `OPEN`, never to `CLOSED`, so an operator who closes elections individually would never satisfy that conjunct.

The predicate moved to `src/utils/votingStatus.ts` so it is testable without mounting the screen — there is precedent in `src/utils/loginHints.test.ts`.

## Verification

`tsc --noEmit` clean, `prettier --check` clean, 11 new unit tests pass, covering the online-only-closed case that the discarded version got wrong, plus not-started, paused, kiosk-only, early-voting-still-open, and missing status.

## Not addressed: "no result published"

The issue title is about events that have not started, which is fixed. The body also mentions results appearing when nothing is published, and that half is **not** covered.

`isResultsWebsiteEnabled` only reads `presentation.results_website.status`, an authoring-time flag with no relation to whether a tally ran. The real signal exists — `sequent_backend.tally_results_publication` has a `publication_status` with a unique partial index on `Published AND revoked_at IS NULL` per event and per election, which is exactly what both gates want. It is not reachable from the voting portal today: its Hasura permissions grant select only to `admin-user`, `publish-results-read`, `publish-results-write` and `service-account`, with no voter role.

So closing that half needs a Hasura metadata change, not just a frontend edit. Today a closed-but-untallied event still shows a link that lands on the results portal's "Results not published yet" screen. Say the word and I'll do it as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved election result availability by showing results only when relevant voting channels have started and all active channels are closed.
  * Corrected result-link behavior for online, kiosk, early, and telephone voting statuses.
  * Preserved event-level safeguards, including closed voting and enabled results access.

* **Tests**
  * Added coverage for open, paused, closed, not-started, missing, and partially active voting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->