### PR TITLE
Fixed settings not persisting at Event Data when saving

### DIFF
--- a/packages/admin-portal/src/resources/ElectionEvent/EditElectionEventData.tsx
+++ b/packages/admin-portal/src/resources/ElectionEvent/EditElectionEventData.tsx
@@ -103,7 +103,7 @@ export const EditElectionEventData: React.FC = () => {
             mutationMode="pessimistic"
             mutationOptions={{onSuccess}}
         >
-            <EditElectionEventDataForm />
+            <EditElectionEventDataForm transform={transform} />
         </EditBase>
     )
 }

--- a/packages/admin-portal/src/resources/ElectionEvent/EditElectionEventDataForm.tsx
+++ b/packages/admin-portal/src/resources/ElectionEvent/EditElectionEventDataForm.tsx
@@ -233,7 +233,9 @@ const CustomDateTimeFormatInvalidNotifier: React.FC<{
     return null
 }
 
-export const EditElectionEventDataForm: React.FC = () => {
+export const EditElectionEventDataForm: React.FC<{
+    transform: (data: Sequent_Backend_Election_Event_Extended) => RaRecord<Identifier>
+}> = ({transform}) => {
     const {t} = useTranslation()
     const [addWidget, setWidgetTaskId, updateWidgetFail] = useWidgetStore()
     const [tenantId] = useTenantStore()
@@ -1077,7 +1079,7 @@ export const EditElectionEventDataForm: React.FC = () => {
         }
         setActivateSave(false)
 
-        return {
+        return transform({
             ...values,
             presentation: {
                 ...values.presentation,
@@ -1085,7 +1087,7 @@ export const EditElectionEventDataForm: React.FC = () => {
                     ? {results_website: JSON.stringify(values.resultsWebsitePolicy)}
                     : {}),
             },
-        }
+        })
     }
     return (
         <>


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved election event editing so saved records are correctly transformed before submission.
  * Ensured edited election event data is consistently formatted and complete when saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->