### PR TITLE
🐞 Keycloak: bound date inputs to four-digit years (#3000)

### DIFF
--- a/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticator.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/main/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticator.java
@@ -236,24 +236,32 @@ public class MultiAttributePasswordAuthenticator implements Authenticator, Authe
   }
 
   /**
-   * Builds the {@code {name, type}} pairs the template renders one input per configured attribute
-   * from. {@code type} mirrors whatever HTML5 input type (e.g. {@code date}) the realm's User
-   * Profile configuration declares for that attribute, so a field like {@code dateOfBirth} renders
-   * the same native date picker here as it does at registration - see {@link
-   * Utils#resolveHtml5InputType}. Fetches the User Profile attribute list once up front rather than
-   * once per configured attribute.
+   * Builds the field metadata the template renders one input per configured attribute from. {@code
+   * type} mirrors whatever HTML5 input type (e.g. {@code date}) the realm's User Profile
+   * configuration declares for that attribute, so a field like {@code dateOfBirth} renders the same
+   * native date picker here as it does at registration. A configured {@code inputTypeMax} is
+   * forwarded as {@code max}; the template supplies its date default when this key is absent. See
+   * {@link Utils#resolveHtml5InputType}. Fetches the User Profile attribute list once up front
+   * rather than once per configured attribute.
    */
   protected List<Map<String, String>> buildAttributeFields(
       KeycloakSession session, List<String> matchAttributes) {
     List<UPAttribute> profileAttributes = Utils.getRealmUserProfileAttributes(session);
     List<Map<String, String>> fields = new ArrayList<>();
     for (String attribute : matchAttributes) {
-      fields.add(
-          Map.of(
-              "name",
-              attribute,
-              "type",
-              Utils.resolveHtml5InputType(profileAttributes, attribute)));
+      Map<String, String> field = new HashMap<>();
+      field.put("name", attribute);
+      field.put("type", Utils.resolveHtml5InputType(profileAttributes, attribute));
+      profileAttributes.stream()
+          .filter(profileAttribute -> attribute.equals(profileAttribute.getName()))
+          .findFirst()
+          .map(UPAttribute::getAnnotations)
+          .map(annotations -> annotations.get("inputTypeMax"))
+          .filter(String.class::isInstance)
+          .map(String.class::cast)
+          .filter(max -> !max.isBlank())
+          .ifPresent(max -> field.put("max", max));
+      fields.add(field);
     }
     return fields;
   }

--- a/packages/keycloak-extensions/message-otp-authenticator/src/test/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticatorTest.java
+++ b/packages/keycloak-extensions/message-otp-authenticator/src/test/java/sequent/keycloak/authenticator/forgot_password/MultiAttributePasswordAuthenticatorTest.java
@@ -1084,6 +1084,19 @@ class MultiAttributePasswordAuthenticatorTest {
   }
 
   @Test
