### PR TITLE
🐞 Admin Portal: apply tenant voting channels to new election events

### DIFF
--- a/packages/admin-portal/src/resources/Settings/SettingsVotingChannel.tsx
+++ b/packages/admin-portal/src/resources/Settings/SettingsVotingChannel.tsx
@@ -34,10 +34,12 @@ export const SettingsVotingChannels: React.FC<void> = () => {
         undoable: false,
     })
 
+    // `??`, not `||`: disabling a channel stores `false`, and `false || true`
+    // reads back as enabled, so the online toggle could never be turned off.
     const [voting, setVoting] = useState<any>({
-        online: record?.voting_channels?.online || true,
-        kiosk: record?.voting_channels?.kiosk || false,
-        telephone: record?.voting_channels?.telephone || false,
+        online: record?.voting_channels?.online ?? true,
+        kiosk: record?.voting_channels?.kiosk ?? false,
+        telephone: record?.voting_channels?.telephone ?? false,
     })
 
     const handleToggle = (method: any) => {
@@ -65,9 +67,9 @@ export const SettingsVotingChannels: React.FC<void> = () => {
         console.log(record)
         if (record.voting_channels) {
             setVoting({
-                online: record?.voting_channels?.online || true,
-                kiosk: record?.voting_channels?.kiosk || false,
-                telephone: record?.voting_channels?.telephone || false,
+                online: record?.voting_channels?.online ?? true,
+                kiosk: record?.voting_channels?.kiosk ?? false,
+                telephone: record?.voting_channels?.telephone ?? false,
             })
         }
     }, [record])

--- a/packages/windmill/src/tasks/insert_election_event.rs
+++ b/packages/windmill/src/tasks/insert_election_event.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use crate::postgres::election_event::update_bulletin_board;
+use crate::postgres::tenant::get_tenant_by_id;
 use crate::services::database::get_hasura_pool;
 use crate::services::election_event_board::BoardSerializable;
 use crate::services::import::import_election_event::insert_election_event_db;
@@ -54,7 +55,17 @@ pub async fn insert_election_event_anyhow(
 
     final_object.id = Some(id.clone());
     if final_object.voting_channels.is_none() {
-        final_object.voting_channels = serde_json::to_value(VotingChannels::default()).ok();
+        // Seed a new event's channels from its tenant, so a channel the tenant
+        // has disabled is not silently re-enabled on every event it creates.
+        // This runs only when the caller supplied none, which is the create
+        // path; existing events keep whatever they already store. META-12778.
+        let tenant_channels = get_tenant_by_id(&hasura_transaction, tenant_id.as_str())
+            .await
+            .ok()
+            .and_then(|tenant| tenant.voting_channels)
+            .and_then(|channels| serde_json::from_value::<VotingChannels>(channels).ok())
+            .unwrap_or_default();
+        final_object.voting_channels = serde_json::to_value(tenant_channels).ok();
     }
 
     match upsert_keycloak_realm(tenant_id.as_str(), &id.as_ref(), None, None).await {


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12778

Scope decision taken with @Findeton before implementing: **new events only**. A tenant disabling a channel must not reconfigure election events that already exist.

## Two faults, neither in the event edit form

### 1. The tenant setting could not be saved as disabled

`SettingsVotingChannel.tsx` read each channel with `record?.voting_channels?.online || true`, in both the initial state and the effect that reacts to the record. `||` cannot tell `false` from absent, so toggling online off saved `false`, the effect recomputed `false || true`, and the switch snapped back on. **Online voting was not disableable at tenant level at all**, which is why the issue's scenario could not even be set up. Now `??`.

### 2. New events never consult the tenant

New election events do not pass through `EditElectionEventDataForm`. `CreateElectionEvent.tsx` submits `INSERT_ELECTION_EVENT` with `voting_channels` undefined, and `windmill/src/tasks/insert_election_event.rs` filled the gap with `VotingChannels::default()` — `online: true`, everything else unset — ignoring the tenant entirely.

The insert now seeds from the tenant row via `get_tenant_by_id`, falling back to the previous default when the tenant has no channel configuration. This runs only when the caller supplied no channels, i.e. the create path, so existing events are untouched.

## What I tried first and threw away

My first attempt changed `EditElectionEventDataForm.tsx` — `||` → `??` on its tenant-derived defaults, and pointing the normalisation loop at them instead of a hardcoded literal. Review showed it was a **no-op for the reported bug and a regression elsewhere**:

- `VotingChannels` has no `skip_serializing_if`, so every new event persists `{"online":true,"kiosk":null,...}`. `incoming.voting_channels?.online` is therefore always `true` and short-circuits the fallback — the tenant value could never win.
- Conversely `kiosk`/`telephone`/`early_voting` persist as `null`, so the fallback *would* fire on **existing** events, meaning a tenant enabling kiosk would flip the toggle on events created long ago. That breaks the new-events-only rule.
- Making the defaults reactive to the async tenant fetch introduced a form-reset hazard: `<SimpleForm>` is rendered without `resetOptions`, so a late content change to the record triggers a full `reset()` and would discard whatever the user had typed.

Recording it because the edit form is the obvious-looking place to fix this and it is the wrong one.

## Verification

- `cargo check` on windmill in the worktree: Finished clean.
- admin-portal `tsc --noEmit`, `eslint`, `prettier --check`: all clean.

Not covered by an automated test. The behaviour is a create-path default that needs a tenant row and a Hasura action to exercise; worth an integration test if you want one, but I did not add a unit test that would only restate the `??`.

## Adjacent, deliberately not fixed

- `SettingsVotingChannel.tsx` saves only `{online, kiosk, telephone}`, so a tenant's `early_voting` is never stored and is wiped if present. The event side does understand `early_voting`, so the settings screen is the side that is short. Separate fix, and it needs a UI decision about whether to expose the toggle.
- `<JsonInput source="voting_channels">` is declared twice in each of `CreateElectionEvent.tsx` and `CreateScreen.tsx` — pre-existing copy/paste, harmless, left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly disabled voting-channel settings instead of replacing them with defaults.
  * Election events now use configured voting channels when available.
  * Added safe fallback behavior when configuration data is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->