### PR TITLE
🐞 Admin Portal: show Voted Channel only on Datafix events (#2996)

### DIFF
--- a/packages/admin-portal/src/resources/User/ListUsers.tsx
+++ b/packages/admin-portal/src/resources/User/ListUsers.tsx
@@ -14,6 +14,7 @@ import {
     useRefresh,
     useNotify,
     useGetList,
+    useGetOne,
     FunctionField,
     Button as ReactAdminButton,
     useRecordContext,
@@ -63,6 +64,7 @@ import {DELETE_USER} from "@/queries/DeleteUser"
 import {MANUAL_VERIFICATION} from "@/queries/ManualVerification"
 import {useMutation, useQuery} from "@apollo/client"
 import {ATTR_RESET_VALUE, IPermissions} from "@/types/keycloak"
+import {isDatafixElectionEvent} from "@/services/Datafix"
 import {ResourceListStyles} from "@/components/styles/ResourceListStyles"
 import {IRole, IUser, translate} from "@sequentech/ui-core"
 import {SettingsContext} from "@/providers/SettingsContextProvider"
@@ -136,6 +138,15 @@ export interface ListUsersProps {
 export const ListUsers: React.FC<ListUsersProps> = ({aside, electionEventId, electionId}) => {
     const {t, i18n} = useTranslation()
     const [tenantId] = useTenantStore()
+    // The Voted Channel attribute can only ever be written by the Datafix
+    // integration, so the column and filter are gated on the event being
+    // configured for it. The event record is not otherwise in scope here.
+    const {data: electionEventRecord} = useGetOne<Sequent_Backend_Election_Event>(
+        "sequent_backend_election_event",
+        {id: electionEventId, meta: {tenant_id: tenantId}},
+        {enabled: Boolean(electionEventId && tenantId)}
+    )
+    const isDatafixEvent = isDatafixElectionEvent(electionEventRecord)
     const {globalSettings} = useContext(SettingsContext)
     const [isOpenSidebar] = useSidebarState()
     const location = useLocation()
@@ -241,17 +252,19 @@ export const ListUsers: React.FC<ListUsersProps> = ({aside, electionEventId, ele
                         label={String(t("usersAndRolesScreen.users.fields.has_voted"))}
                     />
                 )
-                filters.push(
-                    <TextInput
-                        key={VOTED_CHANNEL}
-                        source={`attributes.${VOTED_CHANNEL}`}
-                        label={String(t("usersAndRolesScreen.users.fields.voted-channel"))}
-                    />
-                )
+                if (isDatafixEvent) {
+                    filters.push(
+                        <TextInput
+                            key={VOTED_CHANNEL}
+                            source={`attributes.${VOTED_CHANNEL}`}
+                            label={String(t("usersAndRolesScreen.users.fields.voted-channel"))}
+                        />
+                    )
+                }
             }
         }
         return filters
-    }, [userAttributes?.get_user_profile_attributes])
+    }, [userAttributes?.get_user_profile_attributes, isDatafixEvent])
 
     const [exportTenantUsers] = useMutation<ExportTenantUsersMutation>(EXPORT_TENANT_USERS, {
         context: {
@@ -1200,7 +1213,7 @@ export const ListUsers: React.FC<ListUsersProps> = ({aside, electionEventId, ele
                         )}
 
                         {renderFields(listFields.attributesFields)}
-                        {electionEventId && (
+                        {electionEventId && isDatafixEvent && (
                             <FunctionField<IUser>
                                 source={`attributes['${VOTED_CHANNEL}']`}
                                 label={String(t("usersAndRolesScreen.users.fields.voted-channel"))}

--- a/packages/admin-portal/src/services/Datafix.test.ts
+++ b/packages/admin-portal/src/services/Datafix.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2025 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import {DATAFIX_ID_ANNOTATION, isDatafixElectionEvent} from "./Datafix"
+
+describe("isDatafixElectionEvent", () => {
+    it("is true when the datafix:id annotation is present", () => {
+        expect(isDatafixElectionEvent({annotations: {[DATAFIX_ID_ANNOTATION]: "abc-123"}})).toBe(
+            true
+        )
+    })
+
+    it("is true when the annotation is present alongside others", () => {
+        expect(
+            isDatafixElectionEvent({
+                annotations: {
+                    "datafix:password_policy": "strict",
+                    [DATAFIX_ID_ANNOTATION]: "abc-123",
+                },
+            })
+        ).toBe(true)
+    })
+
+    it("is true when the annotation is present but null, since only the key is checked", () => {
+        expect(isDatafixElectionEvent({annotations: {[DATAFIX_ID_ANNOTATION]: null}})).toBe(true)
+    })
+
+    it("is false when annotations carry other keys only", () => {
+        expect(isDatafixElectionEvent({annotations: {"datafix:voterview_request": "yes"}})).toBe(
+            false
+        )
+    })
+
+    it("is false for an empty annotations object", () => {
+        expect(isDatafixElectionEvent({annotations: {}})).toBe(false)
+    })
+
+    it("is false for absent, null and undefined annotations", () => {
+        expect(isDatafixElectionEvent({})).toBe(false)
+        expect(isDatafixElectionEvent({annotations: null})).toBe(false)
+        expect(isDatafixElectionEvent({annotations: undefined})).toBe(false)
+    })
+
+    it("is false for a missing election event, which is the tenant-level voters view", () => {
+        expect(isDatafixElectionEvent(undefined)).toBe(false)
+        expect(isDatafixElectionEvent(null)).toBe(false)
+    })
+
+    it("is false for malformed annotations that are not a plain object", () => {
+        expect(isDatafixElectionEvent({annotations: "datafix:id"})).toBe(false)
+        expect(isDatafixElectionEvent({annotations: 42})).toBe(false)
+        expect(isDatafixElectionEvent({annotations: [DATAFIX_ID_ANNOTATION]})).toBe(false)
+    })
+
+    it("does not match a key that merely contains the annotation name", () => {
+        expect(isDatafixElectionEvent({annotations: {"x-datafix:id": "abc"}})).toBe(false)
+        expect(isDatafixElectionEvent({annotations: {"datafix:idx": "abc"}})).toBe(false)
+    })
+})

--- a/packages/admin-portal/src/services/Datafix.ts
+++ b/packages/admin-portal/src/services/Datafix.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 Sequent Tech Inc <legal@sequentech.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Annotation key marking an election event as configured for the Datafix
+ * integration. Mirrors `DATAFIX_ID_KEY` in
+ * `windmill/src/services/datafix/utils.rs`.
+ */
+export const DATAFIX_ID_ANNOTATION = "datafix:id"
+
+interface AnnotatedElectionEvent {
+    annotations?: unknown
+}
+
+/**
+ * True when the election event carries the Datafix marker annotation.
+ *
+ * This is the same marker check that `datafix_annotations` in
+ * `windmill/src/services/datafix/utils.rs` uses to decide whether an event is
+ * Datafix-configured at all: the `datafix:id` key is present, whatever value
+ * it holds. It is deliberately only that check. The backend's
+ * `is_datafix_election_event` additionally requires the rest of the Datafix
+ * annotation block to deserialize, which is validation the UI has no business
+ * repeating; gating presentation on the marker alone fails open, showing the
+ * column on a half-configured event rather than hiding it on a working one.
+ *
+ * `annotations` is a free-form jsonb column, so it may be absent, null or not
+ * an object at all; all of those mean "not configured".
+ */
+export const isDatafixElectionEvent = (electionEvent?: AnnotatedElectionEvent | null): boolean => {
+    const annotations = electionEvent?.annotations
+    if (typeof annotations !== "object" || annotations === null || Array.isArray(annotations)) {
+        return false
+    }
+    return DATAFIX_ID_ANNOTATION in (annotations as Record<string, unknown>)
+}


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/12774

## Change

Gates the Voted Channel column and filter on the election event carrying the `datafix:id` marker annotation.

- New `services/Datafix.ts` with `DATAFIX_ID_ANNOTATION` and a single `isDatafixElectionEvent` helper, used at both sites. No literal annotation key in `ListUsers.tsx`.
- `ListUsers.tsx` fetches the election event by id via `useGetOne`, guarded by `enabled` so nothing fires on the tenant-level voters view.
- Not gated on `showVoterListSync`, per the issue.

### The issue's open implementation question, answered

The Voters screen did **not** have the election event record in scope, so a query was needed.

`ListUsers.tsx:759` already holds
`useRecordContext<Sequent_Backend_Election_Event>()`, but that type annotation is wrong on the election-scoped tab:
`EditElectionEventUsers.tsx:19` computes `electionEventId = record?.election_event_id ?? record?.id`, so when an election is in context the record is a `Sequent_Backend_Election` and its `annotations` are the election's, not the event's. Reusing it would have gated on the wrong object. The mistyping is pre-existing and left alone — it is only used for `presentation.custom_filters`, which both types carry.

## Verification

`tsc --noEmit` clean, `eslint` clean, `prettier --check` clean across `src/`, 9 new helper unit tests pass (present / absent / null-valued / malformed / non-object / near-miss keys / no event).

## AC3 (export consistency) is not met and cannot be met here

Verified as the issue asked. The voter export is entirely server-side: `ExportUsers.ts` sends only `tenantId`/`electionEventId`/`electionId`, and there is no column-selection UI.
`windmill/src/services/export/export_users.rs:84-93` builds headers from `get_user_profile_attributes(realm)` and emits every attribute not in `USER_FIELDS`; `voted-channel` is not in `USER_FIELDS`, so the CSV carries an empty `voted-channel` column on non-Datafix events.

Aligning the export requires a windmill change, which AC4 puts out of scope. **AC3 and AC4 are in direct conflict** — flagging for a decision rather than silently picking one.

## Found in review, deliberately not fixed here

Two pre-existing react-admin preference-persistence fragilities that this change can expose. Both are about
`<DatagridConfigurable>`/`useListParams` state in `localStorage`, not about the gating logic, and fixing them properly touches `ListApprovals.tsx` too. Raising separately rather than growing this PR.

1. **Column selection is stored positionally.** `DatagridConfigurable` persists `columns` as indices into the children array and only rebuilds `availableColumns` on a length mismatch. Removing a child shifts every later index, so a manager who had customised columns can see the wrong column after this lands. Note also that the existing cleanup at `ListUsers.tsx:1087-1092` targets
`RaStore.preferences.<key>.datagrid.availableColumns`, but with an explicit `preferenceKey` the real key has no `.datagrid.` segment — that `removeItem` is already a no-op today.

2. **A previously-set `attributes.voted-channel` filter value survives.** `<List>` uses `disableSyncWithLocation` with a `storeKey`, so filter values persist. Removing the input does not clear the value, and `FilterForm` only renders filters that exist in the array — so on a non-Datafix event the value would keep filtering the voter list with no visible input to clear it. Requires a one-off migration of the persisted `filter`/`displayedFilters`; deliberately not attempted here because it means mutating stored list state for every voters screen.

Also noted: reading `sequent_backend_election_event` sends `x-hasura-role: election-event-read`. A user with `VOTER_READ` but not `ELECTION_EVENT_READ` on the election-scoped tab would have this query denied; the failure is safe (column stays hidden) but silent. I could not confirm whether that role split occurs in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The user list now displays the voted-channel filter and column only when applicable to the election event.
  * Added support for identifying election events configured for Datafix.

* **Tests**
  * Added coverage for valid, missing, empty, malformed, and near-match configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->