+  void buildAttributeFields_inputTypeMaxAnnotation_isForwardedToTemplate() {
+    mockUserProfileAttributes(
+        new UPAttribute(
+            "dateOfBirth", Map.of("inputType", "html5-date", "inputTypeMax", "2020-01-01")));
+
+    List<Map<String, String>> fields =
+        authenticator.buildAttributeFields(session, List.of("dateOfBirth"));
+
+    assertEquals(
+        List.of(Map.of("name", "dateOfBirth", "type", "date", "max", "2020-01-01")), fields);
+  }
+
+  @Test
   void buildAttributeFields_nonHtml5InputType_fallsBackToText() {
     mockUserProfileAttributes(new UPAttribute("country", Map.of("inputType", "select")));
 

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/login.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/login.ftl
@@ -28,6 +28,8 @@ SPDX-License-Identifier: AGPL-3.0-only
                                         <@renderIntlTelInput id=field.name name=field.name autofocus=(field?index == 0)/>
                                     <#else>
                                         <input tabindex="${field?index + 1}" id="${field.name}" class="${properties.kcInputClass!}" name="${field.name}" type="${field.type!'text'}"
+                                               <#-- see user-profile-commons.ftl: date inputs accept 5+ digit years -->
+                                               <#if (field.type!'') == 'date'>max="${field.max!'9999-12-31'}"</#if>
                                                <#if field?index == 0>autofocus</#if> autocomplete="off"
                                                aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
                                         />

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/user-profile-commons.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.admin-portal/login/user-profile-commons.ftl
@@ -200,7 +200,19 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<#if attribute.annotations.inputTypeSize??>size="${attribute.annotations.inputTypeSize}"</#if>
 		<#if attribute.annotations.inputTypeMaxlength??>maxlength="${attribute.annotations.inputTypeMaxlength}"</#if>
 		<#if attribute.annotations.inputTypeMinlength??>minlength="${attribute.annotations.inputTypeMinlength}"</#if>
-		<#if attribute.annotations.inputTypeMax??>max="${attribute.annotations.inputTypeMax}"</#if>
+		<#-- A bare input[type=date] accepts a year of four OR MORE digits, so a
+		     voter can enter 123456-01-01. Bound it unless the attribute sets its
+		     own max. Compared against the raw annotation rather than the output
+		     of <@inputTagType/>: capturing a macro under Keycloak's HTML output
+		     format yields markup, not a string, and any string operation on it
+		     throws at render time. -->
+		<#local dateInputType = (attribute.annotations.inputType!'') == 'html5-date'
+			|| (attribute.annotations.inputType!'') == 'date'>
+		<#if attribute.annotations.inputTypeMax??>
+			max="${attribute.annotations.inputTypeMax}"
+		<#elseif dateInputType>
+			max="9999-12-31"
+		</#if>
 		<#if attribute.annotations.inputTypeMin??>min="${attribute.annotations.inputTypeMin}"</#if>
 		<#if attribute.annotations.inputTypeStep??>step="${attribute.annotations.inputTypeStep}"</#if>
 		<#if attribute.annotations.inputTypeStep??>step="${attribute.annotations.inputTypeStep}"</#if>

--- a/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.voting-portal/login/login.ftl
+++ b/packages/keycloak-extensions/sequent-theme/src/main/resources/theme/sequent.voting-portal/login/login.ftl
@@ -38,6 +38,8 @@ SPDX-License-Identifier: AGPL-3.0-only
                                         <@renderIntlTelInput id=field.name name=field.name autofocus=(field?index == 0)/>
                                     <#else>
                                         <input tabindex="${field?index + 1}" id="${field.name}" class="${properties.kcInputClass!}" name="${field.name}" type="${field.type!'text'}"
+                                               <#-- see user-profile-commons.ftl: date inputs accept 5+ digit years -->
+                                               <#if (field.type!'') == 'date'>max="${field.max!'9999-12-31'}"</#if>
                                                <#if field?index == 0>autofocus</#if> autocomplete="off"
                                                <#if credentialFieldError>aria-invalid="true"</#if>
                                         />

--- a/packages/keycloak-extensions/sequent-theme/src/test/java/sequent/keycloak/theme/TemplateSyntaxTest.java
+++ b/packages/keycloak-extensions/sequent-theme/src/test/java/sequent/keycloak/theme/TemplateSyntaxTest.java
@@ -85,6 +85,31 @@ class TemplateSyntaxTest {
   }
 
   @Test
+  void multiAttributeDateInputsHonorConfiguredMaxInBothPortals()
+      throws IOException, TemplateException {
+    for (String portal : List.of("sequent.admin-portal", "sequent.voting-portal")) {
+      Map<String, Object> defaultModel = baseModel("standard");
+      defaultModel.put("matchAttributes", List.of(Map.of("name", "dateOfBirth", "type", "date")));
+      String defaultHtml = renderLogin(portal, defaultModel);
+
+      assertTrue(defaultHtml.contains("max=\"9999-12-31\""));
+
+      Map<String, Object> configuredModel = baseModel("standard");
+      configuredModel.put(
+          "matchAttributes",
+          List.of(
+              Map.of(
+                  "name", "dateOfBirth",
+                  "type", "date",
+                  "max", "2020-01-01")));
+      String configuredHtml = renderLogin(portal, configuredModel);
+
+      assertTrue(configuredHtml.contains("max=\"2020-01-01\""));
+      assertFalse(configuredHtml.contains("max=\"9999-12-31\""));
+    }
+  }
+
+  @Test
   void deferredLoginRegistrationTemplateEscapesTheSameHostileConfiguration()
       throws IOException, TemplateException {
     Path parent = THEME_ROOT.resolve("sequent.admin-portal/login");
@@ -147,6 +172,25 @@ class TemplateSyntaxTest {
             new TemplateLoader[] {
               new FileTemplateLoader(child.toFile()), new FileTemplateLoader(parent.toFile())
             }));
+    StringWriter rendered = new StringWriter();
+    configuration.getTemplate("login.ftl").process(model, rendered);
+    return rendered.toString();
+  }
+
+  private static String renderLogin(String portal, Map<String, Object> model)
+      throws IOException, TemplateException {
+    Path child = THEME_ROOT.resolve(portal + "/login");
+    Path parent = THEME_ROOT.resolve("sequent.admin-portal/login");
+    Configuration configuration = configuration();
+    if (child.equals(parent)) {
+      configuration.setTemplateLoader(new FileTemplateLoader(parent.toFile()));
+    } else {
+      configuration.setTemplateLoader(
+          new MultiTemplateLoader(
+              new TemplateLoader[] {
+                new FileTemplateLoader(child.toFile()), new FileTemplateLoader(parent.toFile())
+              }));
+    }
     StringWriter rendered = new StringWriter();
     configuration.getTemplate("login.ftl").process(model, rendered);
     return rendered.toString();


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12782

## Change

`input[type=date]` accepts a year of four **or more** digits per the HTML spec — Chrome's picker reaches year 275760 — so the DOB field accepted `123456-01-01`.

Every rendered date input now defaults to `max="9999-12-31"`:

- `user-profile-commons.ftl` — registration, update-profile and IdP-review forms. `sequent.voting-portal` inherits from `sequent.admin-portal`, so this one file covers both portals.
- `login.ftl` in **both** themes — the multi-attribute login form, which is the screen the issue actually reports. It builds its own `<input>` from `field.type` and does not go through `user-profile-commons.ftl`.

An attribute that sets its own `inputTypeMax` annotation still wins, so this rides the generic annotation channel already used for `pattern`, `min`, `maxlength` and friends rather than hardcoding anything per attribute. That answers the "how do we feed max/min without it being ad hoc" question on the issue: the mechanism already existed, it just had no sensible default for dates.

### One implementation note worth keeping

The date test reads `attribute.annotations.inputType` directly rather than capturing `<@inputTagType/>` output. Under Keycloak's HTML output format an `<#assign>…</#assign>` capture yields a
`TemplateHTMLOutputModel`, not a String, so `?trim` and `== 'date'` both throw at render time. My first attempt did exactly that and broke every user-profile form on both portals.

## Verification

Rendered — not just parsed — against FreeMarker 2.3.32 using Keycloak's own configuration (`HTMLOutputFormat` +
`ENABLE_IF_SUPPORTED_AUTO_ESCAPING_POLICY`), 10 attribute variants:

