### PR TITLE
🐞 Admin portal - Activity Logs Export Fails — `prepare_user_data` No Longer Supported

### DIFF
--- a/packages/windmill/src/services/export/export_election_event.rs
+++ b/packages/windmill/src/services/export/export_election_event.rs
@@ -17,7 +17,6 @@ use crate::postgres::trustee::get_all_trustees;
 use crate::services::database::get_hasura_pool;
 use crate::services::export::export_ballot_publication::{self, export_election_event_config_file};
 use crate::services::import::import_election_event::ImportElectionEventSchema;
-use crate::services::reports::activity_log;
 use crate::services::reports::activity_log::{ActivityLogsTemplate, ReportFormat};
 use crate::services::reports::template_renderer::{
     ReportOriginatedFrom, ReportOrigins, TemplateRenderer,
@@ -516,17 +515,14 @@ pub async fn process_export_zip(
             ReportFormat::CSV, // Assuming CSV format for this export
         );
 
-        // Prepare user data
-        let user_data = activity_logs_template
-            .prepare_user_data(&hasura_transaction, &hasura_transaction)
+        // Generate the CSV file directly from the electoral log board, streaming
+        // in batches (same path used by ActivityLogsTemplate::execute_report for
+        // the CSV report type), since prepare_user_data is not implemented for
+        // this report type.
+        let temp_activity_logs_file = activity_logs_template
+            .generate_export_csv_data(&activity_logs_filename)
             .await
-            .map_err(|e| anyhow!("Error preparing activity logs data: {e:?}"))?;
-
-        // Generate the CSV file using generate_export_data
-        let temp_activity_logs_file =
-            activity_log::generate_export_data(&user_data.electoral_log, &activity_logs_filename)
-                .await
-                .map_err(|e| anyhow!("Error generating export data: {e:?}"))?;
+            .map_err(|e| anyhow!("Error generating export data: {e:?}"))?;
 
         zip_writer
             .start_file(&activity_logs_filename, options)


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12785

## Summary
- `export_election_event.rs` called `ActivityLogsTemplate::prepare_user_data` directly, but that method was turned into a hard error by the report batching refactor (`prepare_user_data should not be used for this report type, use prepare_user_data_batch instead`), breaking every "Activity Logs" election event export.
- Switched the export path to `ActivityLogsTemplate::generate_export_csv_data`, the same memory-efficient, cursor-paginated CSV generator already used by the Reports tab for this report type/format, instead of reimplementing an offset/limit batching loop.
- Removed the now-unused `activity_log` module import.

## Test plan
- [x] In the admin portal, export an election event with the "Activity Logs" option enabled and confirm the zip is produced without error.
- [x] Re-import the generated election event export and confirm activity logs import successfully (CSV row shape written by `generate_export_csv_data` is unchanged vs. before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity log CSV exports by generating export data directly.
  * Removed unnecessary transaction-backed preparation, resulting in a more streamlined export process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->