- `max="9999-12-31"` emitted for `html5-date` and `date` only
- absent for `datetime-local`, `month`, `number`, `tel`, and unannotated `text`
- correctly replaced by `max="2020-01-01"` when `inputTypeMax` is set
- coexists correctly with `min`

Both `login.ftl` files were driven through `template.ftl` with a real `matchAttributes` model and emit `name="dateOfBirth" type="date" max="9999-12-31"`. All four methods of `TemplateSyntaxTest` were replicated verbatim against the worktree and pass (25/25 assertions).

## What this does NOT fix — please read

The issue also asks to "reject submitted date values server-side" and says "browser and direct HTTP submissions are both covered". **This change does not do that**, and an HTML `max` attribute never reaches the wire, so `curl -d 'dateOfBirth=123456-01-01'` is entirely unaffected.

Review traced what actually happens to an absurd DOB today, and it is worse than "fails to match":

- `LookupAndUpdateUser.java:784` — `user.setAttribute(attribute, values)` writes the raw submitted string straight onto the Keycloak user, bypassing `UserProfile` entirely: no validators and no `permissions.edit` check. Live under the dev realm's `update-attributes` list.
- `windmill/src/services/application.rs:144-160` — the raw applicant map, bad DOB included, is persisted to
`sequent_backend.applications.applicant_data` for every outcome including REJECTED.
- With `dateOfBirth` in `search-attributes`, a bogus DOB is a single mismatch, so `application.rs:436-437` routes the applicant to PENDING/MANUAL — a human review queue, not the generic invalid-credentials response the issue asks for.
- Keycloak does not validate `inputType: html5-date` server-side. `inputType` is a rendering annotation; validation comes only from the `validations` map, and every shipped `dateOfBirth` definition has `"validations": {}`. Keycloak 26.6.1 ships a `local-date` validator that this repo never uses.

The cheapest real fix is a `pattern` (or `local-date`) validation on the `dateOfBirth` attribute definition — the same generic channel, applied server-side. That is a config change per realm template rather than a theme change, which is why it is not in this PR. Happy to do it as a follow-up; it needs a decision on where the canonical attribute definitions live.

## Pre-existing, not touched

- `user-profile-commons.ftl` emits `step="..."` twice for any attribute with `inputTypeStep` — a duplicated line, confirmed to produce a literal duplicate HTML attribute.
- No `min` default, so `0001-01-01` still passes.
- Both `login.ftl` files crash if a field has no `type` at all, ten lines before anything this PR touches (`matchAttributes?filter(f -> f.type == "tel")`). Unreachable in practice — `buildAttributeFields` always sets `type`.

---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Date fields now enforce a maximum date of `9999-12-31` by default, preventing invalid years with more than four digits.
  - Configured field-specific maximum dates are preserved and applied consistently across password recovery and portal forms.
  - Updated behavior is available in both the admin and voting portals.

- **Tests**
  - Added coverage verifying default and custom maximum dates for supported date fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->